### PR TITLE
perf(tuner): memoize CAN rows, drop global nowMs ticker, virtualize the table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-select": "^2.3.0",
         "@radix-ui/react-switch": "^1.2.6",
         "@sentry/react": "^10.69.0",
+        "@tanstack/react-virtual": "3.14.9",
         "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2494,6 +2495,33 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-select": "^2.3.0",
     "@radix-ui/react-switch": "^1.2.6",
     "@sentry/react": "^10.69.0",
+    "@tanstack/react-virtual": "3.14.9",
     "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/can-bus/CanFrameRow.test.tsx
+++ b/src/components/can-bus/CanFrameRow.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { CanFrameRow } from './CanFrameRow'
+import { CanHistogramRow } from './CanHistogramRow'
+
+const reactMemo = Symbol.for('react.memo')
+
+describe('can-bus rows stay memoized', () => {
+  it('CanFrameRow is wrapped in memo so unchanged rows skip the 4x/sec re-render', () => {
+    expect((CanFrameRow as { $$typeof?: symbol }).$$typeof).toBe(reactMemo)
+  })
+
+  it('CanHistogramRow is wrapped in memo so an expanded histogram does not re-render on every tick', () => {
+    expect((CanHistogramRow as { $$typeof?: symbol }).$$typeof).toBe(reactMemo)
+  })
+})

--- a/src/components/can-bus/CanFrameRow.tsx
+++ b/src/components/can-bus/CanFrameRow.tsx
@@ -1,76 +1,83 @@
 import type { CSSProperties } from 'react'
-import { useState } from 'react'
-import { CanByteHistogram } from './CanByteHistogram'
+import { forwardRef, memo, useEffect, useState } from 'react'
 import type { CanFrameStats } from '../../hooks/useCanScanner'
 import { MONO_FONT } from '../../lib/typography'
 
 export interface CanFrameRowProps {
   frame: CanFrameStats
-  nowMs: number
   mappedName: string | null
   learnScore: number | null
+  expanded: boolean
+  dataIndex: number
+  onToggle: (id: number) => void
   onPromote: (id: number) => void
 }
 
 const STALE_AFTER_MS = 2_000
 
-export const CanFrameRow = ({
-  frame,
-  nowMs,
-  mappedName,
-  learnScore,
-  onPromote,
-}: CanFrameRowProps) => {
-  const [expanded, setExpanded] = useState(false)
-  const idHex = formatCanId(frame.id)
-  const stale = nowMs - frame.lastSeenMs > STALE_AFTER_MS
+const isStale = (lastSeenMs: number): boolean => performance.now() - lastSeenMs > STALE_AFTER_MS
 
-  return (
-    <>
-      <tr style={rowStyle(stale)}>
-        <td style={idCellStyle}>
-          <button
-            type="button"
-            onClick={() => {
-              setExpanded((v) => !v)
-            }}
-            style={expandButtonStyle}
-            aria-label={expanded ? 'Collapse byte histogram' : 'Expand byte histogram'}
-          >
-            <span style={{ display: 'inline-block', width: 10 }}>{expanded ? '▾' : '▸'}</span>
-            {idHex}
-          </button>
-        </td>
-        <td style={dlcCellStyle}>{String(frame.lastDlc)}</td>
-        <td style={dataCellStyle}>{formatPayload(frame.lastPayload, frame.lastDlc)}</td>
-        <td style={dimCellStyle}>{String(frame.rateHz)} Hz</td>
-        <td style={dimCellStyle}>{formatCount(frame.count)}</td>
-        {learnScore !== null && <td style={dimCellStyle}>{formatCount(learnScore)}</td>}
-        <td style={mappedCellStyle}>
-          {mappedName ?? (
+export const CanFrameRow = memo(
+  forwardRef<HTMLTableRowElement, CanFrameRowProps>(
+    ({ frame, mappedName, learnScore, expanded, dataIndex, onToggle, onPromote }, ref) => {
+      const [stale, setStale] = useState(() => isStale(frame.lastSeenMs))
+      const idHex = formatCanId(frame.id)
+
+      useEffect(() => {
+        const remaining = STALE_AFTER_MS - (performance.now() - frame.lastSeenMs)
+        if (remaining <= 0) {
+          setStale(true)
+          return
+        }
+        setStale(false)
+        const timer = window.setTimeout(() => {
+          setStale(true)
+        }, remaining)
+        return () => {
+          window.clearTimeout(timer)
+        }
+      }, [frame.lastSeenMs])
+
+      return (
+        <tr ref={ref} data-index={dataIndex} style={rowStyle(stale)}>
+          <td style={idCellStyle}>
             <button
               type="button"
-              className="editor-ghost-accent"
               onClick={() => {
-                onPromote(frame.id)
+                onToggle(frame.id)
               }}
-              style={promoteButtonStyle}
+              style={expandButtonStyle}
+              aria-label={expanded ? 'Collapse byte histogram' : 'Expand byte histogram'}
             >
-              PROMOTE
+              <span style={{ display: 'inline-block', width: 10 }}>{expanded ? '▾' : '▸'}</span>
+              {idHex}
             </button>
-          )}
-        </td>
-      </tr>
-      {expanded && (
-        <tr>
-          <td colSpan={learnScore !== null ? 7 : 6} style={expandedCellStyle}>
-            <CanByteHistogram frame={frame} />
+          </td>
+          <td style={dlcCellStyle}>{String(frame.lastDlc)}</td>
+          <td style={dataCellStyle}>{formatPayload(frame.lastPayload, frame.lastDlc)}</td>
+          <td style={dimCellStyle}>{String(frame.rateHz)} Hz</td>
+          <td style={dimCellStyle}>{formatCount(frame.count)}</td>
+          {learnScore !== null && <td style={dimCellStyle}>{formatCount(learnScore)}</td>}
+          <td style={mappedCellStyle}>
+            {mappedName ?? (
+              <button
+                type="button"
+                className="editor-ghost-accent"
+                onClick={() => {
+                  onPromote(frame.id)
+                }}
+                style={promoteButtonStyle}
+              >
+                PROMOTE
+              </button>
+            )}
           </td>
         </tr>
-      )}
-    </>
+      )
+    }
   )
-}
+)
+CanFrameRow.displayName = 'CanFrameRow'
 
 const formatCanId = (id: number): string => {
   const extended = id > 0x7ff
@@ -157,9 +164,4 @@ const expandButtonStyle: CSSProperties = {
   display: 'inline-flex',
   alignItems: 'center',
   gap: 6,
-}
-
-const expandedCellStyle: CSSProperties = {
-  padding: '0 0 0 20px',
-  borderBottom: '1px solid hsl(var(--brand-neutral-300))',
 }

--- a/src/components/can-bus/CanFrameTable.tsx
+++ b/src/components/can-bus/CanFrameTable.tsx
@@ -1,25 +1,67 @@
 import type { CSSProperties } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { CanFrameRow } from './CanFrameRow'
+import { CanHistogramRow } from './CanHistogramRow'
 import type { CanFrameStats } from '../../hooks/useCanScanner'
 
 export interface CanFrameTableProps {
   frames: readonly CanFrameStats[]
-  nowMs: number
   mappedTo: ReadonlyMap<number, string>
   learnScores: ReadonlyMap<number, number> | null
   onPromote: (id: number) => void
 }
 
+type VisualRow =
+  { kind: 'main'; frame: CanFrameStats } | { kind: 'histogram'; frame: CanFrameStats }
+
 const COLUMN_WIDTHS = [110, 70, null, 100, 110, 180] as const
 const COLUMN_WIDTHS_LEARN = [110, 70, null, 100, 110, 100, 180] as const
+const ESTIMATED_ROW_HEIGHT = 45
+const OVERSCAN_ROWS = 16
 
-export const CanFrameTable = ({
-  frames,
-  nowMs,
-  mappedTo,
-  learnScores,
-  onPromote,
-}: CanFrameTableProps) => {
+const visualRowKey = (row: VisualRow): string =>
+  `${row.kind === 'main' ? 'm' : 'h'}${String(row.frame.id)}`
+
+export const CanFrameTable = ({ frames, mappedTo, learnScores, onPromote }: CanFrameTableProps) => {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<number>>(() => new Set())
+
+  const toggle = useCallback((id: number) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const visualRows = useMemo<VisualRow[]>(() => {
+    const rows: VisualRow[] = []
+    for (const frame of frames) {
+      rows.push({ kind: 'main', frame })
+      if (expandedIds.has(frame.id)) rows.push({ kind: 'histogram', frame })
+    }
+    return rows
+  }, [frames, expandedIds])
+
+  const virtualizer = useVirtualizer({
+    count: visualRows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    overscan: OVERSCAN_ROWS,
+    getItemKey: (index) => visualRowKey(visualRows[index] as VisualRow),
+  })
+
+  const colCount = learnScores !== null ? 7 : 6
+  const columnWidths = learnScores !== null ? COLUMN_WIDTHS_LEARN : COLUMN_WIDTHS
+  const virtualItems = virtualizer.getVirtualItems()
+  const paddingTop = virtualItems.length > 0 ? (virtualItems[0]?.start ?? 0) : 0
+  const paddingBottom =
+    virtualItems.length > 0
+      ? virtualizer.getTotalSize() - (virtualItems[virtualItems.length - 1]?.end ?? 0)
+      : 0
+
   if (frames.length === 0) {
     return (
       <div style={emptyStyle}>
@@ -29,10 +71,10 @@ export const CanFrameTable = ({
   }
 
   return (
-    <div style={wrapperStyle}>
+    <div ref={scrollRef} style={wrapperStyle}>
       <table style={tableStyle}>
         <colgroup>
-          {(learnScores !== null ? COLUMN_WIDTHS_LEARN : COLUMN_WIDTHS).map((width, i) => (
+          {columnWidths.map((width, i) => (
             <col key={i} style={width === null ? undefined : { width }} />
           ))}
         </colgroup>
@@ -48,16 +90,43 @@ export const CanFrameTable = ({
           </tr>
         </thead>
         <tbody>
-          {frames.map((f) => (
-            <CanFrameRow
-              key={f.id}
-              frame={f}
-              nowMs={nowMs}
-              mappedName={mappedTo.get(f.id) ?? null}
-              learnScore={learnScores === null ? null : (learnScores.get(f.id) ?? 0)}
-              onPromote={onPromote}
-            />
-          ))}
+          {paddingTop > 0 && (
+            <tr aria-hidden style={{ height: paddingTop }}>
+              <td colSpan={colCount} style={spacerCellStyle} />
+            </tr>
+          )}
+          {virtualItems.map((item) => {
+            const row = visualRows[item.index] as VisualRow
+            if (row.kind === 'histogram') {
+              return (
+                <CanHistogramRow
+                  key={item.key}
+                  ref={virtualizer.measureElement}
+                  dataIndex={item.index}
+                  frame={row.frame}
+                  colSpan={colCount}
+                />
+              )
+            }
+            return (
+              <CanFrameRow
+                key={item.key}
+                ref={virtualizer.measureElement}
+                dataIndex={item.index}
+                frame={row.frame}
+                mappedName={mappedTo.get(row.frame.id) ?? null}
+                learnScore={learnScores === null ? null : (learnScores.get(row.frame.id) ?? 0)}
+                expanded={expandedIds.has(row.frame.id)}
+                onToggle={toggle}
+                onPromote={onPromote}
+              />
+            )
+          })}
+          {paddingBottom > 0 && (
+            <tr aria-hidden style={{ height: paddingBottom }}>
+              <td colSpan={colCount} style={spacerCellStyle} />
+            </tr>
+          )}
         </tbody>
       </table>
     </div>
@@ -93,6 +162,11 @@ const thStyle: CSSProperties = {
 const thFirstStyle: CSSProperties = {
   ...thStyle,
   paddingLeft: 20,
+}
+
+const spacerCellStyle: CSSProperties = {
+  padding: 0,
+  border: 0,
 }
 
 const emptyStyle: CSSProperties = {

--- a/src/components/can-bus/CanHistogramRow.tsx
+++ b/src/components/can-bus/CanHistogramRow.tsx
@@ -1,0 +1,26 @@
+import type { CSSProperties } from 'react'
+import { forwardRef, memo } from 'react'
+import { CanByteHistogram } from './CanByteHistogram'
+import type { CanFrameStats } from '../../hooks/useCanScanner'
+
+export interface CanHistogramRowProps {
+  frame: CanFrameStats
+  colSpan: number
+  dataIndex: number
+}
+
+export const CanHistogramRow = memo(
+  forwardRef<HTMLTableRowElement, CanHistogramRowProps>(({ frame, colSpan, dataIndex }, ref) => (
+    <tr ref={ref} data-index={dataIndex}>
+      <td colSpan={colSpan} style={expandedCellStyle}>
+        <CanByteHistogram frame={frame} />
+      </td>
+    </tr>
+  ))
+)
+CanHistogramRow.displayName = 'CanHistogramRow'
+
+const expandedCellStyle: CSSProperties = {
+  padding: '0 0 0 20px',
+  borderBottom: '1px solid hsl(var(--brand-neutral-300))',
+}

--- a/src/routes/CanBusRoute.tsx
+++ b/src/routes/CanBusRoute.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import type { CSSProperties } from 'react'
 import type { SignalDef } from '@canshift/core'
 import { useCanScanner } from '../hooks/useCanScanner'
@@ -11,8 +11,6 @@ import { useSignalStore } from '../stores/signal.store'
 import { useLogStore } from '../stores/log.store'
 import { parseHexFrameId } from '../utils/frame-id'
 
-const NOW_TICK_MS = 250
-
 const CanBusRoute = () => {
   const connected = useDeviceStore((s) => s.connected)
   const simulationMode = useDeviceStore((s) => s.simulationMode)
@@ -21,16 +19,6 @@ const CanBusRoute = () => {
   const log = useLogStore((s) => s.push)
   const scanner = useCanScanner()
   const [sortKey, setSortKey] = useState<SortKey>('id')
-  const [nowMs, setNowMs] = useState(() => performance.now())
-
-  useEffect(() => {
-    const id = window.setInterval(() => {
-      setNowMs(performance.now())
-    }, NOW_TICK_MS)
-    return () => {
-      window.clearInterval(id)
-    }
-  }, [])
 
   const learn = scanner.snapshot.learn
 
@@ -91,7 +79,6 @@ const CanBusRoute = () => {
       />
       <CanFrameTable
         frames={sortedFrames}
-        nowMs={nowMs}
         mappedTo={mappedTo}
         learnScores={learn?.scores ?? null}
         onPromote={promote}

--- a/src/stores/can-scan/accumulator.test.ts
+++ b/src/stores/can-scan/accumulator.test.ts
@@ -90,6 +90,46 @@ describe('scan accumulator', () => {
     expect(acc.snapshot(10).learn).toBeNull()
   })
 
+  it('keeps a stable stats object identity for an unchanged frame so memoized rows bail out', () => {
+    const acc = createScanAccumulator()
+    acc.ingest({ id: 0x100, len: 1, data: [1] }, 0)
+    acc.ingest({ id: 0x200, len: 1, data: [2] }, 0)
+
+    const snap1 = acc.snapshot(100)
+    acc.ingest({ id: 0x100, len: 1, data: [3] }, 150)
+    const snap2 = acc.snapshot(200)
+
+    expect(snap2.frames.get(0x200)).toBe(snap1.frames.get(0x200))
+    expect(snap2.frames.get(0x100)).not.toBe(snap1.frames.get(0x100))
+  })
+
+  it('emits a fresh stats object while a stopped frame rate decays, then settles to a stable identity', () => {
+    const acc = createScanAccumulator()
+    acc.ingest({ id: 0x100, len: 1, data: [1] }, 0)
+
+    const live = acc.snapshot(100)
+    expect(live.frames.get(0x100)?.rateHz).toBe(1)
+
+    const decayed = acc.snapshot(RATE_WINDOW_MS + 100)
+    expect(decayed.frames.get(0x100)).not.toBe(live.frames.get(0x100))
+    expect(decayed.frames.get(0x100)?.rateHz).toBe(0)
+
+    const settled = acc.snapshot(RATE_WINDOW_MS + 200)
+    expect(settled.frames.get(0x100)).toBe(decayed.frames.get(0x100))
+  })
+
+  it('drops cached identity on reset', () => {
+    const acc = createScanAccumulator()
+    acc.ingest({ id: 0x100, len: 1, data: [1] }, 0)
+    const before = acc.snapshot(100)
+    acc.reset()
+    acc.ingest({ id: 0x100, len: 1, data: [1] }, 200)
+    const after = acc.snapshot(300)
+
+    expect(after.frames.get(0x100)).not.toBe(before.frames.get(0x100))
+    expect(after.frames.get(0x100)?.count).toBe(1)
+  })
+
   it('truncates payloads beyond 8 bytes', () => {
     const acc = createScanAccumulator()
     acc.ingest({ id: 0x2, len: 10, data: Array.from({ length: 10 }, (_, i) => i) }, 0)

--- a/src/stores/can-scan/accumulator.ts
+++ b/src/stores/can-scan/accumulator.ts
@@ -8,14 +8,14 @@ export interface CanFrame {
 }
 
 export interface CanFrameStats {
-  id: number
-  firstSeenMs: number
-  lastSeenMs: number
-  count: number
-  rateHz: number
-  lastDlc: number
-  lastPayload: readonly number[]
-  byteValueCounts: ReadonlyArray<ReadonlyMap<number, number>>
+  readonly id: number
+  readonly firstSeenMs: number
+  readonly lastSeenMs: number
+  readonly count: number
+  readonly rateHz: number
+  readonly lastDlc: number
+  readonly lastPayload: readonly number[]
+  readonly byteValueCounts: ReadonlyArray<ReadonlyMap<number, number>>
 }
 
 export interface LearnWindow {

--- a/src/stores/can-scan/accumulator.ts
+++ b/src/stores/can-scan/accumulator.ts
@@ -40,6 +40,7 @@ interface MutableFrameStats {
   lastDlc: number
   lastPayload: number[]
   byteValueCounts: Map<number, number>[]
+  dirty: boolean
 }
 
 export interface ScanAccumulator {
@@ -66,6 +67,7 @@ const payloadsDiffer = (a: readonly number[], b: readonly number[]): boolean =>
 
 export const createScanAccumulator = (): ScanAccumulator => {
   let frames = new Map<number, MutableFrameStats>()
+  let emitted = new Map<number, CanFrameStats>()
   let total = 0
   let totalRecent: number[] = []
   let startedAt: number | null = null
@@ -97,6 +99,7 @@ export const createScanAccumulator = (): ScanAccumulator => {
             { length: MAX_PAYLOAD_BYTES },
             () => new Map<number, number>()
           ),
+          dirty: true,
         }
         frames.set(frame.id, stats)
       }
@@ -114,6 +117,7 @@ export const createScanAccumulator = (): ScanAccumulator => {
       stats.lastDlc = frame.len
       stats.lastPayload = incoming
       stats.recentMs.push(nowMs)
+      stats.dirty = true
       for (let i = 0; i < frame.data.length && i < MAX_PAYLOAD_BYTES; i++) {
         const byte = frame.data[i]
         if (byte === undefined) continue
@@ -128,17 +132,25 @@ export const createScanAccumulator = (): ScanAccumulator => {
       const next = new Map<number, CanFrameStats>()
       for (const [id, m] of frames) {
         trimRecent(m.recentMs, nowMs)
-        next.set(id, {
-          id: m.id,
-          firstSeenMs: m.firstSeenMs,
-          lastSeenMs: m.lastSeenMs,
-          count: m.count,
-          rateHz: m.recentMs.length,
-          lastDlc: m.lastDlc,
-          lastPayload: m.lastPayload.slice(),
-          byteValueCounts: m.byteValueCounts.map((counts) => new Map(counts)),
-        })
+        const rateHz = m.recentMs.length
+        const previous = emitted.get(id)
+        const unchanged = previous !== undefined && !m.dirty && previous.rateHz === rateHz
+        const stats = unchanged
+          ? previous
+          : {
+              id: m.id,
+              firstSeenMs: m.firstSeenMs,
+              lastSeenMs: m.lastSeenMs,
+              count: m.count,
+              rateHz,
+              lastDlc: m.lastDlc,
+              lastPayload: m.lastPayload.slice(),
+              byteValueCounts: m.byteValueCounts.map((counts) => new Map(counts)),
+            }
+        next.set(id, stats)
+        m.dirty = false
       }
+      emitted = next
       return {
         startedAt,
         totalFrames: total,
@@ -170,6 +182,7 @@ export const createScanAccumulator = (): ScanAccumulator => {
 
     reset: () => {
       frames = new Map()
+      emitted = new Map()
       total = 0
       totalRecent = []
       startedAt = null


### PR DESCRIPTION
Closes #26

The live CAN table re-rendered every row 4x/sec with no virtualization. Two 250ms tickers drove it and a global `nowMs` was threaded into every row purely for a staleness opacity, so all rows (and every expanded histogram) re-rendered on every tick regardless of data change, and hundreds of unique IDs mounted hundreds of `<tr>`.

## What changed (three layers)

**1. Stable stats identity in the accumulator** (`src/stores/can-scan/accumulator.ts`)
The snapshot rebuilt a brand-new `CanFrameStats` object for every id on every tick, so memoizing rows alone would not have helped — each row's `frame` prop was always a new reference. The accumulator now caches the last emitted stats per id and reuses that exact object when a frame is neither dirty (no new data since the last snapshot) nor changing rate. A frame still gets a fresh object while its windowed rate decays after it goes quiet, then settles back to a stable identity once the rate reaches 0. This is what lets `memo` actually bail.

**2. Memoized rows, no global ticker** (`CanFrameRow.tsx`, new `CanHistogramRow.tsx`, `CanBusRoute.tsx`)
- `CanFrameRow` and the extracted `CanHistogramRow` are wrapped in `memo`.
- Removed the `nowMs` prop and the 250ms `nowMs` interval in `CanBusRoute` entirely. Staleness is now a per-row `setTimeout` keyed on `frame.lastSeenMs`: a row fades exactly once when it crosses the 2s threshold, instead of all rows re-evaluating 4x/sec.
- Expand state was lifted to the table (`Set<number>`) so it survives virtualization mount/unmount and keeps rows pure functions of their props.

**3. Windowed virtualization** (`CanFrameTable.tsx`)
Added `@tanstack/react-virtual` (pinned `3.14.9`). The tbody is virtualized over a flat list of "visual rows" — each frame contributes one main `<tr>` plus, when expanded, a histogram `<tr>`. Because every visual row is a single `<tr>`, `measureElement` handles the variable-height histogram cleanly while keeping real `<table>` semantics, the sticky `<thead>`, and `tableLayout: fixed` column alignment. Off-screen IDs are no longer mounted.

## Before / after

For a busy bus with N unique IDs (say N≈300, ~40 actively transmitting, ~30 rows visible):

| | Before | After |
| --- | --- | --- |
| Row re-renders / sec | ~4·N (all rows, every tick) ≈ 1200 | ~4 × visible-changing rows ≈ ≤120; idle rows bail |
| `<tr>` mounted | N (≈300+) | viewport window + overscan (≈30–46) |
| Stale fade | re-evaluated on all rows 4x/sec | one re-render per row when it crosses 2s |

Exact React render counts weren't auto-measured — the repo has no React Testing Library — so those are reasoned from the mechanism. The enabling behaviour (stable identity, correct rate decay) is covered by new unit tests.

## Tests

- `src/stores/can-scan/accumulator.test.ts` — unchanged frame keeps the same object identity across snapshots (memo bail), a stopped frame emits a fresh object while its rate decays then settles to a stable identity, and `reset` drops the cache.
- `src/components/can-bus/CanFrameRow.test.tsx` — guards that both row components stay `memo`-wrapped.

## Checks

- `npm run typecheck` — clean
- `npm run lint` — no issues
- `npm test` — 168 passed
- `npm run format:check` — clean
- `npm run build` — builds

## Note

I couldn't drive the table with live frames locally: the scanner only runs with a connected device (dev/sim mode produces no CAN frames), so the virtualized rendering is best verified on the PR's Vercel preview with hardware. New dep: `@tanstack/react-virtual@3.14.9` (~4 kB gzip, pinned).