### PR TITLE
restyle(tuner): custom focus, hover and pressed states

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils'
 const buttonVariants = cva(
   [
     'inline-flex items-center justify-center gap-2 whitespace-nowrap',
-    'text-sm font-medium transition-colors',
+    'text-sm font-medium transition-colors active:brightness-95',
     'disabled:pointer-events-none disabled:opacity-50',
     '[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   ].join(' '),

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -9,7 +9,7 @@ const Checkbox = forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer h-[15px] w-[15px] shrink-0 border-2 border-brand-neutral-400 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-brand-accent data-[state=checked]:bg-brand-accent data-[state=checked]:text-brand-ground',
+      'peer h-[15px] w-[15px] shrink-0 border-2 border-brand-neutral-400 transition-colors hover:border-brand-accent active:brightness-95 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-brand-neutral-400 data-[state=checked]:border-brand-accent data-[state=checked]:bg-brand-accent data-[state=checked]:text-brand-ground',
       className
     )}
     {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,10 +8,10 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({ className, type, ...pr
     type={type}
     ref={ref}
     className={cn(
-      'flex h-10 w-full border border-input bg-background px-3 py-2 text-sm',
+      'flex h-10 w-full border border-input bg-background px-3 py-2 text-sm transition-colors',
       'file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-text',
-      'placeholder:text-text-muted',
-      'disabled:cursor-not-allowed disabled:opacity-50',
+      'placeholder:text-text-muted hover:border-brand-accent focus:border-brand-accent',
+      'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-input',
       className
     )}
     {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -47,7 +47,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-9 w-full items-center justify-between gap-2 border border-border bg-surface px-3 py-1 text-sm text-text shadow-sm hover:border-brand-accent disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-border',
+      'flex h-9 w-full items-center justify-between gap-2 border border-border bg-surface px-3 py-1 text-sm text-text shadow-sm transition-colors hover:border-brand-accent active:brightness-95 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-border',
       className
     )}
     {...props}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -9,7 +9,7 @@ const Switch = forwardRef<
   <SwitchPrimitive.Root
     ref={ref}
     className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center border-2 border-transparent transition-colors',
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center border-2 border-transparent transition-colors active:brightness-95',
       'disabled:cursor-not-allowed disabled:opacity-50',
       'data-[state=checked]:bg-brand-accent data-[state=unchecked]:bg-input',
       className

--- a/src/components/ui/toggle-pill.tsx
+++ b/src/components/ui/toggle-pill.tsx
@@ -22,7 +22,7 @@ const accentPillStyle = (active: boolean, accentColor: string): CSSProperties =>
 
 const basePillClasses = (active: boolean): string =>
   cn(
-    'cursor-pointer border px-3 py-[3px] text-[11px] font-semibold uppercase tracking-[0.04em] transition-colors',
+    'cursor-pointer border px-3 py-[3px] text-[11px] font-semibold uppercase tracking-[0.04em] transition-colors active:brightness-95',
     active
       ? 'border-brand-accent bg-brand-accent/15 text-brand-accent'
       : 'border-border bg-transparent text-text-dim hover:border-brand-accent'


### PR DESCRIPTION
## What

Gives every interactive UI primitive consistent, theme-aware interaction states so no browser defaults leak through.

- **Focus** — the global `:focus-visible` accent ring (`outline: 2px solid var(--brand-accent); outline-offset: 2px`) in `index.css` already matches the spec and applies to every element, so keyboard focus never shows the UA default. Left unchanged; no `:focus` outline is suppressed anywhere without a replacement (the one `outline-none` on select items is replaced by a `focus:bg` highlight).
- **Hover** — primary buttons darken to `brand-accent-600`, outline/secondary/select/checkbox/toggle-pill borders switch to accent. Added the missing hover on `Input` (border turns accent) and `Checkbox` (border turns accent).
- **Pressed** — added a uniform `active:brightness-95` pressed state across the primitives (`Button`, `Checkbox`, `Switch`, `Select` trigger, `TogglePill`). Buttons previously had no pressed feedback at all. It uses only an existing Tailwind step (no new tokens, no magic colours) and reads correctly in both light and dark themes.

All changes live in the shadcn primitives under `src/components/ui/` so the states flow everywhere they're used, rather than per-call overrides.

## Why

Closes #4 — consistent interaction states across the Tuner, no browser defaults, keyboard focus always visible.

## Test plan

- `npm run typecheck` — clean
- `npm run lint` — no issues
- `npm test` — 159 passed
- `npm run build` — builds
- `prettier --check` — formatted
- Keyboard-tab through the primitives shows the accent ring; hover/pressed states render consistently.

## Components touched

`button.tsx`, `input.tsx`, `checkbox.tsx`, `switch.tsx`, `select.tsx`, `toggle-pill.tsx`