### PR TITLE
feat(tuner): project switcher in the header with duplicate, import and export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@canshift/core": "^2.0.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
+        "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.3.0",
         "@radix-ui/react-switch": "^1.2.6",
@@ -1387,6 +1388,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
@@ -1452,6 +1482,46 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1554,6 +1624,39 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1703,6 +1806,21 @@
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.4"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@canshift/core": "^2.0.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.3.0",
     "@radix-ui/react-switch": "^1.2.6",

--- a/src/components/project/ProjectSwitcher.tsx
+++ b/src/components/project/ProjectSwitcher.tsx
@@ -1,0 +1,159 @@
+import { useRef, type ChangeEvent } from 'react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { DEFAULT_PROJECT_NAME, useProjectStore } from '../../stores/project/project.store'
+import { useDashboardStore } from '../../stores/dashboard.store'
+import { useLogStore } from '../../stores/log.store'
+import {
+  PROJECT_FILE_ACCEPT,
+  downloadProjectFile,
+  readProjectFileText,
+} from '../../lib/project-file'
+
+const RECENT_LIMIT = 8
+
+const ChevronIcon = () => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+)
+
+export const ProjectSwitcher = () => {
+  const projects = useProjectStore((s) => s.projects)
+  const activeProjectId = useProjectStore((s) => s.activeProjectId)
+  const switchProject = useProjectStore((s) => s.switchProject)
+  const duplicateProject = useProjectStore((s) => s.duplicateProject)
+  const importProject = useProjectStore((s) => s.importProject)
+  const exportProject = useProjectStore((s) => s.exportProject)
+  const dashboardName = useDashboardStore((s) => s.config?.name ?? null)
+  const log = useLogStore((s) => s.push)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const activeMeta = projects.find((p) => p.id === activeProjectId) ?? null
+  const activeName = activeMeta?.name ?? dashboardName ?? DEFAULT_PROJECT_NAME
+  const recent = [...projects]
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+    .slice(0, RECENT_LIMIT)
+
+  const handleSwitch = (id: string) => {
+    if (id === activeProjectId) return
+    if (!switchProject(id)) log('error', 'Could not open that project.')
+  }
+
+  const handleDuplicate = () => {
+    if (activeProjectId === null) return
+    const newId = duplicateProject(activeProjectId)
+    if (newId === null) log('error', 'Could not duplicate the project.')
+    else log('success', `Duplicated “${activeName}”.`)
+  }
+
+  const handleExport = () => {
+    if (activeProjectId === null) return
+    const json = exportProject(activeProjectId)
+    if (json === null) {
+      log('error', 'Could not export the project.')
+      return
+    }
+    downloadProjectFile(activeName, json)
+    log('info', `Exported “${activeName}”.`)
+  }
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) return
+    const raw = await readProjectFileText(file)
+    const result = importProject(raw)
+    if (result.ok) log('success', `Imported “${result.name}”.`)
+    else log('error', result.error)
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            title="Switch project"
+            className="flex max-w-[280px] items-center gap-1.5 text-[15px] font-extrabold text-text transition-colors hover:text-brand-accent focus-visible:text-brand-accent"
+          >
+            <span className="truncate">{activeName}</span>
+            <ChevronIcon />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuLabel>Recent projects</DropdownMenuLabel>
+          <DropdownMenuGroup>
+            {recent.map((project) => (
+              <DropdownMenuItem
+                key={project.id}
+                onSelect={() => {
+                  handleSwitch(project.id)
+                }}
+              >
+                <span className="w-3 text-brand-accent">
+                  {project.id === activeProjectId ? '●' : ''}
+                </span>
+                <span className="truncate">{project.name}</span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            disabled={activeProjectId === null}
+            onSelect={() => {
+              handleDuplicate()
+            }}
+          >
+            Duplicate
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              handleImportClick()
+            }}
+          >
+            Import .canshift…
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            disabled={activeProjectId === null}
+            onSelect={() => {
+              handleExport()
+            }}
+          >
+            Export .canshift
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={PROJECT_FILE_ACCEPT}
+        onChange={(event) => {
+          void handleFileChange(event)
+        }}
+        style={{ display: 'none' }}
+      />
+    </>
+  )
+}

--- a/src/components/project/ProjectSwitcher.tsx
+++ b/src/components/project/ProjectSwitcher.tsx
@@ -83,7 +83,13 @@ export const ProjectSwitcher = () => {
     const file = event.target.files?.[0]
     event.target.value = ''
     if (!file) return
-    const raw = await readProjectFileText(file)
+    let raw: string
+    try {
+      raw = await readProjectFileText(file)
+    } catch {
+      log('error', 'Could not read the selected file.')
+      return
+    }
     const result = importProject(raw)
     if (result.ok) log('success', `Imported “${result.name}”.`)
     else log('error', result.error)

--- a/src/components/shell/Header.tsx
+++ b/src/components/shell/Header.tsx
@@ -8,6 +8,7 @@ import { useDeviceStore } from '../../stores/device.store'
 import { useThemeStore } from '../../stores/theme.store'
 import { useUiStore } from '../../stores/ui.store'
 import { ThemeToggleButton } from './ThemeToggleButton'
+import { ProjectSwitcher } from '../project/ProjectSwitcher'
 import { useBurnDashboard } from '../../hooks/useBurnDashboard'
 import { deviceEvents } from '../../transport'
 import {
@@ -119,6 +120,7 @@ const Header = () => {
       lastSavedAt={lastSavedAt}
       portLabel={portLabel}
       activityPulse={pulsing}
+      projectSwitcher={<ProjectSwitcher />}
       firmwareSlot={<UiFirmwareSlot version={firmwareVersion} compat={firmwareCompat} />}
       themeToggle={<ThemeToggle />}
       burnButton={<BurnButton />}

--- a/src/components/shell/HeaderView.tsx
+++ b/src/components/shell/HeaderView.tsx
@@ -13,6 +13,7 @@ export interface HeaderViewProps {
   lastSavedAt?: number | null
   portLabel?: string | null
   activityPulse?: boolean
+  projectSwitcher?: ReactNode
   firmwareSlot?: ReactNode
   themeToggle?: ReactNode
   burnButton?: ReactNode
@@ -49,6 +50,7 @@ export const HeaderView = ({
   lastSavedAt = null,
   portLabel,
   activityPulse = false,
+  projectSwitcher,
   firmwareSlot,
   themeToggle,
   burnButton,
@@ -63,7 +65,8 @@ export const HeaderView = ({
       </div>
 
       <div style={middleZoneStyle}>
-        {projectName !== null && <span style={projectNameStyle}>{projectName}</span>}
+        {projectSwitcher ??
+          (projectName !== null && <span style={projectNameStyle}>{projectName}</span>)}
         <AutosavePill lastSavedAt={lastSavedAt} />
         <span style={statusPillStyle(visual.color)}>
           <span

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,82 @@
+import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react'
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+import { cn } from '@/lib/utils'
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuContent = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[13rem] overflow-hidden border border-border bg-surface p-1 text-text shadow-md',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out',
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Item>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-pointer select-none items-center gap-2 px-2 py-1.5 text-sm outline-none transition-colors',
+      'focus:bg-brand-accent/15 focus:text-text active:brightness-95',
+      'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuLabel = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Label>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      'px-2 py-1.5 text-[10px] font-extrabold uppercase tracking-[0.14em] text-text-muted',
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-border', className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+}

--- a/src/lib/project-file.ts
+++ b/src/lib/project-file.ts
@@ -18,7 +18,9 @@ export const downloadProjectFile = (name: string, json: string): void => {
   anchor.href = url
   anchor.download = projectFileName(name)
   anchor.click()
-  URL.revokeObjectURL(url)
+  setTimeout(() => {
+    URL.revokeObjectURL(url)
+  }, 10_000)
 }
 
 export const readProjectFileText = (file: File): Promise<string> => file.text()

--- a/src/lib/project-file.ts
+++ b/src/lib/project-file.ts
@@ -1,0 +1,24 @@
+export const PROJECT_FILE_EXTENSION = 'canshift'
+export const PROJECT_FILE_ACCEPT = '.canshift,application/json'
+
+const sanitizeFileName = (name: string): string =>
+  name
+    .trim()
+    .replace(/[^a-z0-9\-_]+/gi, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase() || 'project'
+
+export const projectFileName = (name: string): string =>
+  `${sanitizeFileName(name)}.${PROJECT_FILE_EXTENSION}`
+
+export const downloadProjectFile = (name: string, json: string): void => {
+  const blob = new Blob([json], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = projectFileName(name)
+  anchor.click()
+  URL.revokeObjectURL(url)
+}
+
+export const readProjectFileText = (file: File): Promise<string> => file.text()

--- a/src/stores/project/project.store.test.ts
+++ b/src/stores/project/project.store.test.ts
@@ -96,4 +96,62 @@ describe('project store', () => {
     expect(readProject(secondId)).toBeNull()
     expect(useProjectStore.getState().projects).toHaveLength(1)
   })
+
+  it('duplicates the active project into a copy and switches to it', () => {
+    bootstrapProjects()
+    const firstId = useProjectStore.getState().activeProjectId ?? ''
+    const originalName =
+      useProjectStore.getState().projects.find((p) => p.id === firstId)?.name ?? ''
+
+    const copyId = useProjectStore.getState().duplicateProject(firstId)
+    expect(copyId).not.toBeNull()
+    expect(copyId).not.toBe(firstId)
+    expect(useProjectStore.getState().activeProjectId).toBe(copyId)
+    expect(useProjectStore.getState().projects).toHaveLength(2)
+
+    const copy = readProject(copyId ?? '')
+    expect(copy?.name).toBe(`${originalName} copy`)
+    expect(copy?.dashboard.defaultPageId).toBe(DEFAULT_SIM_CONFIG.defaultPageId)
+  })
+
+  it('exports and re-imports a project as a new copy without data loss', () => {
+    bootstrapProjects()
+    const originalId = useProjectStore.getState().activeProjectId ?? ''
+
+    const json = useProjectStore.getState().exportProject(originalId)
+    expect(json).not.toBeNull()
+
+    const result = useProjectStore.getState().importProject(json ?? '')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.id).not.toBe(originalId)
+    expect(useProjectStore.getState().activeProjectId).toBe(result.id)
+    expect(useProjectStore.getState().projects).toHaveLength(2)
+
+    const imported = readProject(result.id)
+    const original = readProject(originalId)
+    expect(imported?.name).toBe(original?.name)
+    expect(imported?.dashboard.defaultPageId).toBe(original?.dashboard.defaultPageId)
+    expect(imported?.signals).toEqual(original?.signals)
+  })
+
+  it('rejects malformed or non-project files on import', () => {
+    bootstrapProjects()
+    expect(useProjectStore.getState().importProject('not json').ok).toBe(false)
+    expect(useProjectStore.getState().importProject('{"foo":1}').ok).toBe(false)
+    expect(useProjectStore.getState().projects).toHaveLength(1)
+  })
+
+  it('export flushes pending editor edits before serializing', () => {
+    bootstrapProjects()
+    const id = useProjectStore.getState().activeProjectId ?? ''
+    useDashboardStore.getState().updatePage(DEFAULT_SIM_CONFIG.defaultPageId, { visible: false })
+
+    const json = useProjectStore.getState().exportProject(id)
+    const parsed = JSON.parse(json ?? '{}') as {
+      dashboard: { pages: { id: string; visible: boolean }[] }
+    }
+    const page = parsed.dashboard.pages.find((p) => p.id === DEFAULT_SIM_CONFIG.defaultPageId)
+    expect(page?.visible).toBe(false)
+  })
 })

--- a/src/stores/project/project.store.ts
+++ b/src/stores/project/project.store.ts
@@ -6,14 +6,18 @@ import { captureFlowEvent } from '../../lib/posthog'
 import { useDashboardStore } from '../dashboard.store'
 import { useSignalStore, DEFAULT_PROFILE_KEY } from '../signal.store'
 import {
+  deserializeProject,
   readProject,
   readProjectIndex,
   removeProject,
+  serializeProject,
   writeProject,
   writeProjectIndex,
 } from './storage'
 
 export const DEFAULT_PROJECT_NAME = 'My dashboard'
+
+export type ImportResult = { ok: true; id: string; name: string } | { ok: false; error: string }
 
 interface ProjectState {
   projects: ProjectMeta[]
@@ -22,8 +26,13 @@ interface ProjectState {
   switchProject: (id: string) => boolean
   renameProject: (id: string, name: string) => void
   deleteProject: (id: string) => boolean
+  duplicateProject: (id: string) => string | null
+  importProject: (raw: string) => ImportResult
+  exportProject: (id: string) => string | null
   saveActiveProject: () => void
 }
+
+const duplicateName = (name: string): string => `${name} copy`.slice(0, PROJECT_NAME_MAX)
 
 const nowIso = (): string => new Date().toISOString()
 
@@ -138,6 +147,59 @@ export const useProjectStore = create<ProjectState>()((set, get) => ({
     set({ projects: nextProjects })
     persistIndex(nextProjects, get().activeProjectId)
     return true
+  },
+
+  duplicateProject: (id) => {
+    get().saveActiveProject()
+    const source = readProject(id)
+    if (!source) return null
+    const newId = createId('proj')
+    const createdAt = nowIso()
+    const copy: Project = {
+      ...source,
+      id: newId,
+      name: duplicateName(source.name),
+      createdAt,
+      updatedAt: createdAt,
+    }
+    if (!writeProject(copy)) return null
+    const nextProjects = upsertMeta(get().projects, {
+      id: newId,
+      name: copy.name,
+      createdAt,
+      updatedAt: createdAt,
+    })
+    set({ projects: nextProjects, activeProjectId: newId })
+    persistIndex(nextProjects, newId)
+    loadProjectIntoStores(copy)
+    captureFlowEvent('project_duplicated')
+    return newId
+  },
+
+  importProject: (raw) => {
+    const parsed = deserializeProject(raw)
+    if (!parsed) return { ok: false, error: 'That file is not a valid .canshift project.' }
+    get().saveActiveProject()
+    const newId = createId('proj')
+    const imported: Project = { ...parsed, id: newId, updatedAt: nowIso() }
+    if (!writeProject(imported)) return { ok: false, error: 'Could not save the imported project.' }
+    const nextProjects = upsertMeta(get().projects, {
+      id: newId,
+      name: imported.name,
+      createdAt: imported.createdAt,
+      updatedAt: imported.updatedAt,
+    })
+    set({ projects: nextProjects, activeProjectId: newId })
+    persistIndex(nextProjects, newId)
+    loadProjectIntoStores(imported)
+    captureFlowEvent('project_imported')
+    return { ok: true, id: newId, name: imported.name }
+  },
+
+  exportProject: (id) => {
+    if (id === get().activeProjectId) get().saveActiveProject()
+    const project = readProject(id)
+    return project ? serializeProject(project) : null
   },
 }))
 

--- a/src/stores/project/storage.ts
+++ b/src/stores/project/storage.ts
@@ -70,9 +70,7 @@ export const writeProjectIndex = (index: ProjectIndex): void => {
   safeSet(PROJECT_INDEX_KEY, JSON.stringify(index))
 }
 
-export const readProject = (id: string): Project | null => {
-  const raw = safeGet(projectStorageKey(id))
-  if (raw === null) return null
+export const deserializeProject = (raw: string): Project | null => {
   let outer: unknown
   try {
     outer = JSON.parse(raw)
@@ -92,6 +90,14 @@ export const readProject = (id: string): Project | null => {
   }
   const parsed = ProjectSchema.safeParse(candidate)
   return parsed.success ? parsed.data : null
+}
+
+export const serializeProject = (project: Project): string => JSON.stringify(project, null, 2)
+
+export const readProject = (id: string): Project | null => {
+  const raw = safeGet(projectStorageKey(id))
+  if (raw === null) return null
+  return deserializeProject(raw)
 }
 
 export const writeProject = (project: Project): boolean => {


### PR DESCRIPTION
Closes #6

Implements Flow 2's project switcher (`docs/design/tuner-flows.md`, canshift-brand): a dropdown in the header, next to the project name, to move between projects and to duplicate / import / export them.

## What changed

**Store (`stores/project/project.store.ts`)** — three new actions on top of the existing project model:
- `duplicateProject(id)` — flushes the active editor state, copies the project (dashboard + ECU profile + signals) under a new id named `"<name> copy"`, and switches to it.
- `importProject(raw)` — validates the file, assigns a fresh id so an import never overwrites an existing project, adds it and switches. Returns a discriminated `ImportResult` (`{ ok, id, name } | { ok: false, error }`) — invalid input is reported, never silently swallowed.
- `exportProject(id)` — flushes pending edits for the active project, then returns the serialized JSON.

**Storage (`stores/project/storage.ts`)** — factored the existing read/validate path into a reusable `deserializeProject(raw)` (used by both `readProject` and import; runs `migrateConfig` so older files upgrade on import) and added `serializeProject` (pretty JSON).

**File I/O (`lib/project-file.ts`)** — DOM helpers kept out of the store: `downloadProjectFile` (Blob + anchor, sanitized `<name>.canshift`) and `readProjectFileText`.

**UI**
- New shadcn primitive `components/ui/dropdown-menu.tsx` (Radix `@radix-ui/react-dropdown-menu`, styled to match the existing `select` primitive — keyboard nav, focus ring, `focus:bg-brand-accent/15` items).
- New `components/project/ProjectSwitcher.tsx` — trigger shows the active project name; menu lists recent projects (active-marked, most-recent first, capped at 8), then Duplicate / Import .canshift… / Export .canshift. Import uses a hidden file input; outcomes are surfaced through the log store.
- `HeaderView` gained a `projectSwitcher` slot that replaces the static name span; `Header` renders `<ProjectSwitcher />` into it.

## Interim note (.canshift format)

Export/import currently write and read the project's JSON with a `.canshift` extension and validate against `ProjectSchema` (with schema migration). The dedicated `.canshift` container/versioned file format is #10 — this PR is forward-compatible with that: it round-trips the exact schema, so #10 can wrap it without changing the store contract.

## Scope note (New project)

Flow 2 lists "New project" in the switcher, but that entry opens the three-step new-project wizard (target panel → ECU → starting point), which is a separate Flow 2 sub-piece. It's intentionally not in this PR; the switcher covers switch + duplicate + import + export per the task scope.

## Verification

Beyond the checks below, I drove it in the browser (sim mode): the switcher renders in the header, the menu opens with the recent list + actions, Duplicate creates a copy and switches to it, and the project index persists with both projects (recent-first) — acceptance's "recent list persisted". Zero console errors.

## Tests

`stores/project/project.store.test.ts` — duplicate creates+switches, export→import round-trips with no data loss (new id, same dashboard/signals/name), import rejects malformed and non-project JSON, and export flushes pending editor edits.

## Checks
- `npm run typecheck` — clean
- `npm run lint` — no issues
- `npm test` — 172 passed
- `npm run format:check` — clean
- `npm run build` — builds

New dep: `@radix-ui/react-dropdown-menu` (matches the repo's existing Radix/shadcn primitives).