### PR TITLE
feat: Vercel Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-select": "^2.3.0",
         "@radix-ui/react-switch": "^1.2.6",
         "@sentry/react": "^10.69.0",
+        "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "esptool-js": "^0.6.0",
@@ -2864,6 +2865,48 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "CANShift Tuner \u2014 Betaflight-style web configurator. Talks to the firmware via WebSerial over the CH340 UART; hosted on Vercel.",
+  "description": "CANShift Tuner — Betaflight-style web configurator. Talks to the firmware via WebSerial over the CH340 UART; hosted on Vercel.",
   "scripts": {
     "predev": "npm run tokens:gen",
     "dev": "vite",
@@ -32,6 +32,7 @@
     "@radix-ui/react-select": "^2.3.0",
     "@radix-ui/react-switch": "^1.2.6",
     "@sentry/react": "^10.69.0",
+    "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "esptool-js": "^0.6.0",
@@ -55,6 +56,8 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^17.2.0",
     "postcss": "^8.5.25",
     "prettier": "^3.8.4",
     "tailwindcss": "^3.4.19",
@@ -63,9 +66,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.61.0",
     "vite": "^7.3.2",
-    "vitest": "^4.1.5",
-    "husky": "^9.1.7",
-    "lint-staged": "^17.2.0"
+    "vitest": "^4.1.5"
   },
   "lint-staged": {
     "*.{ts,tsx,css,json,md,yml,yaml,html}": "prettier --write --ignore-unknown",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
+import { inject } from '@vercel/analytics'
 import { initPostHog } from './lib/posthog'
 import { initSentry } from './lib/sentry'
 import './index.css'
 
+inject()
 initPostHog()
 initSentry()
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,10 +22,9 @@
       "@components/*": ["src/components/*"],
       "@stores/*": ["src/stores/*"],
       "@services/*": ["src/transport/*"],
-      "@hooks/*": ["src/hooks/*"],
-      "@canshift/core": ["../canshift-core/src/index.ts"]
+      "@hooks/*": ["src/hooks/*"]
     }
   },
-  "include": ["src/**/*", "../canshift-core/src/**/*"],
-  "exclude": ["node_modules", "dist", "../canshift-core/dist", "../canshift-core/src/__tests__/**"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,8 @@ const firmwareMajor = existsSync(FIRMWARE_PKG_PATH)
   : Number(readFileSync(resolve(__dirname, 'firmware-major.txt'), 'utf8').trim())
 
 const CORE_SRC_INDEX = resolve(__dirname, '../canshift-core/src/index.ts')
+const CORE_SIBLING_READY =
+  existsSync(CORE_SRC_INDEX) && existsSync(resolve(__dirname, '../canshift-core/node_modules'))
 
 const FIRMWARE_OWNER = 'CANShift'
 const FIRMWARE_REPO = 'canshift-firmware'
@@ -95,9 +97,7 @@ export default defineConfig(({ command }) => ({
       '@stores': resolve(__dirname, 'src/stores'),
       '@services': resolve(__dirname, 'src/transport'),
       '@hooks': resolve(__dirname, 'src/hooks'),
-      ...(command === 'serve' && existsSync(CORE_SRC_INDEX)
-        ? { '@canshift/core': CORE_SRC_INDEX }
-        : {}),
+      ...(command === 'serve' && CORE_SIBLING_READY ? { '@canshift/core': CORE_SRC_INDEX } : {}),
     },
   },
   build: {


### PR DESCRIPTION
Injects `@vercel/analytics` at boot — pageviews + web vitals in the Vercel dashboard, mirroring the docs site. No-ops outside Vercel deployments.