### PR TITLE
chore(tuner): drop screen sleep setting for @canshift/core 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^1.0.0",
+        "@canshift/core": "^2.0.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-label": "^2.1.8",
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-1.0.0.tgz",
-      "integrity": "sha512-mB5gl4zwPk0wTQJydz7xT5Qe3LcdTMZDXuHe4b5DzutyPVzUzbg4yXAfXv3MO7drP3So0mN93Th0MyiB8qoBAw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-CP73cFi9c7A7KR6Kh7PfF7LYCpZiEU4d7sgCjLNov8XHiD64xnmfiq5F/60KvjU9V40rCq8V3b+fnWk9wyDaAw==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^1.0.0",
+    "@canshift/core": "^2.0.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-label": "^2.1.8",

--- a/src/components/editor/ScreenSettingsPanel.tsx
+++ b/src/components/editor/ScreenSettingsPanel.tsx
@@ -33,7 +33,6 @@ interface ScreenSettingsPanelProps {
 
 const ScreenSettingsPanel = ({ scale }: ScreenSettingsPanelProps) => {
   const brightness = useScreenSettingsStore((s) => s.brightness)
-  const sleep = useScreenSettingsStore((s) => s.sleep)
   const rotation = useScreenSettingsStore((s) => s.rotation)
   const updateScreenSettings = useScreenSettingsStore((s) => s.update)
   const { connected, simulationMode, isDayMode, setIsDayMode } = useDeviceState()
@@ -51,7 +50,6 @@ const ScreenSettingsPanel = ({ scale }: ScreenSettingsPanelProps) => {
     if (simulationMode || !connected) return
     const result = await usbService.pushScreenSettings({
       brightness,
-      sleep,
       rotation: nextRotation,
     })
     if (result.success) {

--- a/src/stores/screen-settings.store.test.ts
+++ b/src/stores/screen-settings.store.test.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useScreenSettingsStore, type StoredScreenSettings } from './screen-settings.store'
 
-const DEFAULTS: StoredScreenSettings = { brightness: 80, sleep: 0, rotation: 0 }
+const DEFAULTS: StoredScreenSettings = { brightness: 80, rotation: 0 }
 
 describe('screen-settings.store (#1705)', () => {
   beforeEach(() => {
     useScreenSettingsStore.getState().update(DEFAULTS)
   })
 
-  it('exposes core-shaped defaults with a sleep field', () => {
+  it('exposes core-shaped defaults', () => {
     const s = useScreenSettingsStore.getState()
     expect(s.brightness).toBe(80)
-    expect(s.sleep).toBe(0)
     expect(s.rotation).toBe(0)
   })
 
@@ -19,16 +18,13 @@ describe('screen-settings.store (#1705)', () => {
     useScreenSettingsStore.getState().update({ brightness: 40 })
     const s = useScreenSettingsStore.getState()
     expect(s.brightness).toBe(40)
-    expect(s.sleep).toBe(0)
     expect(s.rotation).toBe(0)
   })
 
-  it('preserves the last-known sleep across unrelated updates', () => {
-    useScreenSettingsStore.getState().update({ sleep: 300 })
+  it('accumulates sequential single-field updates', () => {
     useScreenSettingsStore.getState().update({ brightness: 60 })
     useScreenSettingsStore.getState().update({ rotation: 180 })
     const s = useScreenSettingsStore.getState()
-    expect(s.sleep).toBe(300)
     expect(s.brightness).toBe(60)
     expect(s.rotation).toBe(180)
   })

--- a/src/stores/screen-settings.store.ts
+++ b/src/stores/screen-settings.store.ts
@@ -11,7 +11,6 @@ interface ScreenSettingsState extends StoredScreenSettings {
 
 const DEFAULTS: StoredScreenSettings = {
   brightness: 80,
-  sleep: 0,
   rotation: 0,
 }
 


### PR DESCRIPTION
## What

`@canshift/core@2.0.0` removed the `sleep` field from `ScreenSettingsSchema` (breaking). This bumps the tuner to `@canshift/core@2.0.0` and removes every reference to the screen-setting `sleep`:

- `src/stores/screen-settings.store.ts` — dropped `sleep` from the store defaults (`StoredScreenSettings` now derives from the slimmer `ScreenSettings`).
- `src/stores/screen-settings.store.test.ts` — removed `sleep` from the defaults and assertions; the sleep-persistence test now covers sequential single-field updates via `brightness`/`rotation`.
- `src/components/editor/ScreenSettingsPanel.tsx` — dropped the `sleep` selector and stopped sending it in the `pushScreenSettings` payload. The panel had no dedicated sleep control, so no UI control was removed.
- `package.json` / `package-lock.json` — `@canshift/core` `^1.0.0` → `^2.0.0`.

The `sleep(ms)` helpers in `src/lib/firmware/flash.ts` and `src/hooks/verifyBurnedConfig.ts` are unrelated `setTimeout` delay utilities (name collision) and were intentionally left untouched.

## Why

Keeps the tuner in sync with the core 2.0.0 schema; without the bump the removed field would drift out of contract with the firmware.

## Test plan

- `npm run typecheck` — clean
- `npm run lint` — no issues
- `npm test` — 159 passed
- `npm run format:check` — clean
- `npm run build` — builds

Closes CANShift/canshift-core#1