### PR TITLE
feat(tuner): board-aware firmware download and flash via release manifest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^2.4.0",
+        "@canshift/core": "^2.5.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-7RnMYhAGi+ZgRZ52xx8iz9gdGN3ahdtF8NB1pUOeLS+A39SyJpEQQvyWZ9XzaZ9EgQEstXP1dB+jxdawLBwoXA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-80GD7SWlZ4Bt1V+Ou/GswM9aisTLT/Rd4XbdKWMuefnEwXp3/bpxjZnJIFe5uktjZT8zq6/ySvMQHqSAWo6hMA==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^2.4.0",
+    "@canshift/core": "^2.5.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/components/firmware/BoardSelector.tsx
+++ b/src/components/firmware/BoardSelector.tsx
@@ -1,0 +1,114 @@
+import type { CSSProperties } from 'react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { boardLabel, boardSummary, type BoardManifestEntry } from '../../lib/firmware/manifest'
+import { FALLBACK_BOARD_ID } from '../../lib/firmware/manifest'
+import type { ManifestState } from '../../hooks/useFirmwareManifest'
+import { MONO_FONT } from '../../lib/typography'
+
+export interface BoardSelectorProps {
+  manifestState: ManifestState
+  boards: BoardManifestEntry[]
+  selectedId: string | null
+  detected: boolean
+  onSelect: (id: string) => void
+}
+
+export const BoardSelector = ({
+  manifestState,
+  boards,
+  selectedId,
+  detected,
+  onSelect,
+}: BoardSelectorProps) => {
+  if (manifestState.kind === 'idle') return null
+
+  if (manifestState.kind === 'loading') {
+    return (
+      <div style={wrapperStyle}>
+        <span style={labelStyle}>Board</span>
+        <span style={noteStyle}>Reading the release board manifest…</span>
+      </div>
+    )
+  }
+
+  if (manifestState.kind === 'none' || manifestState.kind === 'error') {
+    return (
+      <div style={wrapperStyle}>
+        <span style={labelStyle}>Board</span>
+        <span style={noteStyle}>
+          {manifestState.kind === 'error'
+            ? `Couldn't read the board manifest (${manifestState.message}). `
+            : 'This release predates per-board builds. '}
+          Falling back to the single {boardLabel(FALLBACK_BOARD_ID)} ({FALLBACK_BOARD_ID}) image.
+        </span>
+      </div>
+    )
+  }
+
+  const selected = boards.find((board) => board.id === selectedId) ?? null
+
+  return (
+    <div style={wrapperStyle}>
+      <span style={labelStyle}>Board</span>
+      {detected && selected && (
+        <span style={detectedPillStyle}>Detected: {boardLabel(selected.id)}</span>
+      )}
+      <Select {...(selectedId !== null ? { value: selectedId } : {})} onValueChange={onSelect}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select your board" />
+        </SelectTrigger>
+        <SelectContent>
+          {boards.map((board) => (
+            <SelectItem key={board.id} value={board.id}>
+              {boardLabel(board.id)} — {boardSummary(board)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {selected && <span style={summaryStyle}>{boardSummary(selected)}</span>}
+    </div>
+  )
+}
+
+const wrapperStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  padding: '16px 24px',
+  borderBottom: '1px solid hsl(var(--brand-neutral-200))',
+}
+
+const labelStyle: CSSProperties = {
+  fontWeight: 800,
+  fontSize: 10,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  color: 'hsl(var(--brand-neutral-600))',
+}
+
+const detectedPillStyle: CSSProperties = {
+  alignSelf: 'flex-start',
+  padding: '3px 10px',
+  border: '1px solid hsl(var(--success))',
+  fontFamily: MONO_FONT,
+  fontSize: 11,
+  color: 'hsl(var(--brand-text))',
+}
+
+const summaryStyle: CSSProperties = {
+  fontFamily: MONO_FONT,
+  fontSize: 11,
+  color: 'hsl(var(--brand-neutral-600))',
+}
+
+const noteStyle: CSSProperties = {
+  fontSize: 12,
+  lineHeight: 1.5,
+  color: 'hsl(var(--brand-neutral-700))',
+}

--- a/src/components/firmware/FlashActions.tsx
+++ b/src/components/firmware/FlashActions.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties } from 'react'
 import { useEffect, useRef, useState } from 'react'
-import type { ReleaseInfo } from '@canshift/core'
+import type { ReleaseAsset, ReleaseInfo } from '@canshift/core'
 import type { FirmwareSelection } from '../../stores/firmware-selection.store'
 import { useFirmwareSelectionStore } from '../../stores/firmware-selection.store'
 import { useFlashHistoryStore } from '../../stores/flash-history.store'
@@ -8,13 +8,14 @@ import { useFlasher } from '../../hooks/useFlasher'
 import type { FlasherState } from '../../hooks/useFlasher'
 import { useLogStore } from '../../stores/log.store'
 import { downloadFirmwareAsset } from '../../lib/firmware/download'
-import { findMergedAsset } from '../../lib/firmware/releases'
 import { formatBytes } from '../../lib/format'
 import { MONO_FONT } from '../../lib/typography'
 
 export interface FlashActionsProps {
   selection: FirmwareSelection
   pickedRelease: ReleaseInfo | null
+  mergedAsset: ReleaseAsset | null
+  expectedChip?: string
 }
 
 const selectionLabel = (selection: FirmwareSelection): string =>
@@ -40,7 +41,12 @@ const useFlashHistoryRecorder = (
   }, [state, flashedLabel, record])
 }
 
-export const FlashActions = ({ selection, pickedRelease }: FlashActionsProps) => {
+export const FlashActions = ({
+  selection,
+  pickedRelease,
+  mergedAsset,
+  expectedChip,
+}: FlashActionsProps) => {
   const setReleaseFirmware = useFirmwareSelectionStore((s) => s.setReleaseFirmware)
   const log = useLogStore((s) => s.push)
   const { state, canFlash, flash, reset } = useFlasher()
@@ -49,7 +55,7 @@ export const FlashActions = ({ selection, pickedRelease }: FlashActionsProps) =>
 
   const handleFlash = () => {
     flashedLabelRef.current = selectionLabel(selection)
-    flash()
+    flash(expectedChip)
   }
 
   const [downloading, setDownloading] = useState(false)
@@ -57,7 +63,7 @@ export const FlashActions = ({ selection, pickedRelease }: FlashActionsProps) =>
   const [loadedBytes, setLoadedBytes] = useState(0)
   const [downloadError, setDownloadError] = useState<string | null>(null)
 
-  const pickedAsset = pickedRelease ? findMergedAsset(pickedRelease) : null
+  const pickedAsset = mergedAsset
   const pickedIsDownloaded =
     selection.kind === 'release' &&
     pickedRelease !== null &&

--- a/src/hooks/useFirmwareManifest.test.ts
+++ b/src/hooks/useFirmwareManifest.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import type { BoardManifest } from '../lib/firmware/manifest'
+import { resolveManifestForRelease } from './useFirmwareManifest'
+
+const manifest: BoardManifest = {
+  schema: 1,
+  version: '1.0.0',
+  tag: 'v1.0.0',
+  boards: [
+    {
+      id: 'crowpanel_28',
+      chip: 'esp32',
+      display: 'ILI9341 320x240',
+      touch: 'XPT2046',
+      artifacts: { merged: 'm.bin', firmware: 'f.bin', spiffs: 's.bin' },
+    },
+  ],
+}
+
+describe('resolveManifestForRelease', () => {
+  it('returns the scoped state when it matches the requested release', () => {
+    const result = resolveManifestForRelease('v1.0.0', {
+      tag: 'v1.0.0',
+      state: { kind: 'ok', manifest },
+    })
+    expect(result).toEqual({ kind: 'ok', manifest })
+  })
+
+  it('returns loading (never the previous manifest) while switching to another release', () => {
+    const result = resolveManifestForRelease('v2.0.0', {
+      tag: 'v1.0.0',
+      state: { kind: 'ok', manifest },
+    })
+    expect(result).toEqual({ kind: 'loading' })
+  })
+
+  it('returns idle when no release is requested', () => {
+    const result = resolveManifestForRelease(null, {
+      tag: 'v1.0.0',
+      state: { kind: 'ok', manifest },
+    })
+    expect(result).toEqual({ kind: 'idle' })
+  })
+})

--- a/src/hooks/useFirmwareManifest.ts
+++ b/src/hooks/useFirmwareManifest.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react'
+import type { ReleaseInfo } from '@canshift/core'
+import { findManifestAsset } from '../lib/firmware/releases'
+import { firmwareAssetProxyUrl } from '../lib/firmware/download'
+import { parseManifest, type BoardManifest } from '../lib/firmware/manifest'
+
+const MANIFEST_FETCH_TIMEOUT_MS = 10_000
+
+export type ManifestState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'none' }
+  | { kind: 'ok'; manifest: BoardManifest }
+  | { kind: 'error'; message: string }
+
+export const useFirmwareManifest = (release: ReleaseInfo | null): ManifestState => {
+  const [state, setState] = useState<ManifestState>({ kind: 'idle' })
+
+  useEffect(() => {
+    if (!release) {
+      setState({ kind: 'idle' })
+      return
+    }
+    const asset = findManifestAsset(release)
+    if (!asset) {
+      setState({ kind: 'none' })
+      return
+    }
+
+    let cancelled = false
+    setState({ kind: 'loading' })
+    const controller = new AbortController()
+    const timer = setTimeout(() => {
+      controller.abort()
+    }, MANIFEST_FETCH_TIMEOUT_MS)
+
+    void fetch(firmwareAssetProxyUrl(asset.downloadUrl), { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`HTTP ${String(response.status)}`)
+        return response.text()
+      })
+      .then((text) => {
+        if (cancelled) return
+        const manifest = parseManifest(text)
+        if (!manifest) {
+          setState({ kind: 'error', message: 'The release manifest was malformed.' })
+          return
+        }
+        setState({ kind: 'ok', manifest })
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setState({
+          kind: 'error',
+          message: err instanceof Error ? err.message : 'Manifest fetch failed.',
+        })
+      })
+      .finally(() => {
+        clearTimeout(timer)
+      })
+
+    return () => {
+      cancelled = true
+      controller.abort()
+      clearTimeout(timer)
+    }
+  }, [release])
+
+  return state
+}

--- a/src/hooks/useFirmwareManifest.ts
+++ b/src/hooks/useFirmwareManifest.ts
@@ -13,22 +13,38 @@ export type ManifestState =
   | { kind: 'ok'; manifest: BoardManifest }
   | { kind: 'error'; message: string }
 
+interface ScopedManifest {
+  tag: string | null
+  state: ManifestState
+}
+
+export const resolveManifestForRelease = (
+  requestedTag: string | null,
+  scoped: ScopedManifest
+): ManifestState => {
+  if (requestedTag !== scoped.tag) {
+    return requestedTag === null ? { kind: 'idle' } : { kind: 'loading' }
+  }
+  return scoped.state
+}
+
 export const useFirmwareManifest = (release: ReleaseInfo | null): ManifestState => {
-  const [state, setState] = useState<ManifestState>({ kind: 'idle' })
+  const [scoped, setScoped] = useState<ScopedManifest>({ tag: null, state: { kind: 'idle' } })
 
   useEffect(() => {
     if (!release) {
-      setState({ kind: 'idle' })
+      setScoped({ tag: null, state: { kind: 'idle' } })
       return
     }
+    const tag = release.tag
     const asset = findManifestAsset(release)
     if (!asset) {
-      setState({ kind: 'none' })
+      setScoped({ tag, state: { kind: 'none' } })
       return
     }
 
     let cancelled = false
-    setState({ kind: 'loading' })
+    setScoped({ tag, state: { kind: 'loading' } })
     const controller = new AbortController()
     const timer = setTimeout(() => {
       controller.abort()
@@ -42,17 +58,21 @@ export const useFirmwareManifest = (release: ReleaseInfo | null): ManifestState 
       .then((text) => {
         if (cancelled) return
         const manifest = parseManifest(text)
-        if (!manifest) {
-          setState({ kind: 'error', message: 'The release manifest was malformed.' })
-          return
-        }
-        setState({ kind: 'ok', manifest })
+        setScoped({
+          tag,
+          state: manifest
+            ? { kind: 'ok', manifest }
+            : { kind: 'error', message: 'The release manifest was malformed.' },
+        })
       })
       .catch((err: unknown) => {
         if (cancelled) return
-        setState({
-          kind: 'error',
-          message: err instanceof Error ? err.message : 'Manifest fetch failed.',
+        setScoped({
+          tag,
+          state: {
+            kind: 'error',
+            message: err instanceof Error ? err.message : 'Manifest fetch failed.',
+          },
         })
       })
       .finally(() => {
@@ -66,5 +86,5 @@ export const useFirmwareManifest = (release: ReleaseInfo | null): ManifestState 
     }
   }, [release])
 
-  return state
+  return resolveManifestForRelease(release?.tag ?? null, scoped)
 }

--- a/src/hooks/useFlasher.ts
+++ b/src/hooks/useFlasher.ts
@@ -44,7 +44,7 @@ const acquirePort = async (
 export interface UseFlasher {
   state: FlasherState
   canFlash: boolean
-  flash: () => void
+  flash: (expectedChip?: string) => void
   reset: () => void
 }
 
@@ -56,7 +56,7 @@ export const useFlasher = (): UseFlasher => {
 
   const canFlash = selection.kind !== 'none' && state.kind !== 'flashing' && isWebSerialAvailable()
 
-  const flash = () => {
+  const flash = (expectedChip?: string) => {
     if (selection.kind === 'none') return
     if (!isWebSerialAvailable()) {
       setState({ kind: 'error', message: 'WebSerial unavailable in this browser.' })
@@ -65,7 +65,7 @@ export const useFlasher = (): UseFlasher => {
     const name = selection.kind === 'release' ? selection.release.tag : selection.firmware.name
     log('info', `Flash requested — ${name}`)
 
-    void runFlash(selection, log, setState).catch((err: unknown) => {
+    void runFlash(selection, log, setState, expectedChip).catch((err: unknown) => {
       const message =
         err instanceof FlashError || err instanceof OtaError
           ? err.message
@@ -106,7 +106,8 @@ const resolveOtaBytes = async (
 const runFlash = async (
   selection: Exclude<FirmwareSelection, { kind: 'none' }>,
   log: ReturnType<typeof useLogStore.getState>['push'],
-  setState: (next: FlasherState) => void
+  setState: (next: FlasherState) => void,
+  expectedChip?: string
 ): Promise<void> => {
   const conn = useConnectionStore.getState()
   const canUseOta = conn.status === 'connected'
@@ -136,6 +137,7 @@ const runFlash = async (
   await flashFirmware({
     port,
     bytes,
+    ...(expectedChip !== undefined ? { expectedChip } : {}),
     onProgress: (written, total) => {
       setState({ kind: 'flashing', written, total })
     },

--- a/src/hooks/useVersionHandshake.ts
+++ b/src/hooks/useVersionHandshake.ts
@@ -8,6 +8,7 @@ export const useVersionHandshake = (): void => {
   const transport = useDeviceStore((s) => s.transport)
   const simulationMode = useDeviceStore((s) => s.simulationMode)
   const setFirmwareVersion = useDeviceStore((s) => s.setFirmwareVersion)
+  const setBoardId = useDeviceStore((s) => s.setBoardId)
   const setFirmwareCompat = useDeviceStore((s) => s.setFirmwareCompat)
   const setIsDayMode = useDeviceStore((s) => s.setIsDayMode)
   const log = useLogStore((s) => s.push)
@@ -22,8 +23,9 @@ export const useVersionHandshake = (): void => {
         setFirmwareCompat({ kind: 'unknown' })
         return
       }
-      const { version, protocol, isDay } = result.identity
+      const { version, protocol, isDay, boardId } = result.identity
       setFirmwareVersion(version)
+      setBoardId(boardId ?? null)
       setIsDayMode(isDay)
       const reportedMajor = Number(version.split('.')[0] ?? 0)
       if (reportedMajor !== __EXPECTED_FIRMWARE_MAJOR__) {
@@ -50,6 +52,7 @@ export const useVersionHandshake = (): void => {
     simulationMode,
     transport,
     setFirmwareVersion,
+    setBoardId,
     setFirmwareCompat,
     setIsDayMode,
     log,

--- a/src/lib/firmware/board-resolution.test.ts
+++ b/src/lib/firmware/board-resolution.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import type { BoardManifest } from './manifest'
+import { chipFamiliesMatch, resolveBoardSelection } from './board-resolution'
+
+const manifest = (): BoardManifest => ({
+  schema: 1,
+  version: '1.4.0',
+  tag: 'v1.4.0',
+  boards: [
+    {
+      id: 'crowpanel_28',
+      chip: 'esp32',
+      display: 'ILI9341 320x240',
+      touch: 'XPT2046',
+      artifacts: { merged: 'a-merged.bin', firmware: 'a-firmware.bin', spiffs: 'a-spiffs.bin' },
+    },
+    {
+      id: 'generic_ili9341_gt911',
+      chip: 'esp32',
+      display: 'ILI9341 320x240',
+      touch: 'GT911',
+      artifacts: { merged: 'b-merged.bin', firmware: 'b-firmware.bin', spiffs: 'b-spiffs.bin' },
+    },
+  ],
+})
+
+describe('resolveBoardSelection', () => {
+  it('preselects the detected board when its id is in the manifest', () => {
+    const resolution = resolveBoardSelection(manifest(), 'generic_ili9341_gt911')
+    expect(resolution.source).toBe('detected')
+    expect(resolution.selectedId).toBe('generic_ili9341_gt911')
+  })
+
+  it('falls back to the first board when nothing is detected', () => {
+    const resolution = resolveBoardSelection(manifest(), null)
+    expect(resolution.source).toBe('default')
+    expect(resolution.selectedId).toBe('crowpanel_28')
+  })
+
+  it('ignores a detected id that is not in the manifest and defaults instead', () => {
+    const resolution = resolveBoardSelection(manifest(), 'unknown_board')
+    expect(resolution.source).toBe('default')
+    expect(resolution.selectedId).toBe('crowpanel_28')
+  })
+
+  it('reports no boards when there is no manifest (old release fallback)', () => {
+    const resolution = resolveBoardSelection(null, 'crowpanel_28')
+    expect(resolution.source).toBe('none')
+    expect(resolution.selectedId).toBeNull()
+    expect(resolution.boards).toHaveLength(0)
+  })
+})
+
+describe('chipFamiliesMatch', () => {
+  it('matches case- and separator-insensitively', () => {
+    expect(chipFamiliesMatch('esp32', 'ESP32')).toBe(true)
+    expect(chipFamiliesMatch('esp32-s3', 'ESP32-S3')).toBe(true)
+    expect(chipFamiliesMatch('esp32', 'ESP32-S3')).toBe(false)
+  })
+})

--- a/src/lib/firmware/board-resolution.ts
+++ b/src/lib/firmware/board-resolution.ts
@@ -1,0 +1,26 @@
+import type { BoardManifest, BoardManifestEntry } from './manifest'
+
+export type BoardSource = 'detected' | 'default' | 'none'
+
+export interface BoardResolution {
+  boards: BoardManifestEntry[]
+  selectedId: string | null
+  source: BoardSource
+}
+
+export const resolveBoardSelection = (
+  manifest: BoardManifest | null,
+  detectedBoardId: string | null
+): BoardResolution => {
+  if (!manifest) return { boards: [], selectedId: null, source: 'none' }
+  const boards = manifest.boards
+  const detected =
+    detectedBoardId !== null ? (boards.find((board) => board.id === detectedBoardId) ?? null) : null
+  if (detected) return { boards, selectedId: detected.id, source: 'detected' }
+  return { boards, selectedId: boards[0]?.id ?? null, source: 'default' }
+}
+
+const normalizeChip = (chip: string): string => chip.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+export const chipFamiliesMatch = (expected: string, detected: string): boolean =>
+  normalizeChip(expected) === normalizeChip(detected)

--- a/src/lib/firmware/download.ts
+++ b/src/lib/firmware/download.ts
@@ -11,7 +11,7 @@ export type DownloadProgress = (loaded: number, total: number) => void
 
 const PROXY_PATH = '/api/firmware-download'
 
-const buildProxyUrl = (downloadUrl: string): string => {
+export const firmwareAssetProxyUrl = (downloadUrl: string): string => {
   const u = new URL(downloadUrl)
   const parts = u.pathname.split('/').filter(Boolean)
   const tag = parts[4]
@@ -34,7 +34,7 @@ export const downloadFirmwareAsset = async (
     )
   }
 
-  const proxyUrl = buildProxyUrl(asset.downloadUrl)
+  const proxyUrl = firmwareAssetProxyUrl(asset.downloadUrl)
 
   const controller = new AbortController()
   const timer = setTimeout(() => {

--- a/src/lib/firmware/flash.test.ts
+++ b/src/lib/firmware/flash.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { assertChipMatchesBoard, FlashError } from './flash'
+
+describe('assertChipMatchesBoard', () => {
+  it('throws on a cross-architecture mismatch even when the detected chip is itself supported', () => {
+    expect(() => assertChipMatchesBoard('esp32s3', 'ESP32')).toThrow(FlashError)
+  })
+
+  it('throws when the selected board family differs from the detected chip', () => {
+    expect(() => assertChipMatchesBoard('esp32', 'ESP32-S3')).toThrow(FlashError)
+  })
+
+  it('passes when the families match, case- and separator-insensitively', () => {
+    expect(() => assertChipMatchesBoard('esp32', 'ESP32')).not.toThrow()
+    expect(() => assertChipMatchesBoard('esp32-s3', 'ESP32-S3')).not.toThrow()
+  })
+
+  it('passes when no board chip is known (old release / no manifest)', () => {
+    expect(() => assertChipMatchesBoard(undefined, 'ESP32-S3')).not.toThrow()
+  })
+})

--- a/src/lib/firmware/flash.ts
+++ b/src/lib/firmware/flash.ts
@@ -61,6 +61,18 @@ export class FlashError extends Error {
   }
 }
 
+export const assertChipMatchesBoard = (
+  expectedChip: string | undefined,
+  detectedChip: string
+): void => {
+  if (expectedChip !== undefined && !chipFamiliesMatch(expectedChip, detectedChip)) {
+    throw new FlashError(
+      `Refusing to flash — you picked a ${expectedChip} board but esptool detected ${detectedChip}. Writing a ${expectedChip} image onto a ${detectedChip} would brick it. Select the matching board and retry.`,
+      null
+    )
+  }
+}
+
 export class UnsupportedChipError extends Error {
   readonly detectedChip: string
   constructor(detectedChip: string) {
@@ -134,11 +146,7 @@ export const flashFirmware = async ({
 
     const detectedChip = loader.chip.CHIP_NAME
     onLog(`Detected chip: ${detectedChip}`)
-    if (expectedChip !== undefined && !chipFamiliesMatch(expectedChip, detectedChip)) {
-      onLog(
-        `Warning: selected board expects ${expectedChip}, but esptool detected ${detectedChip}. Continuing — double-check you picked the right board.`
-      )
-    }
+    assertChipMatchesBoard(expectedChip, detectedChip)
     if (!SUPPORTED_CHIPS.includes(detectedChip)) {
       throw new UnsupportedChipError(detectedChip)
     }

--- a/src/lib/firmware/flash.ts
+++ b/src/lib/firmware/flash.ts
@@ -1,3 +1,5 @@
+import { chipFamiliesMatch } from './board-resolution'
+
 const FLASH_BAUD = 460_800
 const MERGED_FLASH_OFFSET = 0x0
 
@@ -45,6 +47,7 @@ export type FlashLog = (line: string) => void
 export interface FlashOptions {
   port: SerialPort
   bytes: Uint8Array
+  expectedChip?: string
   onProgress: FlashProgress
   onLog: FlashLog
 }
@@ -82,6 +85,7 @@ const ROM_BOOTLOADER_CONNECT_ATTEMPTS = 15
 export const flashFirmware = async ({
   port,
   bytes,
+  expectedChip,
   onProgress,
   onLog,
 }: FlashOptions): Promise<void> => {
@@ -130,6 +134,11 @@ export const flashFirmware = async ({
 
     const detectedChip = loader.chip.CHIP_NAME
     onLog(`Detected chip: ${detectedChip}`)
+    if (expectedChip !== undefined && !chipFamiliesMatch(expectedChip, detectedChip)) {
+      onLog(
+        `Warning: selected board expects ${expectedChip}, but esptool detected ${detectedChip}. Continuing — double-check you picked the right board.`
+      )
+    }
     if (!SUPPORTED_CHIPS.includes(detectedChip)) {
       throw new UnsupportedChipError(detectedChip)
     }

--- a/src/lib/firmware/manifest.test.ts
+++ b/src/lib/firmware/manifest.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { boardLabel, findBoard, parseManifest } from './manifest'
+
+const MANIFEST = JSON.stringify({
+  schema: 1,
+  version: '1.4.0',
+  tag: 'v1.4.0',
+  boards: [
+    {
+      id: 'crowpanel_28',
+      chip: 'esp32',
+      display: 'ILI9341 320x240',
+      touch: 'XPT2046',
+      artifacts: {
+        merged: 'canshift-crowpanel_28-v1.4.0-merged.bin',
+        firmware: 'canshift-crowpanel_28-v1.4.0-firmware.bin',
+        spiffs: 'canshift-crowpanel_28-v1.4.0-spiffs.bin',
+      },
+    },
+    {
+      id: 'generic_ili9341_gt911',
+      chip: 'esp32',
+      display: 'ILI9341 320x240',
+      touch: 'GT911',
+      artifacts: {
+        merged: 'canshift-generic_ili9341_gt911-v1.4.0-merged.bin',
+        firmware: 'canshift-generic_ili9341_gt911-v1.4.0-firmware.bin',
+        spiffs: 'canshift-generic_ili9341_gt911-v1.4.0-spiffs.bin',
+      },
+    },
+  ],
+})
+
+describe('parseManifest', () => {
+  it('parses a well-formed manifest and its boards', () => {
+    const manifest = parseManifest(MANIFEST)
+    expect(manifest).not.toBeNull()
+    if (!manifest) return
+    expect(manifest.boards).toHaveLength(2)
+    expect(findBoard(manifest, 'crowpanel_28')?.artifacts.merged).toBe(
+      'canshift-crowpanel_28-v1.4.0-merged.bin'
+    )
+  })
+
+  it('returns null for invalid JSON, wrong shape, or an empty board list', () => {
+    expect(parseManifest('not json')).toBeNull()
+    expect(parseManifest(JSON.stringify({ schema: 1 }))).toBeNull()
+    expect(
+      parseManifest(JSON.stringify({ schema: 1, version: '1', tag: 'v1', boards: [] }))
+    ).toBeNull()
+    expect(
+      parseManifest(JSON.stringify({ schema: 1, version: '1', tag: 'v1', boards: [{ id: 'x' }] }))
+    ).toBeNull()
+  })
+
+  it('labels a board slug in a human-readable way', () => {
+    expect(boardLabel('crowpanel_28')).toBe('Crowpanel 28')
+    expect(boardLabel('generic_ili9341_gt911')).toBe('Generic Ili9341 Gt911')
+  })
+})

--- a/src/lib/firmware/manifest.ts
+++ b/src/lib/firmware/manifest.ts
@@ -1,0 +1,72 @@
+export const FALLBACK_BOARD_ID = 'crowpanel_28'
+
+export interface BoardArtifacts {
+  merged: string
+  firmware: string
+  spiffs: string
+}
+
+export interface BoardManifestEntry {
+  id: string
+  chip: string
+  display: string
+  touch: string
+  artifacts: BoardArtifacts
+}
+
+export interface BoardManifest {
+  schema: number
+  version: string
+  tag: string
+  boards: BoardManifestEntry[]
+}
+
+const isArtifacts = (value: unknown): value is BoardArtifacts => {
+  if (typeof value !== 'object' || value === null) return false
+  const a = value as Record<string, unknown>
+  return (
+    typeof a.merged === 'string' && typeof a.firmware === 'string' && typeof a.spiffs === 'string'
+  )
+}
+
+const isEntry = (value: unknown): value is BoardManifestEntry => {
+  if (typeof value !== 'object' || value === null) return false
+  const e = value as Record<string, unknown>
+  return (
+    typeof e.id === 'string' &&
+    typeof e.chip === 'string' &&
+    typeof e.display === 'string' &&
+    typeof e.touch === 'string' &&
+    isArtifacts(e.artifacts)
+  )
+}
+
+export const parseManifest = (raw: string): BoardManifest | null => {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const manifest = parsed as Record<string, unknown>
+  if (typeof manifest.schema !== 'number') return null
+  if (typeof manifest.version !== 'string' || typeof manifest.tag !== 'string') return null
+  if (!Array.isArray(manifest.boards)) return null
+  const boards = manifest.boards.filter(isEntry)
+  if (boards.length === 0) return null
+  return { schema: manifest.schema, version: manifest.version, tag: manifest.tag, boards }
+}
+
+export const boardLabel = (id: string): string =>
+  id
+    .split('_')
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+
+export const boardSummary = (entry: BoardManifestEntry): string =>
+  `${entry.chip.toUpperCase()} · ${entry.display} · ${entry.touch}`
+
+export const findBoard = (manifest: BoardManifest, boardId: string): BoardManifestEntry | null =>
+  manifest.boards.find((board) => board.id === boardId) ?? null

--- a/src/lib/firmware/releases.ts
+++ b/src/lib/firmware/releases.ts
@@ -148,3 +148,9 @@ export const findFirmwareAsset = (release: ReleaseInfo): ReleaseAsset | null =>
   release.assets.find(
     (a) => a.name.endsWith(FIRMWARE_ASSET_SUFFIX) && !a.name.endsWith(MERGED_ASSET_SUFFIX)
   ) ?? null
+
+export const findManifestAsset = (release: ReleaseInfo): ReleaseAsset | null =>
+  release.assets.find((a) => a.name === 'manifest.json') ?? null
+
+export const findAssetByName = (release: ReleaseInfo, name: string): ReleaseAsset | null =>
+  release.assets.find((a) => a.name === name) ?? null

--- a/src/routes/FirmwareRoute.tsx
+++ b/src/routes/FirmwareRoute.tsx
@@ -1,13 +1,18 @@
 import type { CSSProperties } from 'react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { BuildChooser } from '../components/firmware/BuildChooser'
+import { BoardSelector } from '../components/firmware/BoardSelector'
 import { FirmwareSidePanel } from '../components/firmware/FirmwareSidePanel'
 import { FlashActions } from '../components/firmware/FlashActions'
 import { KeyFigures } from '../components/firmware/KeyFigures'
 import { WriteAndPreflight } from '../components/firmware/WriteAndPreflight'
 import { useFirmwareReleases } from '../hooks/useFirmwareReleases'
+import { useFirmwareManifest } from '../hooks/useFirmwareManifest'
 import { useDeviceStore } from '../stores/device.store'
 import { useFirmwareSelectionStore } from '../stores/firmware-selection.store'
+import { resolveBoardSelection } from '../lib/firmware/board-resolution'
+import { findBoard } from '../lib/firmware/manifest'
+import { findAssetByName, findMergedAsset } from '../lib/firmware/releases'
 import { MONO_FONT } from '../lib/typography'
 
 const FirmwareRoute = () => {
@@ -17,7 +22,9 @@ const FirmwareRoute = () => {
   const connected = useDeviceStore((s) => s.connected)
   const simulationMode = useDeviceStore((s) => s.simulationMode)
   const installedVersion = useDeviceStore((s) => s.firmwareVersion)
+  const rawBoardId = useDeviceStore((s) => s.boardId)
   const [pickedTag, setPickedTag] = useState<string | null>(null)
+  const [boardOverride, setBoardOverride] = useState<string | null>(null)
 
   const releases = useMemo(
     () => (releasesState.kind === 'ok' ? releasesState.releases : []),
@@ -34,6 +41,27 @@ const FirmwareRoute = () => {
   )
 
   const linked = connected && !simulationMode
+
+  const manifestState = useFirmwareManifest(pickedRelease)
+  const manifest = manifestState.kind === 'ok' ? manifestState.manifest : null
+  const detectedBoardId = linked ? rawBoardId : null
+  const resolution = resolveBoardSelection(manifest, detectedBoardId)
+
+  useEffect(() => {
+    setBoardOverride(null)
+  }, [effectiveTag])
+
+  const selectedBoardId = boardOverride ?? resolution.selectedId
+  const selectedBoard = manifest && selectedBoardId ? findBoard(manifest, selectedBoardId) : null
+  const boardDetected = resolution.source === 'detected' && boardOverride === null
+  const expectedChip = selectedBoard?.chip
+
+  const mergedAsset =
+    pickedRelease === null
+      ? null
+      : selectedBoard
+        ? findAssetByName(pickedRelease, selectedBoard.artifacts.merged)
+        : findMergedAsset(pickedRelease)
 
   const pickRelease = (tag: string) => {
     if (selection.kind === 'local') clearSelection()
@@ -70,8 +98,20 @@ const FirmwareRoute = () => {
             onLocalPicked={localPicked}
             onRefresh={refresh}
           />
+          <BoardSelector
+            manifestState={manifestState}
+            boards={resolution.boards}
+            selectedId={selectedBoardId}
+            detected={boardDetected}
+            onSelect={setBoardOverride}
+          />
           <WriteAndPreflight selection={selection} />
-          <FlashActions selection={selection} pickedRelease={pickedRelease} />
+          <FlashActions
+            selection={selection}
+            pickedRelease={pickedRelease}
+            mergedAsset={mergedAsset}
+            {...(expectedChip !== undefined ? { expectedChip } : {})}
+          />
         </div>
         <FirmwareSidePanel
           release={

--- a/src/stores/device.store.ts
+++ b/src/stores/device.store.ts
@@ -35,6 +35,7 @@ interface DeviceState {
   portPath: string | null
   transport: Transport | null
   firmwareVersion: string | null
+  boardId: string | null
   lastSyncAt: Date | null
   errorMessage: string | null
 
@@ -59,6 +60,7 @@ interface DeviceState {
   setError: (message: string) => void
   clearError: () => void
   setFirmwareVersion: (version: string | null) => void
+  setBoardId: (boardId: string | null) => void
   setFirmwareCompat: (compat: FirmwareCompat) => void
   setFirmwareLiveness: (liveness: FirmwareLiveness) => void
   pushHeapStats: (entry: Omit<HeapStatsEntry, 'receivedAt'>) => void
@@ -82,6 +84,7 @@ export const useDeviceStore = create<DeviceState>()((set) => ({
   portPath: null,
   transport: null,
   firmwareVersion: null,
+  boardId: null,
   lastSyncAt: null,
   errorMessage: null,
   connected: false,
@@ -117,6 +120,7 @@ export const useDeviceStore = create<DeviceState>()((set) => ({
       syncing: false,
       isDayMode: null,
       firmwareVersion: null,
+      boardId: null,
       firmwareCompat: { kind: 'unknown' },
       firmwareLiveness: { kind: 'unknown' },
       heapStats: [],
@@ -151,6 +155,10 @@ export const useDeviceStore = create<DeviceState>()((set) => ({
 
   setFirmwareVersion: (version) => {
     set({ firmwareVersion: version })
+  },
+
+  setBoardId: (boardId) => {
+    set({ boardId })
   },
 
   setFirmwareCompat: (compat) => {

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -9,6 +9,7 @@ export interface FirmwareIdentity {
   version: string
   protocol: number
   isDay: boolean
+  boardId?: string
 }
 
 export type FirmwareIdentityResult =

--- a/src/transport/usb-service.ts
+++ b/src/transport/usb-service.ts
@@ -78,6 +78,7 @@ export const usbService = {
         version: d.version,
         protocol: d.protocol,
         isDay: d.is_day === 1,
+        ...(typeof d.board_id === 'string' ? { boardId: d.board_id } : {}),
       },
     }
   },


### PR DESCRIPTION
Closes #41
Refs CANShift/canshift-firmware#66

The /firmware flasher stops assuming a single binary. It reads the release `manifest.json` (per-board artifacts + chip/display) and flashes the right board's image — auto-detected from a connected device, or picked from a dropdown for a blank board — while degrading gracefully on old releases that have no manifest.

## Contract (firmware#66)

`manifest.json` (a release asset): `{ schema, version, tag, boards: [{ id, chip, display, touch, artifacts: { merged, firmware, spiffs } }] }`. A connected CANShift device reports `board_id` in its device-info, matching a board `id` slug (e.g. `crowpanel_28`). `@canshift/core@2.5.0` exposes `parseUsbStatus`/`UsbStatus.boardId`.

## What changed

**Pure logic (unit-tested)**
- `lib/firmware/manifest.ts` — `parseManifest` (shape-guarded, mirrors the existing release guards), `boardLabel`/`boardSummary`, `findBoard`.
- `lib/firmware/board-resolution.ts` — `resolveBoardSelection(manifest, detectedBoardId)` returns `{ boards, selectedId, source: 'detected' | 'default' | 'none' }`, plus `chipFamiliesMatch`.

**Manifest fetch** — `useFirmwareManifest(release)` finds the `manifest.json` asset and fetches it through the existing firmware-download proxy (`firmwareAssetProxyUrl`, extracted from `download.ts`). No manifest asset → `none` (old release); malformed → `error`. Both fall back to today's behaviour.

**Detection** — `board_id` is mapped at the usb-service boundary into `FirmwareIdentity.boardId`, stored on `device.store` (`boardId`, reset on disconnect), set during the version handshake.

**Board-aware flashing** — `FirmwareRoute` resolves the board (detected preselect with manual override, else picker, else fallback) and hands `FlashActions` the exact merged asset to download: the selected board's `artifacts.merged` from the manifest, or — with no manifest — the single `-merged.bin` (the `crowpanel_28` assumption, labeled as such in the UI). The flasher then flashes those bytes exactly as before.

**Chip sanity guard** — the selected board's manifest `chip` is passed into `flashFirmware`; if esptool's detected family differs it logs a warning and continues (not a hard block). The pre-existing non-ESP32 hard block (anti-brick) is unchanged.

**UI** — new `BoardSelector` (shadcn `Select`): "Detected: <board>" pill when auto-detected, dropdown to override or pick, per-board summary, and the fallback note for manifest-less releases.

**Signatures** — `.sig` assets (firmware#67) are simply ignored; asset selection is by exact name / `-merged.bin` suffix, so their presence doesn't break anything. Verification is out of scope (separate issue).

## Tests

- `manifest.test.ts` — parse valid manifest; reject bad JSON / wrong shape / empty boards; board labelling.
- `board-resolution.test.ts` — detected-preselect, default fallback, unknown-detected-id → default, no-manifest → `none`; chip-family matching.

## Checks
- `npm run typecheck` — clean
- `npm run lint` — no issues
- `npm test` — 190 passed
- `npm run format:check` — clean
- `npm run build` — builds (against core 2.5.0)

## Verification note — what still needs real hardware / a real release

The manifest-parsing and board-resolution logic is fully unit-tested, and the app typechecks/builds. But the end-to-end paths could **not** be exercised this session:
- **No published firmware release** yet carries a `manifest.json` (the firmware release with per-board artifacts hasn't shipped), so the live manifest fetch + picker population is unverified against a real asset. The parser is tested against the exact manifest shape from the firmware release workflow.
- **Auto-detection** needs a connected device reporting `board_id` — the board is dead, so the detected-preselect path is unverified live.
- **The flash itself** needs hardware.
- I also couldn't smoke-test the /firmware route render in the browser: the Playwright/Helium backend has been unresponsive for several sessions (navigate times out while the dev server serves 200), and per project rule I didn't fall back to driving real Chrome. A manual pass on the Vercel preview — and ideally once a manifest-bearing release + a live board exist — is the remaining gap.

One implementation note: the tuner transport parses the device-info JSON before usb-service sees it, so `board_id` is mapped there (matching core's `usbStatusFromWire` camelCasing) rather than routing the raw string through `parseUsbStatus`; wiring the raw string through core's parser would be a transport refactor beyond this issue.