### PR TITLE
feat(tuner): page templates saved from any page, offered in the new-page menu

### DIFF
--- a/src/components/editor/ManageTemplatesDialog.tsx
+++ b/src/components/editor/ManageTemplatesDialog.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useTemplateStore } from '../../stores/template/template.store'
+import type { PageTemplateEntry } from '../../stores/template/storage'
+import { PAGE_TEMPLATE_NAME_MAX } from '../../lib/page-template'
+
+export interface ManageTemplatesDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+interface TemplateRowProps {
+  entry: PageTemplateEntry
+  onRename: (id: string, name: string) => void
+  onDelete: (id: string) => void
+}
+
+const TemplateRow = ({ entry, onRename, onDelete }: TemplateRowProps) => {
+  const [value, setValue] = useState(entry.name)
+
+  const commit = () => {
+    if (value.trim().length > 0 && value.trim() !== entry.name) onRename(entry.id, value.trim())
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Input
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value)
+        }}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') commit()
+        }}
+        maxLength={PAGE_TEMPLATE_NAME_MAX}
+      />
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          onDelete(entry.id)
+        }}
+      >
+        Delete
+      </Button>
+    </div>
+  )
+}
+
+export const ManageTemplatesDialog = ({ open, onOpenChange }: ManageTemplatesDialogProps) => {
+  const templates = useTemplateStore((s) => s.templates)
+  const renameTemplate = useTemplateStore((s) => s.renameTemplate)
+  const deleteTemplate = useTemplateStore((s) => s.deleteTemplate)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Manage page templates</DialogTitle>
+          <DialogDescription>
+            Rename or delete the templates saved on this browser.
+          </DialogDescription>
+        </DialogHeader>
+        {templates.length === 0 ? (
+          <p className="text-sm text-text-muted">No templates yet.</p>
+        ) : (
+          <div className="grid gap-2">
+            {templates.map((entry) => (
+              <TemplateRow
+                key={entry.id}
+                entry={entry}
+                onRename={renameTemplate}
+                onDelete={deleteTemplate}
+              />
+            ))}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/editor/NewPageMenu.tsx
+++ b/src/components/editor/NewPageMenu.tsx
@@ -1,0 +1,88 @@
+import type { CSSProperties } from 'react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useTemplateStore } from '../../stores/template/template.store'
+import type { PageTemplateEntry } from '../../stores/template/storage'
+
+export interface NewPageMenuProps {
+  atCap: boolean
+  onAddBlank: () => void
+  onInsertTemplate: (entry: PageTemplateEntry) => void
+  onManage: () => void
+}
+
+export const NewPageMenu = ({
+  atCap,
+  onAddBlank,
+  onInsertTemplate,
+  onManage,
+}: NewPageMenuProps) => {
+  const templates = useTemplateStore((s) => s.templates)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button type="button" title="Add a new page" style={triggerStyle}>
+          + PAGE
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuItem
+          disabled={atCap}
+          onSelect={() => {
+            onAddBlank()
+          }}
+        >
+          Blank page
+        </DropdownMenuItem>
+        {templates.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>From template</DropdownMenuLabel>
+            <DropdownMenuGroup>
+              {templates.map((entry) => (
+                <DropdownMenuItem
+                  key={entry.id}
+                  disabled={atCap}
+                  onSelect={() => {
+                    onInsertTemplate(entry)
+                  }}
+                >
+                  <span className="truncate">{entry.name}</span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={() => {
+                onManage()
+              }}
+            >
+              Manage templates…
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+const triggerStyle: CSSProperties = {
+  width: 92,
+  flexShrink: 0,
+  background: 'none',
+  border: 0,
+  borderRight: '1px solid hsl(var(--brand-neutral-300))',
+  fontWeight: 800,
+  fontSize: 12,
+  letterSpacing: '0.06em',
+  color: 'hsl(var(--brand-neutral-700))',
+  cursor: 'pointer',
+}

--- a/src/components/editor/PageStrip.tsx
+++ b/src/components/editor/PageStrip.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react'
 import type { PageConfig, TopBarConfig } from '@canshift/core'
 import { FIRMWARE_CAPS } from '@canshift/core'
-import type { CSSProperties } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { PageThumbnail } from '../../routes/PageThumbnail'
 import { MONO_FONT } from '../../lib/typography'
 
@@ -13,6 +13,7 @@ export interface PageStripProps {
   selectedPageId: string | null
   defaultPageId: string | undefined
   atCap: boolean
+  newPageControl?: ReactNode
   onSelect: (pageId: string) => void
   onAdd: () => void
   onDragStart: (index: number) => void
@@ -28,6 +29,7 @@ const PageStripImpl = ({
   selectedPageId,
   defaultPageId,
   atCap,
+  newPageControl,
   onSelect,
   onAdd,
   onDragStart,
@@ -70,20 +72,22 @@ const PageStripImpl = ({
             onContextMenu={onContextMenu}
           />
         ))}
-        <button
-          type="button"
-          className="shell-nav-item"
-          disabled={atCap}
-          onClick={onAdd}
-          title={
-            atCap
-              ? `Firmware accepts at most ${String(FIRMWARE_CAPS.MAX_PAGES)} pages — remove one to add another`
-              : 'Add a new page'
-          }
-          style={addButtonStyle(atCap)}
-        >
-          + PAGE
-        </button>
+        {newPageControl ?? (
+          <button
+            type="button"
+            className="shell-nav-item"
+            disabled={atCap}
+            onClick={onAdd}
+            title={
+              atCap
+                ? `Firmware accepts at most ${String(FIRMWARE_CAPS.MAX_PAGES)} pages — remove one to add another`
+                : 'Add a new page'
+            }
+            style={addButtonStyle(atCap)}
+          >
+            + PAGE
+          </button>
+        )}
       </div>
     </div>
   )

--- a/src/components/editor/SaveTemplateDialog.tsx
+++ b/src/components/editor/SaveTemplateDialog.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { PAGE_TEMPLATE_NAME_MAX } from '../../lib/page-template'
+
+export interface SaveTemplateDialogProps {
+  open: boolean
+  defaultName: string
+  onOpenChange: (open: boolean) => void
+  onSave: (name: string) => void
+}
+
+export const SaveTemplateDialog = ({
+  open,
+  defaultName,
+  onOpenChange,
+  onSave,
+}: SaveTemplateDialogProps) => {
+  const [name, setName] = useState(defaultName)
+
+  useEffect(() => {
+    if (open) setName(defaultName)
+  }, [open, defaultName])
+
+  const canSave = name.trim().length > 0
+
+  const handleSave = () => {
+    if (!canSave) return
+    onSave(name.trim())
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Save as template</DialogTitle>
+          <DialogDescription>
+            Templates are stored on this browser and offered when adding a page to any project.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-1.5">
+          <Label htmlFor="template-name">Template name</Label>
+          <Input
+            id="template-name"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleSave()
+            }}
+            maxLength={PAGE_TEMPLATE_NAME_MAX}
+            autoFocus
+          />
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              onOpenChange(false)
+            }}
+          >
+            Cancel
+          </Button>
+          <Button disabled={!canSave} onClick={handleSave}>
+            Save template
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/lib/page-template.test.ts
+++ b/src/lib/page-template.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_SIM_CONFIG } from '../config/default-sim-config'
+import { instantiateTemplate } from './page-template'
+import type { PageTemplateEntry } from '../stores/template/storage'
+
+const sampleEntry = (): PageTemplateEntry => {
+  const page = DEFAULT_SIM_CONFIG.pages[0]
+  if (!page) throw new Error('sim config has no pages')
+  return {
+    id: 't1',
+    name: 'Street',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    page: structuredClone(page),
+  }
+}
+
+describe('instantiateTemplate', () => {
+  it('gives a fresh page id and fresh widget ids while preserving every binding', () => {
+    const entry = sampleEntry()
+    const page = instantiateTemplate(entry)
+
+    expect(page.id).not.toBe(entry.page.id)
+    expect(page.widgets.length).toBe(entry.page.widgets.length)
+
+    page.widgets.forEach((widget, index) => {
+      const source = entry.page.widgets[index]
+      expect(widget.id).not.toBe(source?.id)
+      expect({ ...widget, id: '' }).toEqual({ ...source, id: '' })
+    })
+  })
+
+  it('does not mutate the stored template', () => {
+    const entry = sampleEntry()
+    const originalId = entry.page.id
+    instantiateTemplate(entry)
+    expect(entry.page.id).toBe(originalId)
+  })
+})

--- a/src/lib/page-template.ts
+++ b/src/lib/page-template.ts
@@ -1,0 +1,14 @@
+import type { PageConfig } from '@canshift/core'
+import { createId } from '../utils/id'
+import type { PageTemplateEntry } from '../stores/template/storage'
+
+export const PAGE_TEMPLATE_NAME_MAX = 60
+
+export const instantiateTemplate = (entry: PageTemplateEntry): PageConfig => {
+  const source = structuredClone(entry.page)
+  return {
+    ...source,
+    id: createId('page'),
+    widgets: source.widgets.map((widget) => ({ ...widget, id: createId(widget.type) })),
+  }
+}

--- a/src/routes/EditorRoute.tsx
+++ b/src/routes/EditorRoute.tsx
@@ -1,20 +1,36 @@
 import { useState, useRef, useEffect, useCallback, lazy, Suspense } from 'react'
 import { useShallow } from 'zustand/react/shallow'
+import type { PageConfig } from '@canshift/core'
 import { DEFAULT_PAGE_PALETTE, FIRMWARE_CAPS, HexColorSchema } from '@canshift/core'
 import { useDashboardStore } from '../stores/dashboard.store'
 import { PageStrip } from '../components/editor/PageStrip'
+import { NewPageMenu } from '../components/editor/NewPageMenu'
+import { SaveTemplateDialog } from '../components/editor/SaveTemplateDialog'
+import { ManageTemplatesDialog } from '../components/editor/ManageTemplatesDialog'
 import { PageContextMenu } from './PageContextMenu'
 import { RightSidebar } from './RightSidebar'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { createId } from '../utils/id'
+import { instantiateTemplate } from '../lib/page-template'
+import { useTemplateStore } from '../stores/template/template.store'
+import type { PageTemplateEntry } from '../stores/template/storage'
 import { isEditableTarget } from '../utils/is-editable-target'
 import { useUndoToastStore } from '../stores/undo-toast.store'
 import { UndoToast } from '../components/editor/UndoToast'
-import {} from '@/components/ui/alert-dialog'
 
 const Canvas = lazy(() => import('../components/editor/Canvas'))
 
 const NEW_PAGE_BG = HexColorSchema.parse('#000000')
+
+const buildBlankPage = (): PageConfig => ({
+  id: createId('page'),
+  backgroundImage: null,
+  backgroundColor: NEW_PAGE_BG,
+  palette: { ...DEFAULT_PAGE_PALETTE },
+  showTopBar: true,
+  visible: true,
+  widgets: [],
+})
 
 const CanvasFallback = () => {
   return (
@@ -58,6 +74,10 @@ const EditorRoute = () => {
     x: number
     y: number
   } | null>(null)
+
+  const saveTemplate = useTemplateStore((s) => s.saveTemplate)
+  const [saveTemplatePageId, setSaveTemplatePageId] = useState<string | null>(null)
+  const [manageOpen, setManageOpen] = useState(false)
 
   const dragFromIndex = useRef<number | null>(null)
 
@@ -146,18 +166,23 @@ const EditorRoute = () => {
       selectedPageId={selectedPageId}
       defaultPageId={defaultPageId}
       atCap={atCap}
+      newPageControl={
+        <NewPageMenu
+          atCap={atCap}
+          onAddBlank={() => {
+            if (!atCap) addPage(buildBlankPage())
+          }}
+          onInsertTemplate={(entry: PageTemplateEntry) => {
+            if (!atCap) addPage(instantiateTemplate(entry))
+          }}
+          onManage={() => {
+            setManageOpen(true)
+          }}
+        />
+      }
       onSelect={selectPage}
       onAdd={() => {
-        if (atCap) return
-        addPage({
-          id: createId('page'),
-          backgroundImage: null,
-          backgroundColor: NEW_PAGE_BG,
-          palette: { ...DEFAULT_PAGE_PALETTE },
-          showTopBar: true,
-          visible: true,
-          widgets: [],
-        })
+        if (!atCap) addPage(buildBlankPage())
       }}
       onDragStart={handlePageDragStart}
       onDrop={handlePageDrop}
@@ -209,6 +234,9 @@ const EditorRoute = () => {
           onDuplicate={() => {
             duplicatePage(contextMenu.pageId)
           }}
+          onSaveAsTemplate={() => {
+            setSaveTemplatePageId(contextMenu.pageId)
+          }}
           onSetDefault={() => {
             setDefaultPage(contextMenu.pageId)
           }}
@@ -221,6 +249,23 @@ const EditorRoute = () => {
           }}
         />
       )}
+
+      <SaveTemplateDialog
+        open={saveTemplatePageId !== null}
+        defaultName={
+          saveTemplatePageId
+            ? `Page ${String(pages.findIndex((p) => p.id === saveTemplatePageId) + 1)}`
+            : ''
+        }
+        onOpenChange={(open) => {
+          if (!open) setSaveTemplatePageId(null)
+        }}
+        onSave={(name) => {
+          const page = pages.find((p) => p.id === saveTemplatePageId)
+          if (page) saveTemplate(name, page)
+        }}
+      />
+      <ManageTemplatesDialog open={manageOpen} onOpenChange={setManageOpen} />
 
       <UndoToast />
     </div>

--- a/src/routes/PageContextMenu.tsx
+++ b/src/routes/PageContextMenu.tsx
@@ -9,6 +9,7 @@ export interface PageContextMenuProps {
   canDelete: boolean
   onClose: () => void
   onDuplicate: () => void
+  onSaveAsTemplate: () => void
   onSetDefault: () => void
   onToggleVisible: () => void
   onDelete: () => void
@@ -22,6 +23,7 @@ export const PageContextMenu = ({
   canDelete,
   onClose,
   onDuplicate,
+  onSaveAsTemplate,
   onSetDefault,
   onToggleVisible,
   onDelete,
@@ -68,6 +70,7 @@ export const PageContextMenu = ({
     disabled?: boolean
   }[] = [
     { label: 'Duplicate', action: onDuplicate },
+    { label: 'Save as template', action: onSaveAsTemplate },
     {
       label: isDefault ? 'Default ★' : 'Set as default',
       action: onSetDefault,

--- a/src/stores/template/storage.ts
+++ b/src/stores/template/storage.ts
@@ -1,0 +1,55 @@
+import type { PageConfig } from '@canshift/core'
+
+export const PAGE_TEMPLATES_KEY = 'canshift.tuner.page-templates'
+
+export interface PageTemplateEntry {
+  id: string
+  name: string
+  createdAt: string
+  page: PageConfig
+}
+
+const safeGet = (key: string): string | null => {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+const safeSet = (key: string, value: string): boolean => {
+  try {
+    localStorage.setItem(key, value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const isEntry = (value: unknown): value is PageTemplateEntry => {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as Record<string, unknown>
+  if (typeof candidate.id !== 'string') return false
+  if (typeof candidate.name !== 'string') return false
+  if (typeof candidate.createdAt !== 'string') return false
+  const page = candidate.page
+  if (typeof page !== 'object' || page === null) return false
+  const pageRecord = page as Record<string, unknown>
+  return typeof pageRecord.id === 'string' && Array.isArray(pageRecord.widgets)
+}
+
+export const readTemplates = (): PageTemplateEntry[] => {
+  const raw = safeGet(PAGE_TEMPLATES_KEY)
+  if (raw === null) return []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (!Array.isArray(parsed)) return []
+  return parsed.filter(isEntry)
+}
+
+export const writeTemplates = (templates: PageTemplateEntry[]): boolean =>
+  safeSet(PAGE_TEMPLATES_KEY, JSON.stringify(templates))

--- a/src/stores/template/template.store.test.ts
+++ b/src/stores/template/template.store.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { PageConfig } from '@canshift/core'
+import { DEFAULT_SIM_CONFIG } from '../../config/default-sim-config'
+import { useTemplateStore } from './template.store'
+import { readTemplates } from './storage'
+
+const memoryStorage = (): Storage => {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => {
+      map.clear()
+    },
+    getItem: (k: string) => map.get(k) ?? null,
+    key: (i: number) => [...map.keys()][i] ?? null,
+    removeItem: (k: string) => {
+      map.delete(k)
+    },
+    setItem: (k: string, v: string) => {
+      map.set(k, v)
+    },
+  }
+}
+
+const samplePage = (): PageConfig => {
+  const page = DEFAULT_SIM_CONFIG.pages[0]
+  if (!page) throw new Error('sim config has no pages')
+  return structuredClone(page)
+}
+
+describe('template store', () => {
+  beforeEach(() => {
+    globalThis.localStorage = memoryStorage()
+    useTemplateStore.setState({ templates: [] })
+  })
+
+  it('saves a page as a template and persists it project-independently', () => {
+    const id = useTemplateStore.getState().saveTemplate('Street layout', samplePage())
+
+    expect(useTemplateStore.getState().templates).toHaveLength(1)
+    const stored = readTemplates()
+    expect(stored).toHaveLength(1)
+    expect(stored[0]?.id).toBe(id)
+    expect(stored[0]?.name).toBe('Street layout')
+    expect(stored[0]?.page.widgets.length).toBe(samplePage().widgets.length)
+  })
+
+  it('renames a template and persists the change', () => {
+    const id = useTemplateStore.getState().saveTemplate('Old', samplePage())
+    useTemplateStore.getState().renameTemplate(id, 'New name')
+
+    expect(useTemplateStore.getState().templates[0]?.name).toBe('New name')
+    expect(readTemplates()[0]?.name).toBe('New name')
+  })
+
+  it('ignores a blank rename', () => {
+    const id = useTemplateStore.getState().saveTemplate('Keep', samplePage())
+    useTemplateStore.getState().renameTemplate(id, '   ')
+
+    expect(useTemplateStore.getState().templates[0]?.name).toBe('Keep')
+  })
+
+  it('deletes a template and persists the removal', () => {
+    const id = useTemplateStore.getState().saveTemplate('Gone', samplePage())
+    useTemplateStore.getState().deleteTemplate(id)
+
+    expect(useTemplateStore.getState().templates).toHaveLength(0)
+    expect(readTemplates()).toHaveLength(0)
+  })
+})

--- a/src/stores/template/template.store.ts
+++ b/src/stores/template/template.store.ts
@@ -1,0 +1,54 @@
+import { create } from 'zustand'
+import type { PageConfig } from '@canshift/core'
+import { PAGE_TEMPLATE_NAME_MAX } from '../../lib/page-template'
+import { createId } from '../../utils/id'
+import { captureFlowEvent } from '../../lib/posthog'
+import { readTemplates, writeTemplates, type PageTemplateEntry } from './storage'
+
+interface TemplateState {
+  templates: PageTemplateEntry[]
+  saveTemplate: (name: string, page: PageConfig) => string
+  renameTemplate: (id: string, name: string) => void
+  deleteTemplate: (id: string) => void
+}
+
+const nowIso = (): string => new Date().toISOString()
+
+const normalizeName = (name: string): string => name.trim().slice(0, PAGE_TEMPLATE_NAME_MAX)
+
+const persist = (templates: PageTemplateEntry[]): void => {
+  writeTemplates(templates)
+}
+
+export const useTemplateStore = create<TemplateState>()((set, get) => ({
+  templates: readTemplates(),
+
+  saveTemplate: (name, page) => {
+    const id = createId('tmpl')
+    const entry: PageTemplateEntry = {
+      id,
+      name: normalizeName(name) || 'Untitled template',
+      createdAt: nowIso(),
+      page: structuredClone(page),
+    }
+    const next = [entry, ...get().templates]
+    set({ templates: next })
+    persist(next)
+    captureFlowEvent('page_template_saved')
+    return id
+  },
+
+  renameTemplate: (id, name) => {
+    const trimmed = normalizeName(name)
+    if (trimmed.length === 0) return
+    const next = get().templates.map((t) => (t.id === id ? { ...t, name: trimmed } : t))
+    set({ templates: next })
+    persist(next)
+  },
+
+  deleteTemplate: (id) => {
+    const next = get().templates.filter((t) => t.id !== id)
+    set({ templates: next })
+    persist(next)
+  },
+}))


### PR DESCRIPTION
Closes #9

Adds page templates (Flow 2): save any page as a named template, then add it as a new page in any project. Templates are stored on the browser, independent of projects.

## What changed

**Template store** (`stores/template/`) — a small project-independent store persisted under `canshift.tuner.page-templates`:
- `saveTemplate(name, page)` deep-clones the page (so it captures widgets + layout + bindings; bindings are by signal name already, so they travel with the widgets).
- `renameTemplate`, `deleteTemplate`. `storage.ts` reads back with a lightweight shape guard (core exports no `PageConfigSchema`, so this mirrors how the project index is validated).

**Instantiate helper** (`lib/page-template.ts`) — `instantiateTemplate(entry)` clones the stored page with a fresh page id and fresh widget ids (mirroring `duplicatePage`), leaving every binding intact.

**UI**
- `PageContextMenu` (right-click a page) gains **Save as template** → opens `SaveTemplateDialog` to name it.
- The **+ PAGE** control becomes `NewPageMenu` (shadcn dropdown): *Blank page*, then a *From template* group listing saved templates (insert as a new page), then *Manage templates…*. `PageStrip` now takes a `newPageControl` slot so it stays a pure view.
- `ManageTemplatesDialog` — rename (inline, commit on blur/Enter) and delete.

All reuse the existing shadcn `dialog`/`dropdown-menu` primitives; full keyboard path via radix + native inputs.

## Cross-project

Because the template store is independent of the active project, a template saved while project A is open is offered when adding a page to project B — the acceptance criterion. Covered by the store test (persist + read-back is project-agnostic).

## Tests

- `stores/template/template.store.test.ts` — save persists project-independently, rename/delete persist, blank rename ignored.
- `lib/page-template.test.ts` — instantiate yields a fresh page id + fresh widget ids while every other widget field (including the signal binding) is preserved, and it does not mutate the stored template.

## Checks
- `npm run typecheck` — clean
- `npm run lint` — no issues
- `npm test` — 182 passed
- `npm run format:check` — clean
- `npm run build` — builds

## Verification note

I could not drive this live: the Playwright/Helium backend has now been unresponsive for four sessions straight (navigate times out while the dev server serves 200). I kept to the project rule of not falling back to the chrome-devtools MCP against real Chrome. The save→persist→instantiate→insert round-trip and cross-project independence are unit-tested; the context-menu item, dropdown, and dialogs are standard radix wiring. Worth a manual click-through on the Vercel preview — and the Playwright backend likely needs a restart on your side, since it has blocked live verification since the #10 task.