### PR TITLE
feat(tuner): adopt the real .canshift envelope for import and export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^2.0.0",
+        "@canshift/core": "^2.4.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dropdown-menu": "^2.1.24",
@@ -350,9 +350,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-CP73cFi9c7A7KR6Kh7PfF7LYCpZiEU4d7sgCjLNov8XHiD64xnmfiq5F/60KvjU9V40rCq8V3b+fnWk9wyDaAw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-7RnMYhAGi+ZgRZ52xx8iz9gdGN3ahdtF8NB1pUOeLS+A39SyJpEQQvyWZ9XzaZ9EgQEstXP1dB+jxdawLBwoXA==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^2.0.0",
+    "@canshift/core": "^2.4.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dropdown-menu": "^2.1.24",

--- a/src/lib/project-file.ts
+++ b/src/lib/project-file.ts
@@ -1,5 +1,6 @@
-export const PROJECT_FILE_EXTENSION = 'canshift'
-export const PROJECT_FILE_ACCEPT = '.canshift,application/json'
+import { CANSHIFT_FILE_EXTENSION, CANSHIFT_FILE_MIME } from '@canshift/core'
+
+export const PROJECT_FILE_ACCEPT = `${CANSHIFT_FILE_EXTENSION},${CANSHIFT_FILE_MIME}`
 
 const sanitizeFileName = (name: string): string =>
   name
@@ -9,10 +10,10 @@ const sanitizeFileName = (name: string): string =>
     .toLowerCase() || 'project'
 
 export const projectFileName = (name: string): string =>
-  `${sanitizeFileName(name)}.${PROJECT_FILE_EXTENSION}`
+  `${sanitizeFileName(name)}${CANSHIFT_FILE_EXTENSION}`
 
 export const downloadProjectFile = (name: string, json: string): void => {
-  const blob = new Blob([json], { type: 'application/json' })
+  const blob = new Blob([json], { type: CANSHIFT_FILE_MIME })
   const url = URL.createObjectURL(blob)
   const anchor = document.createElement('a')
   anchor.href = url

--- a/src/stores/project/project.store.test.ts
+++ b/src/stores/project/project.store.test.ts
@@ -121,6 +121,10 @@ describe('project store', () => {
     const json = useProjectStore.getState().exportProject(originalId)
     expect(json).not.toBeNull()
 
+    const envelope = JSON.parse(json ?? '{}') as { format: string; formatVersion: number }
+    expect(envelope.format).toBe('canshift')
+    expect(envelope.formatVersion).toBeGreaterThanOrEqual(1)
+
     const result = useProjectStore.getState().importProject(json ?? '')
     expect(result.ok).toBe(true)
     if (!result.ok) return
@@ -135,23 +139,40 @@ describe('project store', () => {
     expect(imported?.signals).toEqual(original?.signals)
   })
 
-  it('rejects malformed or non-project files on import', () => {
+  it('reports a distinct readable error for each kind of bad import', () => {
     bootstrapProjects()
-    expect(useProjectStore.getState().importProject('not json').ok).toBe(false)
-    expect(useProjectStore.getState().importProject('{"foo":1}').ok).toBe(false)
+    const activeId = useProjectStore.getState().activeProjectId ?? ''
+    const envelope = useProjectStore.getState().exportProject(activeId) ?? ''
+    const bumped = JSON.parse(envelope) as { formatVersion: number }
+    bumped.formatVersion = 999
+
+    const invalidJson = useProjectStore.getState().importProject('not json')
+    const notCanshift = useProjectStore.getState().importProject('{"foo":1}')
+    const tooNew = useProjectStore.getState().importProject(JSON.stringify(bumped))
+
+    expect(invalidJson.ok).toBe(false)
+    expect(notCanshift.ok).toBe(false)
+    expect(tooNew.ok).toBe(false)
+    if (invalidJson.ok || notCanshift.ok || tooNew.ok) return
+
+    expect(notCanshift.error).toContain('.canshift file')
+    expect(notCanshift.error).not.toBe(invalidJson.error)
+    expect(tooNew.error).toContain('Update CANShift')
     expect(useProjectStore.getState().projects).toHaveLength(1)
   })
 
-  it('export flushes pending editor edits before serializing', () => {
+  it('export flushes pending editor edits into the envelope before serializing', () => {
     bootstrapProjects()
     const id = useProjectStore.getState().activeProjectId ?? ''
     useDashboardStore.getState().updatePage(DEFAULT_SIM_CONFIG.defaultPageId, { visible: false })
 
     const json = useProjectStore.getState().exportProject(id)
     const parsed = JSON.parse(json ?? '{}') as {
-      dashboard: { pages: { id: string; visible: boolean }[] }
+      project: { dashboard: { pages: { id: string; visible: boolean }[] } }
     }
-    const page = parsed.dashboard.pages.find((p) => p.id === DEFAULT_SIM_CONFIG.defaultPageId)
+    const page = parsed.project.dashboard.pages.find(
+      (p) => p.id === DEFAULT_SIM_CONFIG.defaultPageId
+    )
     expect(page?.visible).toBe(false)
   })
 })

--- a/src/stores/project/project.store.ts
+++ b/src/stores/project/project.store.ts
@@ -1,16 +1,20 @@
 import { create } from 'zustand'
-import { PROJECT_FILE_VERSION, PROJECT_NAME_MAX } from '@canshift/core'
+import {
+  PROJECT_FILE_VERSION,
+  PROJECT_NAME_MAX,
+  describeCanshiftFileError,
+  parseCanshiftFile,
+  serializeCanshiftFile,
+} from '@canshift/core'
 import type { DashboardConfig, Project, ProjectMeta } from '@canshift/core'
 import { createId } from '../../utils/id'
 import { captureFlowEvent } from '../../lib/posthog'
 import { useDashboardStore } from '../dashboard.store'
 import { useSignalStore, DEFAULT_PROFILE_KEY } from '../signal.store'
 import {
-  deserializeProject,
   readProject,
   readProjectIndex,
   removeProject,
-  serializeProject,
   writeProject,
   writeProjectIndex,
 } from './storage'
@@ -177,11 +181,11 @@ export const useProjectStore = create<ProjectState>()((set, get) => ({
   },
 
   importProject: (raw) => {
-    const parsed = deserializeProject(raw)
-    if (!parsed) return { ok: false, error: 'That file is not a valid .canshift project.' }
+    const result = parseCanshiftFile(raw)
+    if (result.kind !== 'ok') return { ok: false, error: describeCanshiftFileError(result) }
     get().saveActiveProject()
     const newId = createId('proj')
-    const imported: Project = { ...parsed, id: newId, updatedAt: nowIso() }
+    const imported: Project = { ...result.project, id: newId, updatedAt: nowIso() }
     if (!writeProject(imported)) return { ok: false, error: 'Could not save the imported project.' }
     const nextProjects = upsertMeta(get().projects, {
       id: newId,
@@ -199,7 +203,7 @@ export const useProjectStore = create<ProjectState>()((set, get) => ({
   exportProject: (id) => {
     if (id === get().activeProjectId) get().saveActiveProject()
     const project = readProject(id)
-    return project ? serializeProject(project) : null
+    return project ? serializeCanshiftFile(project) : null
   },
 }))
 

--- a/src/stores/project/storage.ts
+++ b/src/stores/project/storage.ts
@@ -92,8 +92,6 @@ export const deserializeProject = (raw: string): Project | null => {
   return parsed.success ? parsed.data : null
 }
 
-export const serializeProject = (project: Project): string => JSON.stringify(project, null, 2)
-
 export const readProject = (id: string): Project | null => {
   const raw = safeGet(projectStorageKey(id))
   if (raw === null) return null


### PR DESCRIPTION
Closes #10

Replaces the interim raw-JSON import/export from #6 with the real versioned `.canshift` envelope shipped in `@canshift/core@2.4.0` (`serializeCanshiftFile` / `parseCanshiftFile` / `describeCanshiftFileError` + `CANSHIFT_FILE_*`). The store contract is unchanged, so the header switcher and its handlers are untouched.

## What changed

**`stores/project/project.store.ts`**
- `exportProject` → `serializeCanshiftFile(project)` (versioned envelope `{ format, formatVersion, project }`) instead of bare `JSON.stringify`.
- `importProject` → `parseCanshiftFile(raw)`. Every non-`ok` result is turned into a user-facing message via `describeCanshiftFileError(result)`, so each error kind gets its own distinct wording (invalid JSON, not an object, not a .canshift file, unsupported format version, schema too new, migration failed, wrong shape). The parser reuses core's `CURRENT_SCHEMA_VERSION` + migrations, so older files upgrade on import. On success the imported project still gets a fresh id (never overwrites) and becomes active.

**`stores/project/storage.ts`** — dropped the now-unused local `serializeProject` helper (export goes through core; `deserializeProject` stays, still used by `readProject`).

**`lib/project-file.ts`** — file naming now comes from core: `CANSHIFT_FILE_EXTENSION` (`<name>.canshift`), `CANSHIFT_FILE_MIME` for the Blob and the file-picker `accept`. The deferred blob-URL revoke and read-error handling added during #6 review are preserved.

## Tests (`stores/project/project.store.test.ts`)

Migrated the #6 tests to the envelope shape and added envelope-specific coverage — all run against the real published core, not mocks:
- Round-trip asserts the exported string is a `{ format: 'canshift', formatVersion >= 1 }` envelope and re-imports without data loss.
- Distinct-error test: malformed JSON, non-`.canshift` JSON, and a bumped `formatVersion: 999` file each return a readable error; the too-new one contains “Update CANShift”, and no failed import mutates the project list.
- Export flushes pending editor edits into `envelope.project.dashboard` before serializing.

## Checks
- `npm run typecheck` — clean
- `npm run lint` — no issues
- `npm test` — 172 passed
- `npm run format:check` — clean
- `npm run build` — builds (against core 2.4.0)

## Verification note

I intended to drive the export/import round-trip live, but the Playwright/Helium backend became unresponsive this session (navigate and close both timed out) while the dev server was serving 200 — an MCP/environment issue, not the change. Mitigation: the swapped surface is the serialize/parse boundary, which the store tests exercise against the real core 2.4.0 code, and the UI path around it (switcher → export/import → log) is byte-identical to #6, which was driven live when it landed. Worth a manual round-trip on the Vercel preview before merge.