### PR TITLE
chore(tuner): migrate to tuner.canshift.app / canshift.app docs links

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#201E1D" />
     <meta property="og:title" content="CANShift Tuner" />
-    <meta property="og:image" content="https://canshift.tmbk.ch/og-image-1200x630.png" />
+    <meta property="og:image" content="https://tuner.canshift.app/og-image-1200x630.png" />
     <title>CANShift Tuner</title>
   </head>
   <body>

--- a/src/routes/AboutRoute.tsx
+++ b/src/routes/AboutRoute.tsx
@@ -8,7 +8,7 @@ import { HeapStatsPanel } from '../components/about/HeapStatsPanel'
 import { MONO_FONT } from '../lib/typography'
 
 const REPO_URL = 'https://github.com/CANShift/canshift-tuner'
-const DOCS_URL = 'https://docs.canshift.tmbk.ch'
+const DOCS_URL = 'https://canshift.app'
 const ISSUES_URL = 'https://github.com/CANShift/canshift-tuner/issues'
 
 const DiagnosticsToggle = () => {

--- a/src/routes/WelcomeRoute.tsx
+++ b/src/routes/WelcomeRoute.tsx
@@ -5,7 +5,7 @@ import { useConnectionStore } from '../stores/connection.store'
 import { useDeviceStore } from '../stores/device.store'
 import { humanizeTransportError } from '../transport/humanize-transport-error'
 
-const SUPPORT_EMAIL = 'support@canshift.tmbk.ch'
+const SUPPORT_EMAIL = 'support@canshift.app'
 
 const isWebSerialAvailable = (): boolean => {
   return typeof navigator !== 'undefined' && 'serial' in navigator
@@ -67,7 +67,7 @@ const WelcomeRoute = () => {
           </Link>
           <span style={dotSeparatorStyle}>·</span>
           <a
-            href="https://docs.canshift.tmbk.ch/user-guide/install/boot-issues/"
+            href="https://canshift.app/user-guide/install/boot-issues/"
             target="_blank"
             rel="noreferrer"
             style={linkStyle}


### PR DESCRIPTION
## What

Domain migration companion to canshift-docs#87. The tuner deploys at **tuner.canshift.app**; its docs links point to **canshift.app**.

- `index.html`: OG image → `https://tuner.canshift.app/og-image-1200x630.png`
- `AboutRoute.tsx` `DOCS_URL` + `WelcomeRoute.tsx` boot-issues link → `https://canshift.app`
- `WelcomeRoute.tsx` `SUPPORT_EMAIL` → `support@canshift.app`

## Unchanged

- Feedback delivery stays on the folio backend: `https://tmbk.ch/api/contact/canshift` (`feedback.ts`), and `vercel.json` CSP `connect-src` keeps `https://tmbk.ch` for it.

## Infra note

Requires `tuner.canshift.app` as the tuner project's Vercel domain (done). The backend CORS allowlist must add `https://tuner.canshift.app` (tracked in folio_tmbk#33) for feedback to POST in prod.

## Test plan

- `npm run typecheck` — clean
- `npm run format:check` — clean (touched files)