### PR TITLE
feat(tuner): three-step new-project wizard from the switcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@canshift/core": "^2.4.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
+        "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@canshift/core": "^2.4.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.3.0",

--- a/src/components/project/NewProjectWizard.tsx
+++ b/src/components/project/NewProjectWizard.tsx
@@ -1,0 +1,220 @@
+import { useState } from 'react'
+import {
+  DEFAULT_PROFILE_ID,
+  DEFAULT_SCREEN_PROFILE_ID,
+  ECU_PROFILES,
+  PROJECT_NAME_MAX,
+  SCREEN_PROFILES,
+  type ScreenProfileId,
+} from '@canshift/core'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useProjectStore } from '../../stores/project/project.store'
+import { useLogStore } from '../../stores/log.store'
+import { BLANK_PAGE_SET, PAGE_SET_OPTIONS, buildNewProjectDashboard } from '../../lib/new-project'
+
+const STEP_TITLES = ['Target panel', 'ECU profile', 'Starting point'] as const
+const DEFAULT_NEW_NAME = 'New project'
+
+export interface NewProjectWizardProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+interface OptionCardProps {
+  group: string
+  value: string
+  checked: boolean
+  onSelect: (value: string) => void
+  title: string
+  subtitle?: string
+}
+
+const OptionCard = ({ group, value, checked, onSelect, title, subtitle }: OptionCardProps) => (
+  <label className="relative block cursor-pointer">
+    <input
+      type="radio"
+      name={group}
+      value={value}
+      checked={checked}
+      onChange={() => {
+        onSelect(value)
+      }}
+      className="peer sr-only"
+    />
+    <span className="block border border-border bg-surface px-3 py-2.5 transition-colors hover:border-brand-accent peer-checked:border-brand-accent peer-checked:bg-brand-accent/10 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-brand-accent">
+      <span className="block text-sm font-semibold text-text">{title}</span>
+      {subtitle !== undefined && (
+        <span className="mt-0.5 block text-xs text-text-muted">{subtitle}</span>
+      )}
+    </span>
+  </label>
+)
+
+export const NewProjectWizard = ({ open, onOpenChange }: NewProjectWizardProps) => {
+  const createProject = useProjectStore((s) => s.createProject)
+  const log = useLogStore((s) => s.push)
+  const [step, setStep] = useState(0)
+  const [name, setName] = useState('')
+  const [targetProfileId, setTargetProfileId] = useState<ScreenProfileId>(DEFAULT_SCREEN_PROFILE_ID)
+  const [ecuProfileId, setEcuProfileId] = useState<string>(DEFAULT_PROFILE_ID)
+  const [pageSetId, setPageSetId] = useState<string>(BLANK_PAGE_SET)
+
+  const reset = () => {
+    setStep(0)
+    setName('')
+    setTargetProfileId(DEFAULT_SCREEN_PROFILE_ID)
+    setEcuProfileId(DEFAULT_PROFILE_ID)
+    setPageSetId(BLANK_PAGE_SET)
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset()
+    onOpenChange(next)
+  }
+
+  const finalName = name.trim().slice(0, PROJECT_NAME_MAX) || DEFAULT_NEW_NAME
+  const isLastStep = step === STEP_TITLES.length - 1
+
+  const handleCreate = () => {
+    const profile = ECU_PROFILES.find((p) => p.id === ecuProfileId)
+    const dashboard = buildNewProjectDashboard({
+      name: finalName,
+      targetProfile: targetProfileId,
+      pageSetId,
+    })
+    createProject(
+      finalName,
+      dashboard,
+      profile ? { key: `builtin:${profile.id}`, signals: profile.signals } : undefined
+    )
+    log('success', `Created “${finalName}”.`)
+    handleOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New project</DialogTitle>
+          <DialogDescription>
+            Step {String(step + 1)} of {String(STEP_TITLES.length)} — {STEP_TITLES[step]}
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === 0 && (
+          <div className="grid gap-4">
+            <div className="grid gap-1.5">
+              <Label htmlFor="new-project-name">Project name</Label>
+              <Input
+                id="new-project-name"
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value)
+                }}
+                placeholder={DEFAULT_NEW_NAME}
+                maxLength={PROJECT_NAME_MAX}
+                autoFocus
+              />
+            </div>
+            <div className="grid gap-2">
+              {SCREEN_PROFILES.map((profile) => (
+                <OptionCard
+                  key={profile.id}
+                  group="target-panel"
+                  value={profile.id}
+                  checked={targetProfileId === profile.id}
+                  onSelect={(value) => {
+                    setTargetProfileId(value as ScreenProfileId)
+                  }}
+                  title={profile.name}
+                  subtitle={`${String(profile.width)} × ${String(profile.height)}`}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {step === 1 && (
+          <div className="grid gap-2">
+            {ECU_PROFILES.map((profile) => (
+              <OptionCard
+                key={profile.id}
+                group="ecu-profile"
+                value={profile.id}
+                checked={ecuProfileId === profile.id}
+                onSelect={setEcuProfileId}
+                title={profile.name}
+                subtitle={profile.description}
+              />
+            ))}
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="grid gap-2">
+            <OptionCard
+              group="page-set"
+              value={BLANK_PAGE_SET}
+              checked={pageSetId === BLANK_PAGE_SET}
+              onSelect={setPageSetId}
+              title="Blank"
+              subtitle="Start from an empty page"
+            />
+            {PAGE_SET_OPTIONS.map((option) => (
+              <OptionCard
+                key={option.id}
+                group="page-set"
+                value={option.id}
+                checked={pageSetId === option.id}
+                onSelect={setPageSetId}
+                title={option.label}
+              />
+            ))}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              handleOpenChange(false)
+            }}
+          >
+            Cancel
+          </Button>
+          {step > 0 && (
+            <Button
+              variant="outline"
+              onClick={() => {
+                setStep(step - 1)
+              }}
+            >
+              Back
+            </Button>
+          )}
+          {isLastStep ? (
+            <Button onClick={handleCreate}>Create project</Button>
+          ) : (
+            <Button
+              onClick={() => {
+                setStep(step + 1)
+              }}
+            >
+              Next
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/project/ProjectSwitcher.tsx
+++ b/src/components/project/ProjectSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useRef, type ChangeEvent } from 'react'
+import { useRef, useState, type ChangeEvent } from 'react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -8,6 +8,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { NewProjectWizard } from './NewProjectWizard'
 import { DEFAULT_PROJECT_NAME, useProjectStore } from '../../stores/project/project.store'
 import { useDashboardStore } from '../../stores/dashboard.store'
 import { useLogStore } from '../../stores/log.store'
@@ -45,6 +46,7 @@ export const ProjectSwitcher = () => {
   const dashboardName = useDashboardStore((s) => s.config?.name ?? null)
   const log = useLogStore((s) => s.push)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const [wizardOpen, setWizardOpen] = useState(false)
 
   const activeMeta = projects.find((p) => p.id === activeProjectId) ?? null
   const activeName = activeMeta?.name ?? dashboardName ?? DEFAULT_PROJECT_NAME
@@ -127,6 +129,13 @@ export const ProjectSwitcher = () => {
           </DropdownMenuGroup>
           <DropdownMenuSeparator />
           <DropdownMenuItem
+            onSelect={() => {
+              setWizardOpen(true)
+            }}
+          >
+            New project…
+          </DropdownMenuItem>
+          <DropdownMenuItem
             disabled={activeProjectId === null}
             onSelect={() => {
               handleDuplicate()
@@ -160,6 +169,7 @@ export const ProjectSwitcher = () => {
         }}
         style={{ display: 'none' }}
       />
+      <NewProjectWizard open={wizardOpen} onOpenChange={setWizardOpen} />
     </>
   )
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,96 @@
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+  type HTMLAttributes,
+} from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { cn } from '@/lib/utils'
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = forwardRef<
+  ElementRef<typeof DialogPrimitive.Overlay>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = forwardRef<
+  ElementRef<typeof DialogPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-surface p-6 text-text shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        className
+      )}
+      {...props}
+    />
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-left', className)} {...props} />
+)
+DialogHeader.displayName = 'DialogHeader'
+
+const DialogFooter = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    {...props}
+  />
+)
+DialogFooter.displayName = 'DialogFooter'
+
+const DialogTitle = forwardRef<
+  ElementRef<typeof DialogPrimitive.Title>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = forwardRef<
+  ElementRef<typeof DialogPrimitive.Description>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-text-muted', className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogPortal,
+  DialogClose,
+  DialogOverlay,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/lib/new-project.test.ts
+++ b/src/lib/new-project.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_SIM_CONFIG } from '../config/default-sim-config'
+import { BLANK_PAGE_SET, PAGE_SET_OPTIONS, buildNewProjectDashboard } from './new-project'
+
+describe('buildNewProjectDashboard', () => {
+  it('exposes the six default page sets', () => {
+    expect(PAGE_SET_OPTIONS).toHaveLength(6)
+  })
+
+  it('blank starting point yields a single empty page', () => {
+    const dashboard = buildNewProjectDashboard({
+      name: 'Empty',
+      targetProfile: 'crowpanel-28',
+      pageSetId: BLANK_PAGE_SET,
+    })
+    expect(dashboard.pages).toHaveLength(1)
+    expect(dashboard.pages[0]?.widgets).toHaveLength(0)
+    expect(dashboard.defaultPageId).toBe(dashboard.pages[0]?.id)
+    expect(dashboard.name).toBe('Empty')
+    expect(dashboard.targetProfile).toBe('crowpanel-28')
+  })
+
+  it('a page set yields a single page carrying that set’s widgets', () => {
+    const option = PAGE_SET_OPTIONS[0]
+    expect(option).toBeDefined()
+    if (!option) return
+    const source = DEFAULT_SIM_CONFIG.pages.find((p) => p.id === option.id)
+
+    const dashboard = buildNewProjectDashboard({
+      name: 'From set',
+      targetProfile: 'crowpanel-28',
+      pageSetId: option.id,
+    })
+    expect(dashboard.pages).toHaveLength(1)
+    expect(dashboard.pages[0]?.id).toBe(option.id)
+    expect(dashboard.pages[0]?.widgets.length).toBe(source?.widgets.length)
+    expect(dashboard.defaultPageId).toBe(option.id)
+  })
+})

--- a/src/lib/new-project.ts
+++ b/src/lib/new-project.ts
@@ -1,0 +1,45 @@
+import type { DashboardConfig, PageConfig, ScreenProfileId } from '@canshift/core'
+import { DEFAULT_SIM_CONFIG } from '../config/default-sim-config'
+
+export const BLANK_PAGE_SET = 'blank'
+
+export interface PageSetOption {
+  id: string
+  label: string
+}
+
+const prettify = (id: string): string => id.charAt(0).toUpperCase() + id.slice(1)
+
+export const PAGE_SET_OPTIONS: PageSetOption[] = DEFAULT_SIM_CONFIG.pages.map((page) => ({
+  id: page.id,
+  label: prettify(page.id),
+}))
+
+export interface NewProjectOptions {
+  name: string
+  targetProfile: ScreenProfileId
+  pageSetId: string
+}
+
+const emptyPage = (template: PageConfig): PageConfig => ({
+  ...structuredClone(template),
+  id: 'page-1',
+  widgets: [],
+})
+
+export const buildNewProjectDashboard = (options: NewProjectOptions): DashboardConfig => {
+  const base = structuredClone(DEFAULT_SIM_CONFIG)
+  const template = base.pages[0]
+  if (!template) throw new Error('default configuration has no pages')
+  const chosen =
+    options.pageSetId === BLANK_PAGE_SET
+      ? emptyPage(template)
+      : (base.pages.find((page) => page.id === options.pageSetId) ?? emptyPage(template))
+  return {
+    ...base,
+    name: options.name,
+    targetProfile: options.targetProfile,
+    pages: [chosen],
+    defaultPageId: chosen.id,
+  }
+}

--- a/src/stores/project/project.store.test.ts
+++ b/src/stores/project/project.store.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
+import { ECU_PROFILES } from '@canshift/core'
 import { DEFAULT_SIM_CONFIG } from '../../config/default-sim-config'
+import { buildNewProjectDashboard } from '../../lib/new-project'
 import { useDashboardStore } from '../dashboard.store'
 import { useSignalStore } from '../signal.store'
 import { bootstrapProjects, useProjectStore } from './project.store'
@@ -112,6 +114,34 @@ describe('project store', () => {
     const copy = readProject(copyId ?? '')
     expect(copy?.name).toBe(`${originalName} copy`)
     expect(copy?.dashboard.defaultPageId).toBe(DEFAULT_SIM_CONFIG.defaultPageId)
+  })
+
+  it('createProject applies a provided ECU profile to the new project without touching the outgoing one', () => {
+    bootstrapProjects()
+    const firstId = useProjectStore.getState().activeProjectId ?? ''
+    const firstSignalCount = useSignalStore.getState().signals.length
+
+    const maxx = ECU_PROFILES.find((p) => p.id === 'maxxecu-street')
+    expect(maxx).toBeDefined()
+    if (!maxx) return
+
+    const dashboard = buildNewProjectDashboard({
+      name: 'Track car',
+      targetProfile: 'crowpanel-28',
+      pageSetId: 'blank',
+    })
+    const newId = useProjectStore.getState().createProject('Track car', dashboard, {
+      key: 'builtin:maxxecu-street',
+      signals: maxx.signals,
+    })
+
+    const created = readProject(newId)
+    expect(created?.name).toBe('Track car')
+    expect(created?.ecuProfileKey).toBe('builtin:maxxecu-street')
+    expect(created?.signals).toHaveLength(maxx.signals.length)
+    expect(created?.dashboard.pages).toHaveLength(1)
+
+    expect(readProject(firstId)?.signals).toHaveLength(firstSignalCount)
   })
 
   it('exports and re-imports a project as a new copy without data loss', () => {

--- a/src/stores/project/project.store.ts
+++ b/src/stores/project/project.store.ts
@@ -6,7 +6,7 @@ import {
   parseCanshiftFile,
   serializeCanshiftFile,
 } from '@canshift/core'
-import type { DashboardConfig, Project, ProjectMeta } from '@canshift/core'
+import type { DashboardConfig, Project, ProjectMeta, SignalDef } from '@canshift/core'
 import { createId } from '../../utils/id'
 import { captureFlowEvent } from '../../lib/posthog'
 import { useDashboardStore } from '../dashboard.store'
@@ -23,10 +23,19 @@ export const DEFAULT_PROJECT_NAME = 'My dashboard'
 
 export type ImportResult = { ok: true; id: string; name: string } | { ok: false; error: string }
 
+export interface ProjectEcuProfile {
+  key: string
+  signals: SignalDef[]
+}
+
 interface ProjectState {
   projects: ProjectMeta[]
   activeProjectId: string | null
-  createProject: (name: string, dashboard: DashboardConfig) => string
+  createProject: (
+    name: string,
+    dashboard: DashboardConfig,
+    ecuProfile?: ProjectEcuProfile
+  ) => string
   switchProject: (id: string) => boolean
   renameProject: (id: string, name: string) => void
   deleteProject: (id: string) => boolean
@@ -87,7 +96,7 @@ export const useProjectStore = create<ProjectState>()((set, get) => ({
     persistIndex(nextProjects, activeProjectId)
   },
 
-  createProject: (name, dashboard) => {
+  createProject: (name, dashboard, ecuProfile) => {
     get().saveActiveProject()
     const id = createId('proj')
     const createdAt = nowIso()
@@ -99,8 +108,8 @@ export const useProjectStore = create<ProjectState>()((set, get) => ({
       createdAt,
       updatedAt: createdAt,
       dashboard,
-      ecuProfileKey: signalState.selectedProfileKey || DEFAULT_PROFILE_KEY,
-      signals: signalState.signals,
+      ecuProfileKey: ecuProfile?.key ?? (signalState.selectedProfileKey || DEFAULT_PROFILE_KEY),
+      signals: ecuProfile?.signals ?? signalState.signals,
     }
     if (!writeProject(project)) return get().activeProjectId ?? ''
     const nextProjects = upsertMeta(get().projects, {


### PR DESCRIPTION
Closes #7

Adds the New-project wizard from Flow 2 (`docs/design/tuner-flows.md`) and wires it to the "New project…" entry that #6 deliberately left out of the switcher. Exactly three steps, lands in the editor on the chosen starting point, and is abortable without residue (nothing is created or mutated until Create).

## The three steps

1. **Target panel** — project name + a choice from core's `SCREEN_PROFILES` (currently CrowPanel 2.8" 320×240; sets `dashboard.targetProfile`).
2. **ECU profile** — a choice from core's `ECU_PROFILES` (Generic/blank, MaxxECU Street/Race, OBD-II J1979), each shown with its description. "Generic (blank)" is the scan-later path.
3. **Starting point** — Blank (one empty page) or one of the six default page sets (street, track, engine, tuning, timing, controls) from `DEFAULT_SIM_CONFIG`.

Create builds the dashboard, then calls `createProject` with the chosen ECU profile; the editor loads the new project.

## Notable design points

- **No signal-store corruption.** `createProject` runs `saveActiveProject()` first, so mutating the signal store before it (to set the new project's ECU profile) would have written the new signals onto the *outgoing* project. Instead `createProject` gained an optional `ecuProfile` argument (backward compatible — existing callers pass two args); the new project takes the chosen profile directly and the outgoing project is saved untouched. Covered by a test.
- **Dashboard builder** (`lib/new-project.ts`) clones the valid `DEFAULT_SIM_CONFIG` and swaps in one page (empty for Blank, or the chosen set), so the result always passes `DashboardConfigSchema` — `createProject`'s `writeProject` validates it, and the creation test asserts a real project comes back.
- **New shadcn primitive** `ui/dialog.tsx` (`@radix-ui/react-dialog`, styled to match `alert-dialog`) for the modal. Options are native radios in styled cards, so keyboard arrow-nav/selection and the focus ring come for free; radix Dialog gives the focus trap and ESC-to-close. Full keyboard path throughout.

## Tests

- `stores/project/project.store.test.ts` — `createProject` with an ECU profile writes that profile's key + signals to the new project and leaves the outgoing project's signals intact.
- `lib/new-project.test.ts` — six page sets exposed; Blank → one empty page; a page set → one page carrying that set's widgets; name + targetProfile set.

## Checks
- `npm run typecheck` — clean
- `npm run lint` — no issues
- `npm test` — 176 passed
- `npm run format:check` — clean
- `npm run build` — builds

## Verification note

I could not drive the wizard live this session — the Playwright/Helium backend is unresponsive again (navigate times out with the dev server serving 200), and I'm deliberately not falling back to the chrome-devtools MCP because it drives the real Chrome and the project rule keeps browser automation on isolated Helium to protect WebSerial flashing. The creation path (schema-valid dashboard, profile application, no outgoing-project corruption) is integration-tested through `createProject`; the modal/stepper/keyboard behaviour is standard radix Dialog + native radios. Worth a manual click-through on the Vercel preview before merge.

New dep: `@radix-ui/react-dialog` (matches the existing Radix/shadcn primitives).