### PR TITLE
feat: repository mark in the README

### DIFF
--- a/.github/icons/tuner-avatar-460.svg
+++ b/.github/icons/tuner-avatar-460.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 460 460" width="460" height="460" fill="none">
+  <rect width="460" height="460" fill="#151313"></rect>
+  <svg x="110.4" y="126.9" width="239.2" height="206.2" viewBox="0 0 116 100">
+  <g transform="translate(8,0) skewX(-11)">
+    <path d="M20 20 H96 M20 50 H96 M20 80 H96" stroke="#F3F2F2" stroke-width="13"></path>
+    <path d="M44 6 V34" stroke="#F3F2F2" stroke-width="13"></path>
+    <path d="M72 36 V64" stroke="#FF4747" stroke-width="13"></path>
+    <path d="M34 66 V94" stroke="#F3F2F2" stroke-width="13"></path>
+  </g>
+  </svg>
+</svg>

--- a/.github/icons/tuner-currentcolor.svg
+++ b/.github/icons/tuner-currentcolor.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 116 100" width="116" height="100" fill="none">
+  <g transform="translate(8,0) skewX(-11)">
+    <path d="M20 20 H96 M20 50 H96 M20 80 H96" stroke="currentColor" stroke-width="13"></path>
+    <path d="M44 6 V34" stroke="currentColor" stroke-width="13"></path>
+    <path d="M72 36 V64" stroke="#EC3013" stroke-width="13"></path>
+    <path d="M34 66 V94" stroke="currentColor" stroke-width="13"></path>
+  </g>
+</svg>

--- a/.github/icons/tuner-dark.svg
+++ b/.github/icons/tuner-dark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 116 100" width="116" height="100" fill="none">
+  <g transform="translate(8,0) skewX(-11)">
+    <path d="M20 20 H96 M20 50 H96 M20 80 H96" stroke="#F3F2F2" stroke-width="13"></path>
+    <path d="M44 6 V34" stroke="#F3F2F2" stroke-width="13"></path>
+    <path d="M72 36 V64" stroke="#FF4747" stroke-width="13"></path>
+    <path d="M34 66 V94" stroke="#F3F2F2" stroke-width="13"></path>
+  </g>
+</svg>

--- a/.github/icons/tuner-small-dark.svg
+++ b/.github/icons/tuner-small-dark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 116 100" width="116" height="100" fill="none">
+  <g transform="translate(8,0)">
+    <path d="M18 26 H98 M18 74 H98" stroke="#F3F2F2" stroke-width="15"></path>
+    <path d="M44 10 V42" stroke="#F3F2F2" stroke-width="15"></path>
+    <path d="M74 58 V90" stroke="#FF4747" stroke-width="15"></path>
+  </g>
+</svg>

--- a/.github/icons/tuner-small.svg
+++ b/.github/icons/tuner-small.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 116 100" width="116" height="100" fill="none">
+  <g transform="translate(8,0)">
+    <path d="M18 26 H98 M18 74 H98" stroke="#201E1D" stroke-width="15"></path>
+    <path d="M44 10 V42" stroke="#201E1D" stroke-width="15"></path>
+    <path d="M74 58 V90" stroke="#EC3013" stroke-width="15"></path>
+  </g>
+</svg>

--- a/.github/icons/tuner.svg
+++ b/.github/icons/tuner.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 116 100" width="116" height="100" fill="none">
+  <g transform="translate(8,0) skewX(-11)">
+    <path d="M20 20 H96 M20 50 H96 M20 80 H96" stroke="#201E1D" stroke-width="13"></path>
+    <path d="M44 6 V34" stroke="#201E1D" stroke-width="13"></path>
+    <path d="M72 36 V64" stroke="#EC3013" stroke-width="13"></path>
+    <path d="M34 66 V94" stroke="#201E1D" stroke-width="13"></path>
+  </g>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # canshift-tuner
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset=".github/icons/tuner-dark.svg">
+  <img src=".github/icons/tuner.svg" alt="" height="72">
+</picture>
+
 Betaflight-style web configurator for CANShift dashes. Hosted on Vercel, talks
 to the firmware via **WebSerial** over the CH340 UART that already serves as
 the upload / serial port.


### PR DESCRIPTION
Adds this repo's mark from the [icon system](https://github.com/CANShift/canshift-brand/tree/main/icons) (light/dark variants via `<picture>`). Full set + usage rules live in canshift-brand.