### PR TITLE
fix(tuner): allow Sentry ingest in CSP and deliver feedback off the analytics opt-out

### DIFF
--- a/src/components/shell/FeedbackButton.tsx
+++ b/src/components/shell/FeedbackButton.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
-import { captureFeedback, isPostHogReady } from '../../lib/posthog'
+import { submitFeedback } from '../../lib/feedback'
 
 const STORAGE_KEY = 'canshift:feedback-dismissed-hint'
 const LEGACY_STORAGE_KEY = 'tuner.feedback.dismissed-hint'
@@ -16,24 +16,27 @@ const readDismissed = (): boolean => {
   return false
 }
 
-type Status = 'idle' | 'sending' | 'sent'
+type Status = 'idle' | 'sending' | 'sent' | 'error'
+
+const SEND_LABELS: Record<Status, string> = {
+  idle: 'Send',
+  sending: 'Sending…',
+  sent: 'Send',
+  error: 'Retry',
+}
 
 const FeedbackButton = () => {
-  const [ready, setReady] = useState(false)
   const [showHint, setShowHint] = useState(false)
   const [open, setOpen] = useState(false)
   const [message, setMessage] = useState('')
   const [email, setEmail] = useState('')
   const [status, setStatus] = useState<Status>('idle')
+  const [errorMessage, setErrorMessage] = useState('')
   const location = useLocation()
 
   useEffect(() => {
-    if (!isPostHogReady()) return
-    setReady(true)
     setShowHint(!readDismissed())
   }, [])
-
-  if (!ready) return null
 
   const dismissHint = () => {
     setShowHint(false)
@@ -51,21 +54,28 @@ const FeedbackButton = () => {
     setMessage('')
     setEmail('')
     setStatus('idle')
+    setErrorMessage('')
   }
 
-  const submit = () => {
+  const submit = async () => {
     const trimmed = message.trim()
     if (trimmed.length === 0) return
     setStatus('sending')
+    setErrorMessage('')
     const trimmedEmail = email.trim()
-    captureFeedback({
+    const result = await submitFeedback({
       message: trimmed,
       route: location.pathname,
       tunerVersion: __TUNER_VERSION__,
       ...(trimmedEmail.length > 0 ? { email: trimmedEmail } : {}),
     })
-    setStatus('sent')
-    setTimeout(closeDialog, 1500)
+    if (result.ok) {
+      setStatus('sent')
+      setTimeout(closeDialog, 1500)
+      return
+    }
+    setStatus('error')
+    setErrorMessage(result.error)
   }
 
   return (
@@ -115,6 +125,7 @@ const FeedbackButton = () => {
                 }}
                 placeholder="Describe the bug or your suggestion…"
                 rows={4}
+                maxLength={1900}
                 autoFocus
                 style={{
                   background: 'hsl(var(--brand-neutral-100))',
@@ -144,6 +155,11 @@ const FeedbackButton = () => {
                   fontFamily: 'inherit',
                 }}
               />
+              {status === 'error' && (
+                <div role="alert" style={{ fontSize: 12, color: 'hsl(var(--brand-accent))' }}>
+                  Couldn’t send your feedback ({errorMessage}). Please try again.
+                </div>
+              )}
               <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
                 <button
                   type="button"
@@ -162,7 +178,9 @@ const FeedbackButton = () => {
                 </button>
                 <button
                   type="button"
-                  onClick={submit}
+                  onClick={() => {
+                    void submit()
+                  }}
                   disabled={status === 'sending' || message.trim().length === 0}
                   style={{
                     background:
@@ -176,7 +194,7 @@ const FeedbackButton = () => {
                     cursor: message.trim().length === 0 ? 'not-allowed' : 'pointer',
                   }}
                 >
-                  {status === 'sending' ? 'Sending…' : 'Send'}
+                  {SEND_LABELS[status]}
                 </button>
               </div>
             </>

--- a/src/lib/feedback.test.ts
+++ b/src/lib/feedback.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { submitFeedback } from './feedback'
+
+const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>()
+
+const parseBody = (init?: RequestInit): Record<string, unknown> =>
+  JSON.parse(String(init?.body)) as Record<string, unknown>
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('submitFeedback', () => {
+  it('posts to the canshift contact endpoint with an empty honeypot and context', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }))
+
+    const result = await submitFeedback({
+      message: 'gauge flickers on reconnect',
+      email: 'driver@example.com',
+      route: '/editor',
+      tunerVersion: '9.9.9',
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const call = fetchMock.mock.calls[0]
+    expect(call).toBeDefined()
+    const [url, init] = call ?? []
+    expect(url).toBe('https://tmbk.ch/api/contact/canshift')
+    expect(init?.method).toBe('POST')
+    const body = parseBody(init)
+    expect(body.company).toBe('')
+    expect(body.name).toBe('CANShift Tuner')
+    expect(body.email).toBe('driver@example.com')
+    expect(body.message).toContain('gauge flickers on reconnect')
+    expect(body.message).toContain('/editor')
+    expect(body.message).toContain('9.9.9')
+  })
+
+  it('falls back to a noreply address when no email is provided', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }))
+
+    await submitFeedback({ message: 'anonymous report', route: '/', tunerVersion: '1.0.0' })
+
+    const init = fetchMock.mock.calls[0]?.[1]
+    expect(parseBody(init).email).toBe('noreply@canshift.ch')
+  })
+
+  it('returns an error result on a non-2xx response instead of throwing', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 502 }))
+
+    const result = await submitFeedback({
+      message: 'server error',
+      route: '/',
+      tunerVersion: '1.0.0',
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('502')
+  })
+
+  it('returns an error result when the request throws while offline', async () => {
+    fetchMock.mockRejectedValue(new Error('Failed to fetch'))
+
+    const result = await submitFeedback({
+      message: 'offline report',
+      route: '/',
+      tunerVersion: '1.0.0',
+    })
+
+    expect(result).toEqual({ ok: false, error: 'Failed to fetch' })
+  })
+})

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -1,0 +1,51 @@
+const CONTACT_ENDPOINT = 'https://tmbk.ch/api/contact/canshift'
+const REPORTER_NAME = 'CANShift Tuner'
+const FALLBACK_EMAIL = 'noreply@canshift.ch'
+const SEND_TIMEOUT_MS = 8_000
+
+export interface FeedbackInput {
+  message: string
+  email?: string
+  route: string
+  tunerVersion: string
+}
+
+export type FeedbackResult = { ok: true } | { ok: false; error: string }
+
+const composeMessage = ({ message, route, tunerVersion }: FeedbackInput): string =>
+  `${message}\n\n— route: ${route}\n— tuner: ${tunerVersion}`
+
+const resolveEmail = (email?: string): string => {
+  const trimmed = email?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : FALLBACK_EMAIL
+}
+
+export const submitFeedback = async (input: FeedbackInput): Promise<FeedbackResult> => {
+  const controller = new AbortController()
+  const timer = setTimeout(() => {
+    controller.abort()
+  }, SEND_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(CONTACT_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: REPORTER_NAME,
+        email: resolveEmail(input.email),
+        message: composeMessage(input),
+        company: '',
+      }),
+      signal: controller.signal,
+    })
+    if (!response.ok) {
+      return { ok: false, error: `Feedback endpoint returned HTTP ${String(response.status)}` }
+    }
+    return { ok: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Network unreachable'
+    return { ok: false, error: message }
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -37,13 +37,3 @@ export const captureFlowEvent = (name: string, props: Record<string, unknown> = 
 }
 
 export const isPostHogReady = (): boolean => initialized
-
-export const captureFeedback = (props: {
-  message: string
-  email?: string
-  route: string
-  tunerVersion: string
-}): void => {
-  if (!initialized) return
-  posthog.capture('feedback_submitted', props)
-}

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api.github.com https://eu.i.posthog.com https://eu-assets.i.posthog.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api.github.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://*.ingest.de.sentry.io https://tmbk.ch; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },


### PR DESCRIPTION
Closes #27

Two observability defects from the 2026-08-03 audit.

## Leg (a) — CSP `connect-src` blocked Sentry ingest

`vercel.json` allowlisted `'self'`, GitHub, and PostHog, but no Sentry host, so every captured error was silently dropped in prod even with `VITE_SENTRY_DSN` set. The DSN region is `de` (`vite.config.ts` sets the Sentry URL to `https://de.sentry.io`), so events POST to `*.ingest.de.sentry.io`.

- Added `https://*.ingest.de.sentry.io` to `connect-src` (the exact ingest region, nothing broader).
- Also added `https://tmbk.ch` to `connect-src` for leg (b) below.

## Leg (b) — feedback silently dropped when telemetry is off

`captureFeedback` sent through `posthog.capture()`, but when a user opts out of observability `syncConsent` calls `posthog.opt_out_capturing()`, turning that into a no-op. The user still saw a success toast while the message went nowhere.

- New `src/lib/feedback.ts` — `submitFeedback()` delivers via the tmbk.ch `POST /api/contact/canshift` endpoint (fields `name`, `email`, `message`, honeypot `company` kept empty), a channel independent of the PostHog opt-out. It returns a `{ ok } | { ok: false, error }` result — no throw, no silent catch — with an 8s abort timeout matching the GitHub releases fetch.
  - No email supplied falls back to `noreply@canshift.ch` (the contact schema requires a valid address); route + tuner version are appended to the message body for context.
- `FeedbackButton` now calls `submitFeedback` and renders an explicit error state (visible `role="alert"` message + "Retry") when delivery fails, instead of always showing success. It no longer gates its own visibility on PostHog being ready, since feedback must work regardless of telemetry consent. Textarea capped at 1900 chars to stay within the endpoint's 2000-char limit after the appended context.
- Removed the now-unused `captureFeedback` from `src/lib/posthog.ts`.

## Test plan

- `npm run typecheck` — clean
- `npm run lint` — no issues
- `npm test` — 163 passed (new `src/lib/feedback.test.ts`: endpoint URL + empty honeypot + context, noreply fallback, non-2xx returns an error result, network throw returns an error result)
- `npm run format:check` — clean
- `npm run build` — builds

## Follow-up (out of scope, backend)

The folio_tmbk backend `CORS_ORIGINS` currently defaults to `localhost:5173,tmbk.ch,www.tmbk.ch`. The tuner's production origin must be added there for the cross-origin POST to succeed in prod — a change in that repo, not this one.