### PR TITLE
docs: deployment handled by the Vercel Git integration

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,6 @@ This repo was split from `tburkhalterr/CANShift` with history. Remaining cutover
 
 1. Publish `@canshift/core@1.0.0` from [CANShift/canshift-core](https://github.com/CANShift/canshift-core) (needs the `canshift` npm org + `NPM_TOKEN` secret).
 2. `npm install` here to regenerate `package-lock.json` against the published package — CI is red until then (the lockfile still references the monorepo `file:../canshift-core` link).
-3. Re-link the Vercel tuner project to this repo; move `VERCEL_*` secrets; port `deploy-vercel.yml`.
+3. ~~Re-link Vercel~~ DONE — the Vercel Git integration is connected: preview deploys on PRs, production on main. No VERCEL_* secrets or Actions deploy workflow needed.
 4. Point the flasher release fetch (`src/lib/firmware/releases.ts`) at `CANShift/canshift-firmware` once its first release exists.
 5. Transfer `scope:tuner` issues; flip the repo public.


### PR DESCRIPTION
Records that deploys are native Vercel Git-integration (preview on PRs, production on main) — no Actions deploy workflow or VERCEL_* secrets on this repo.