### PR TITLE
feat(tuner): board picker + custom-profile builder over core board profiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^2.5.0",
+        "@canshift/core": "^2.6.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-80GD7SWlZ4Bt1V+Ou/GswM9aisTLT/Rd4XbdKWMuefnEwXp3/bpxjZnJIFe5uktjZT8zq6/ySvMQHqSAWo6hMA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-bjYKWuyZ6ptPwu+2TDAY/mNCLj4rUIM9tYnE8NclCv1Tibfs8XpM3+Zd7ymKefa9abotq/0RWg1CVZ2muRFCQw==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^2.5.0",
+    "@canshift/core": "^2.6.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ const CanBusRoute = lazy(() => import('./routes/CanBusRoute'))
 const CliRoute = lazy(() => import('./routes/CliRoute'))
 const EcuRoute = lazy(() => import('./routes/EcuRoute'))
 const FirmwareRoute = lazy(() => import('./routes/FirmwareRoute'))
+const BoardConfigRoute = lazy(() => import('./routes/BoardConfigRoute'))
 const LiveDataRoute = lazy(() => import('./routes/LiveDataRoute'))
 const LogsRoute = lazy(() => import('./routes/LogsRoute'))
 const Obd2Route = lazy(() => import('./routes/Obd2Route'))
@@ -66,11 +67,19 @@ const ROUTE_ELEMENTS: Record<RoutePath, ReactNode> = {
   '/live': <LiveDataRoute />,
   '/logs': <LogsRoute />,
   '/cli': <CliRoute />,
+  '/board': <BoardConfigRoute />,
   '/firmware': <FirmwareRoute />,
   '/about': <AboutRoute />,
 }
 
-const DISCONNECTED_ALLOWED_PATHS = new Set(['/', '/firmware', '/about', '/logs', '/themes'])
+const DISCONNECTED_ALLOWED_PATHS = new Set([
+  '/',
+  '/board',
+  '/firmware',
+  '/about',
+  '/logs',
+  '/themes',
+])
 
 const DisconnectedGuard = ({ children }: { children: ReactNode }) => {
   const status = useConnectionStore((s) => s.status)

--- a/src/components/board-config/BoardPicker.tsx
+++ b/src/components/board-config/BoardPicker.tsx
@@ -1,0 +1,95 @@
+import { BOARD_PROFILES } from '@canshift/core'
+import { useBoardConfigStore } from '../../stores/board-config/board-config.store'
+import type { SelectedBoard } from '../../stores/board-config/storage'
+
+interface BoardCardProps {
+  title: string
+  summary: string
+  checked: boolean
+  onSelect: () => void
+  onDelete?: () => void
+}
+
+const BoardCard = ({ title, summary, checked, onSelect, onDelete }: BoardCardProps) => (
+  <div className="relative">
+    <label className="block cursor-pointer">
+      <input
+        type="radio"
+        name="board-pick"
+        checked={checked}
+        onChange={onSelect}
+        className="peer sr-only"
+      />
+      <span className="block border border-border bg-surface px-3 py-2.5 pr-16 transition-colors hover:border-brand-accent peer-checked:border-brand-accent peer-checked:bg-brand-accent/10 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-brand-accent">
+        <span className="block text-sm font-semibold text-text">{title}</span>
+        <span className="mt-0.5 block text-xs text-text-muted">{summary}</span>
+      </span>
+    </label>
+    {onDelete && (
+      <button
+        type="button"
+        onClick={onDelete}
+        className="absolute right-2 top-2 text-xs text-text-muted transition-colors hover:text-brand-accent"
+      >
+        Delete
+      </button>
+    )}
+  </div>
+)
+
+const isSelected = (
+  selected: SelectedBoard | null,
+  source: 'catalog' | 'custom',
+  id: string
+): boolean => selected !== null && selected.source === source && selected.boardId === id
+
+export const BoardPicker = () => {
+  const customBoards = useBoardConfigStore((s) => s.customBoards)
+  const selected = useBoardConfigStore((s) => s.selected)
+  const selectCatalog = useBoardConfigStore((s) => s.selectCatalog)
+  const selectCustom = useBoardConfigStore((s) => s.selectCustom)
+  const deleteCustom = useBoardConfigStore((s) => s.deleteCustom)
+
+  return (
+    <div className="grid gap-4">
+      <div className="grid gap-2">
+        <span className="text-[10px] font-extrabold uppercase tracking-[0.18em] text-text-muted">
+          Known boards
+        </span>
+        {BOARD_PROFILES.map((board) => (
+          <BoardCard
+            key={board.boardId}
+            title={board.boardName}
+            summary={`${board.chipFamily.toUpperCase()} · ${board.lcd.driver} · ${board.touch.driver}`}
+            checked={isSelected(selected, 'catalog', board.boardId)}
+            onSelect={() => {
+              selectCatalog(board.boardId)
+            }}
+          />
+        ))}
+      </div>
+
+      {customBoards.length > 0 && (
+        <div className="grid gap-2">
+          <span className="text-[10px] font-extrabold uppercase tracking-[0.18em] text-text-muted">
+            Custom boards
+          </span>
+          {customBoards.map((entry) => (
+            <BoardCard
+              key={entry.id}
+              title={entry.name}
+              summary={`${entry.profile.chipFamily.toUpperCase()} · ${entry.profile.lcd.driver} · ${entry.profile.touch.driver}`}
+              checked={isSelected(selected, 'custom', entry.id)}
+              onSelect={() => {
+                selectCustom(entry.id)
+              }}
+              onDelete={() => {
+                deleteCustom(entry.id)
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/board-config/CustomBoardBuilder.tsx
+++ b/src/components/board-config/CustomBoardBuilder.tsx
@@ -1,0 +1,424 @@
+import { useState, type ReactNode } from 'react'
+import {
+  BOARD_ID_MAX_LEN,
+  BOARD_NAME_MAX_LEN,
+  CAN_CONTROLLERS,
+  CHIP_FAMILIES,
+  LCD_DRIVERS,
+  TOUCH_DRIVERS,
+  type BacklightProfile,
+  type BoardProfile,
+  type CanController,
+  type CanProfile,
+  type ChipFamily,
+  type ConnectivityProfile,
+  type LcdDriver,
+  type LcdProfile,
+  type StorageProfile,
+  type TouchDriver,
+  type TouchProfile,
+} from '@canshift/core'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+import { blankBoardDraft } from '../../lib/board-profile'
+import { useBoardConfigStore } from '../../stores/board-config/board-config.store'
+
+type NumericKeys<T> = { [K in keyof T]: T[K] extends number ? K : never }[keyof T]
+type BoolKeys<T> = { [K in keyof T]: T[K] extends boolean ? K : never }[keyof T]
+
+const Section = ({ title, children }: { title: string; children: ReactNode }) => (
+  <fieldset className="grid gap-2 border border-border p-3">
+    <legend className="px-1 text-[10px] font-extrabold uppercase tracking-[0.18em] text-text-muted">
+      {title}
+    </legend>
+    <div className="grid grid-cols-2 gap-x-4 gap-y-2">{children}</div>
+  </fieldset>
+)
+
+const NumberField = ({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: number
+  onChange: (value: number) => void
+}) => (
+  <label className="grid gap-1 text-xs">
+    <span className="text-text-muted">{label}</span>
+    <Input
+      type="number"
+      value={String(value)}
+      onChange={(e) => {
+        const next = Number(e.target.value)
+        onChange(Number.isNaN(next) ? 0 : next)
+      }}
+    />
+  </label>
+)
+
+const TextField = ({
+  label,
+  value,
+  maxLength,
+  onChange,
+}: {
+  label: string
+  value: string
+  maxLength: number
+  onChange: (value: string) => void
+}) => (
+  <label className="grid gap-1 text-xs">
+    <span className="text-text-muted">{label}</span>
+    <Input
+      value={value}
+      maxLength={maxLength}
+      onChange={(e) => {
+        onChange(e.target.value)
+      }}
+    />
+  </label>
+)
+
+const BoolField = ({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: boolean
+  onChange: (value: boolean) => void
+}) => (
+  <label className="flex items-center justify-between gap-3 text-xs">
+    <span className="text-text-muted">{label}</span>
+    <Switch checked={value} onCheckedChange={onChange} />
+  </label>
+)
+
+const SelectField = ({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string
+  value: string
+  options: readonly string[]
+  onChange: (value: string) => void
+}) => (
+  <label className="grid gap-1 text-xs">
+    <span className="text-text-muted">{label}</span>
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option} value={option}>
+            {option}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  </label>
+)
+
+export const CustomBoardBuilder = () => {
+  const saveCustom = useBoardConfigStore((s) => s.saveCustom)
+  const [draft, setDraft] = useState<BoardProfile>(blankBoardDraft)
+  const [issues, setIssues] = useState<string[]>([])
+
+  const patch = (p: Partial<BoardProfile>) => {
+    setDraft((d) => ({ ...d, ...p }))
+  }
+  const patchLcd = (p: Partial<LcdProfile>) => {
+    setDraft((d) => ({ ...d, lcd: { ...d.lcd, ...p } }))
+  }
+  const patchBacklight = (p: Partial<BacklightProfile>) => {
+    setDraft((d) => ({ ...d, backlight: { ...d.backlight, ...p } }))
+  }
+  const patchTouch = (p: Partial<TouchProfile>) => {
+    setDraft((d) => ({ ...d, touch: { ...d.touch, ...p } }))
+  }
+  const patchCan = (p: Partial<CanProfile>) => {
+    setDraft((d) => ({ ...d, can: { ...d.can, ...p } }))
+  }
+  const patchStorage = (p: Partial<StorageProfile>) => {
+    setDraft((d) => ({ ...d, storage: { ...d.storage, ...p } }))
+  }
+  const patchConn = (p: Partial<ConnectivityProfile>) => {
+    setDraft((d) => ({ ...d, conn: { ...d.conn, ...p } }))
+  }
+
+  const lcdNum = (key: NumericKeys<LcdProfile>, label: string) => (
+    <NumberField
+      key={key}
+      label={label}
+      value={draft.lcd[key]}
+      onChange={(v) => {
+        patchLcd({ [key]: v } as Partial<LcdProfile>)
+      }}
+    />
+  )
+  const lcdBool = (key: BoolKeys<LcdProfile>, label: string) => (
+    <BoolField
+      key={key}
+      label={label}
+      value={draft.lcd[key]}
+      onChange={(v) => {
+        patchLcd({ [key]: v } as Partial<LcdProfile>)
+      }}
+    />
+  )
+  const touchNum = (key: NumericKeys<TouchProfile>, label: string) => (
+    <NumberField
+      key={key}
+      label={label}
+      value={draft.touch[key]}
+      onChange={(v) => {
+        patchTouch({ [key]: v } as Partial<TouchProfile>)
+      }}
+    />
+  )
+
+  const handleSave = () => {
+    const result = saveCustom(draft.boardName, draft)
+    if (result.ok) {
+      setIssues([])
+      setDraft(blankBoardDraft())
+      return
+    }
+    setIssues(result.issues)
+  }
+
+  return (
+    <div className="grid gap-4">
+      <Section title="Identity">
+        <TextField
+          label="Board id"
+          value={draft.boardId}
+          maxLength={BOARD_ID_MAX_LEN}
+          onChange={(v) => {
+            patch({ boardId: v })
+          }}
+        />
+        <TextField
+          label="Board name"
+          value={draft.boardName}
+          maxLength={BOARD_NAME_MAX_LEN}
+          onChange={(v) => {
+            patch({ boardName: v })
+          }}
+        />
+        <SelectField
+          label="Chip family"
+          value={draft.chipFamily}
+          options={CHIP_FAMILIES}
+          onChange={(v) => {
+            patch({ chipFamily: v as ChipFamily })
+          }}
+        />
+      </Section>
+
+      <Section title="LCD">
+        <SelectField
+          label="Driver"
+          value={draft.lcd.driver}
+          options={LCD_DRIVERS}
+          onChange={(v) => {
+            patchLcd({ driver: v as LcdDriver })
+          }}
+        />
+        {lcdNum('pinMosi', 'MOSI')}
+        {lcdNum('pinMiso', 'MISO')}
+        {lcdNum('pinSclk', 'SCLK')}
+        {lcdNum('pinCs', 'CS')}
+        {lcdNum('pinDc', 'DC')}
+        {lcdNum('pinRst', 'RST')}
+        {lcdNum('pinBl', 'Backlight pin')}
+        {lcdNum('freqWriteHz', 'Write freq (Hz)')}
+        {lcdNum('panelWidth', 'Panel width')}
+        {lcdNum('panelHeight', 'Panel height')}
+        {lcdNum('memoryWidth', 'Memory width')}
+        {lcdNum('memoryHeight', 'Memory height')}
+        {lcdNum('defaultRotation', 'Rotation')}
+        {lcdNum('colorDepth', 'Color depth')}
+        {lcdBool('rgbOrderBgr', 'BGR order')}
+        {lcdBool('invert', 'Invert')}
+        {lcdBool('busSharedWithTouch', 'Bus shared with touch')}
+        {lcdBool('readable', 'Readable')}
+      </Section>
+
+      <Section title="Backlight">
+        <BoolField
+          label="Present"
+          value={draft.backlight.present}
+          onChange={(v) => {
+            patchBacklight({ present: v })
+          }}
+        />
+        <BoolField
+          label="Invert"
+          value={draft.backlight.invert}
+          onChange={(v) => {
+            patchBacklight({ invert: v })
+          }}
+        />
+        <NumberField
+          label="PWM channel"
+          value={draft.backlight.pwmChannel}
+          onChange={(v) => {
+            patchBacklight({ pwmChannel: v })
+          }}
+        />
+        <NumberField
+          label="PWM freq (Hz)"
+          value={draft.backlight.pwmFreqHz}
+          onChange={(v) => {
+            patchBacklight({ pwmFreqHz: v })
+          }}
+        />
+        <NumberField
+          label="Default duty"
+          value={draft.backlight.defaultDuty}
+          onChange={(v) => {
+            patchBacklight({ defaultDuty: v })
+          }}
+        />
+      </Section>
+
+      <Section title="Touch">
+        <SelectField
+          label="Driver"
+          value={draft.touch.driver}
+          options={TOUCH_DRIVERS}
+          onChange={(v) => {
+            patchTouch({ driver: v as TouchDriver })
+          }}
+        />
+        {touchNum('pinCs', 'CS')}
+        {touchNum('pinIrq', 'IRQ')}
+        {touchNum('pinSda', 'SDA')}
+        {touchNum('pinScl', 'SCL')}
+        {touchNum('freqHz', 'Freq (Hz)')}
+        <BoolField
+          label="Needs calibration"
+          value={draft.touch.needsCalibration}
+          onChange={(v) => {
+            patchTouch({ needsCalibration: v })
+          }}
+        />
+      </Section>
+
+      <Section title="CAN">
+        <SelectField
+          label="Controller"
+          value={draft.can.controller}
+          options={CAN_CONTROLLERS}
+          onChange={(v) => {
+            patchCan({ controller: v as CanController })
+          }}
+        />
+        <NumberField
+          label="TX pin"
+          value={draft.can.pinTx}
+          onChange={(v) => {
+            patchCan({ pinTx: v })
+          }}
+        />
+        <NumberField
+          label="RX pin"
+          value={draft.can.pinRx}
+          onChange={(v) => {
+            patchCan({ pinRx: v })
+          }}
+        />
+        <NumberField
+          label="Default speed (kbps)"
+          value={draft.can.defaultSpeedKbps}
+          onChange={(v) => {
+            patchCan({ defaultSpeedKbps: v })
+          }}
+        />
+      </Section>
+
+      <Section title="Storage">
+        <BoolField
+          label="SPIFFS present"
+          value={draft.storage.spiffsPresent}
+          onChange={(v) => {
+            patchStorage({ spiffsPresent: v })
+          }}
+        />
+        <NumberField
+          label="SPIFFS size (KB)"
+          value={draft.storage.spiffsSizeKb}
+          onChange={(v) => {
+            patchStorage({ spiffsSizeKb: v })
+          }}
+        />
+        <BoolField
+          label="SD present"
+          value={draft.storage.sdPresent}
+          onChange={(v) => {
+            patchStorage({ sdPresent: v })
+          }}
+        />
+        <NumberField
+          label="SD CS pin"
+          value={draft.storage.sdPinCs}
+          onChange={(v) => {
+            patchStorage({ sdPinCs: v })
+          }}
+        />
+      </Section>
+
+      <Section title="Connectivity">
+        <BoolField
+          label="Wi-Fi supported"
+          value={draft.conn.wifiSupported}
+          onChange={(v) => {
+            patchConn({ wifiSupported: v })
+          }}
+        />
+        <BoolField
+          label="BLE supported"
+          value={draft.conn.bleSupported}
+          onChange={(v) => {
+            patchConn({ bleSupported: v })
+          }}
+        />
+        <BoolField
+          label="PSRAM present"
+          value={draft.conn.psramPresent}
+          onChange={(v) => {
+            patchConn({ psramPresent: v })
+          }}
+        />
+      </Section>
+
+      {issues.length > 0 && (
+        <div role="alert" className="grid gap-1 border border-brand-accent p-3 text-xs text-text">
+          <span className="font-semibold">This board profile isn’t valid yet:</span>
+          {issues.map((issue) => (
+            <span key={issue} className="text-text-muted">
+              {issue}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div>
+        <Button onClick={handleSave}>Save custom board</Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/shell/SidebarView.tsx
+++ b/src/components/shell/SidebarView.tsx
@@ -11,6 +11,7 @@ export type SidebarRoute =
   | '/live'
   | '/logs'
   | '/cli'
+  | '/board'
   | '/firmware'
   | '/about'
 
@@ -53,6 +54,7 @@ export const SIDEBAR_GROUPS: readonly NavGroup[] = [
   {
     label: 'DEVICE',
     items: [
+      { to: '/board', label: 'Board config' },
       { to: '/firmware', label: 'Firmware' },
       { to: '/about', label: 'About' },
     ],

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -8,6 +8,7 @@ export const ROUTE_PATHS = [
   '/live',
   '/logs',
   '/cli',
+  '/board',
   '/firmware',
   '/about',
 ] as const

--- a/src/hooks/useResolvedBoardProfile.ts
+++ b/src/hooks/useResolvedBoardProfile.ts
@@ -1,0 +1,28 @@
+import { getBoardProfile, type BoardProfile } from '@canshift/core'
+import { useBoardConfigStore } from '../stores/board-config/board-config.store'
+import { validateBoardProfile } from '../lib/board-profile'
+
+export interface ResolvedBoardProfile {
+  source: 'catalog' | 'custom'
+  profile: BoardProfile
+  blob: string
+}
+
+export const useResolvedBoardProfile = (): ResolvedBoardProfile | null => {
+  const selected = useBoardConfigStore((s) => s.selected)
+  const customBoards = useBoardConfigStore((s) => s.customBoards)
+
+  if (!selected) return null
+
+  const profile =
+    selected.source === 'catalog'
+      ? (getBoardProfile(selected.boardId) ?? null)
+      : (customBoards.find((b) => b.id === selected.boardId)?.profile ?? null)
+
+  if (!profile) return null
+
+  const validation = validateBoardProfile(profile)
+  if (!validation.ok) return null
+
+  return { source: selected.source, profile, blob: validation.blob }
+}

--- a/src/lib/board-profile.test.ts
+++ b/src/lib/board-profile.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { BOARD_PROFILES, parseBoardProfile } from '@canshift/core'
+import { blankBoardDraft, validateBoardProfile } from './board-profile'
+
+describe('board-profile', () => {
+  it('exposes a non-empty core catalog', () => {
+    expect(BOARD_PROFILES.length).toBeGreaterThan(0)
+  })
+
+  it('validates and serializes a catalog profile into a blob that round-trips', () => {
+    const profile = BOARD_PROFILES[0]
+    expect(profile).toBeDefined()
+    if (!profile) return
+
+    const result = validateBoardProfile(profile)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    const parsed = parseBoardProfile(result.blob)
+    expect(parsed.kind).toBe('ok')
+    if (parsed.kind === 'ok') expect(parsed.profile.boardId).toBe(profile.boardId)
+  })
+
+  it('validates a completed custom draft (happy path)', () => {
+    const draft = blankBoardDraft()
+    draft.boardId = 'my_custom_28'
+    draft.boardName = 'My Custom 2.8"'
+
+    const result = validateBoardProfile(draft)
+    expect(result.ok).toBe(true)
+  })
+
+  it('reports issues for an invalid profile (empty id, bad enum, out-of-range pin)', () => {
+    const draft = blankBoardDraft()
+    draft.lcd = { ...draft.lcd, driver: 'nonsense' as typeof draft.lcd.driver }
+
+    const result = validateBoardProfile(draft)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.issues.length).toBeGreaterThan(0)
+      expect(result.issues.some((i) => i.includes('lcd') || i.includes('board_id'))).toBe(true)
+    }
+  })
+})

--- a/src/lib/board-profile.ts
+++ b/src/lib/board-profile.ts
@@ -1,0 +1,31 @@
+import {
+  BOARD_PROFILES,
+  BoardProfileWireSchema,
+  boardProfileToWire,
+  getBoardProfile,
+  serializeBoardProfile,
+  type BoardProfile,
+} from '@canshift/core'
+
+const SEED_BOARD_ID = 'crowpanel_28'
+
+export type BoardValidation = { ok: true; blob: string } | { ok: false; issues: string[] }
+
+export const validateBoardProfile = (profile: BoardProfile): BoardValidation => {
+  const result = BoardProfileWireSchema.safeParse(boardProfileToWire(profile))
+  if (!result.success) {
+    return {
+      ok: false,
+      issues: result.error.issues.map(
+        (issue) => `${issue.path.join('.') || 'profile'}: ${issue.message}`
+      ),
+    }
+  }
+  return { ok: true, blob: serializeBoardProfile(profile) }
+}
+
+export const blankBoardDraft = (): BoardProfile => {
+  const seed = getBoardProfile(SEED_BOARD_ID) ?? BOARD_PROFILES[0]
+  if (!seed) throw new Error('no board profiles available in the catalog')
+  return { ...structuredClone(seed), boardId: '', boardName: '' }
+}

--- a/src/routes/BoardConfigRoute.tsx
+++ b/src/routes/BoardConfigRoute.tsx
@@ -1,0 +1,116 @@
+import type { CSSProperties } from 'react'
+import { BoardPicker } from '../components/board-config/BoardPicker'
+import { CustomBoardBuilder } from '../components/board-config/CustomBoardBuilder'
+import { useResolvedBoardProfile } from '../hooks/useResolvedBoardProfile'
+import { MONO_FONT } from '../lib/typography'
+
+const BoardConfigRoute = () => {
+  const resolved = useResolvedBoardProfile()
+
+  return (
+    <div style={containerStyle}>
+      <header style={toolbarStyle}>
+        <span style={titleStyle}>Board configuration</span>
+        <span style={toolInfoStyle}>select a known board, or define your own</span>
+      </header>
+      <div style={bodyStyle}>
+        <section style={columnStyle}>
+          <h2 style={sectionTitleStyle}>Pick a board</h2>
+          <BoardPicker />
+          {resolved && (
+            <div style={resolvedCardStyle}>
+              <div style={resolvedHeadStyle}>
+                Resolved profile — {resolved.profile.boardName} ({resolved.source})
+              </div>
+              <pre style={blobStyle}>{resolved.blob}</pre>
+            </div>
+          )}
+        </section>
+        <section style={columnStyle}>
+          <h2 style={sectionTitleStyle}>Define a custom board</h2>
+          <CustomBoardBuilder />
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default BoardConfigRoute
+
+const containerStyle: CSSProperties = {
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  background: 'hsl(var(--brand-chrome-bg))',
+  overflow: 'hidden',
+}
+
+const toolbarStyle: CSSProperties = {
+  height: 48,
+  flexShrink: 0,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 14,
+  padding: '0 20px',
+  borderBottom: '2px solid var(--brand-divider)',
+}
+
+const titleStyle: CSSProperties = {
+  fontWeight: 800,
+  fontSize: 14,
+  color: 'hsl(var(--brand-text))',
+}
+
+const toolInfoStyle: CSSProperties = {
+  marginLeft: 'auto',
+  fontFamily: MONO_FONT,
+  fontSize: 11,
+  color: 'hsl(var(--brand-neutral-600))',
+}
+
+const bodyStyle: CSSProperties = {
+  flex: 1,
+  minHeight: 0,
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+  gap: 24,
+  padding: 24,
+  overflowY: 'auto',
+}
+
+const columnStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  minWidth: 0,
+}
+
+const sectionTitleStyle: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 800,
+  letterSpacing: '0.06em',
+  color: 'hsl(var(--brand-text))',
+}
+
+const resolvedCardStyle: CSSProperties = {
+  border: '1px solid hsl(var(--success))',
+}
+
+const resolvedHeadStyle: CSSProperties = {
+  padding: '8px 12px',
+  fontSize: 12,
+  fontWeight: 600,
+  color: 'hsl(var(--brand-text))',
+  borderBottom: '1px solid hsl(var(--brand-neutral-200))',
+}
+
+const blobStyle: CSSProperties = {
+  margin: 0,
+  padding: 12,
+  maxHeight: 220,
+  overflow: 'auto',
+  fontFamily: MONO_FONT,
+  fontSize: 11,
+  lineHeight: 1.5,
+  color: 'hsl(var(--brand-neutral-700))',
+}

--- a/src/stores/board-config/board-config.store.test.ts
+++ b/src/stores/board-config/board-config.store.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { BOARD_PROFILES } from '@canshift/core'
+import { blankBoardDraft } from '../../lib/board-profile'
+import { useBoardConfigStore } from './board-config.store'
+import { readCustomBoards, readSelectedBoard } from './storage'
+
+const memoryStorage = (): Storage => {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => {
+      map.clear()
+    },
+    getItem: (k: string) => map.get(k) ?? null,
+    key: (i: number) => [...map.keys()][i] ?? null,
+    removeItem: (k: string) => {
+      map.delete(k)
+    },
+    setItem: (k: string, v: string) => {
+      map.set(k, v)
+    },
+  }
+}
+
+const validDraft = () => {
+  const draft = blankBoardDraft()
+  draft.boardId = 'custom_one'
+  draft.boardName = 'Custom One'
+  return draft
+}
+
+describe('board-config store', () => {
+  beforeEach(() => {
+    globalThis.localStorage = memoryStorage()
+    useBoardConfigStore.setState({ customBoards: [], selected: null })
+  })
+
+  it('selects a catalog board and persists the selection', () => {
+    const first = BOARD_PROFILES[0]
+    expect(first).toBeDefined()
+    if (!first) return
+
+    useBoardConfigStore.getState().selectCatalog(first.boardId)
+    expect(useBoardConfigStore.getState().selected).toEqual({
+      source: 'catalog',
+      boardId: first.boardId,
+    })
+    expect(readSelectedBoard()).toEqual({ source: 'catalog', boardId: first.boardId })
+  })
+
+  it('saves a valid custom board, persists it, and selects it', () => {
+    const result = useBoardConfigStore.getState().saveCustom('Custom One', validDraft())
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(useBoardConfigStore.getState().customBoards).toHaveLength(1)
+    expect(useBoardConfigStore.getState().selected).toEqual({
+      source: 'custom',
+      boardId: result.id,
+    })
+    expect(readCustomBoards()).toHaveLength(1)
+    expect(readSelectedBoard()?.boardId).toBe(result.id)
+  })
+
+  it('refuses an invalid custom board and stores nothing', () => {
+    const bad = blankBoardDraft()
+    bad.boardId = ''
+    bad.lcd = { ...bad.lcd, panelWidth: -5 }
+
+    const result = useBoardConfigStore.getState().saveCustom('Bad', bad)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.issues.length).toBeGreaterThan(0)
+    expect(useBoardConfigStore.getState().customBoards).toHaveLength(0)
+    expect(readCustomBoards()).toHaveLength(0)
+  })
+
+  it('deletes a custom board and clears the selection when it was selected', () => {
+    const result = useBoardConfigStore.getState().saveCustom('Custom One', validDraft())
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    useBoardConfigStore.getState().deleteCustom(result.id)
+    expect(useBoardConfigStore.getState().customBoards).toHaveLength(0)
+    expect(useBoardConfigStore.getState().selected).toBeNull()
+    expect(readCustomBoards()).toHaveLength(0)
+  })
+})

--- a/src/stores/board-config/board-config.store.test.ts
+++ b/src/stores/board-config/board-config.store.test.ts
@@ -50,6 +50,18 @@ describe('board-config store', () => {
     expect(readSelectedBoard()).toEqual({ source: 'catalog', boardId: first.boardId })
   })
 
+  it('rejects selecting an unknown catalog id without touching state or storage', () => {
+    useBoardConfigStore.getState().selectCatalog('not_a_real_board')
+    expect(useBoardConfigStore.getState().selected).toBeNull()
+    expect(readSelectedBoard()).toBeNull()
+  })
+
+  it('rejects selecting an unknown custom id without touching state or storage', () => {
+    useBoardConfigStore.getState().selectCustom('board_missing')
+    expect(useBoardConfigStore.getState().selected).toBeNull()
+    expect(readSelectedBoard()).toBeNull()
+  })
+
   it('saves a valid custom board, persists it, and selects it', () => {
     const result = useBoardConfigStore.getState().saveCustom('Custom One', validDraft())
     expect(result.ok).toBe(true)

--- a/src/stores/board-config/board-config.store.ts
+++ b/src/stores/board-config/board-config.store.ts
@@ -1,0 +1,83 @@
+import { create } from 'zustand'
+import type { BoardProfile } from '@canshift/core'
+import { validateBoardProfile } from '../../lib/board-profile'
+import { createId } from '../../utils/id'
+import { captureFlowEvent } from '../../lib/posthog'
+import {
+  readCustomBoards,
+  readSelectedBoard,
+  writeCustomBoards,
+  writeSelectedBoard,
+  type CustomBoardEntry,
+  type SelectedBoard,
+} from './storage'
+
+const BOARD_NAME_MAX = 64
+
+export type SaveCustomResult = { ok: true; id: string } | { ok: false; issues: string[] }
+
+interface BoardConfigState {
+  customBoards: CustomBoardEntry[]
+  selected: SelectedBoard | null
+  selectCatalog: (boardId: string) => void
+  selectCustom: (id: string) => void
+  saveCustom: (name: string, profile: BoardProfile) => SaveCustomResult
+  renameCustom: (id: string, name: string) => void
+  deleteCustom: (id: string) => void
+}
+
+const nowIso = (): string => new Date().toISOString()
+
+export const useBoardConfigStore = create<BoardConfigState>()((set, get) => ({
+  customBoards: readCustomBoards(),
+  selected: readSelectedBoard(),
+
+  selectCatalog: (boardId) => {
+    const selected: SelectedBoard = { source: 'catalog', boardId }
+    set({ selected })
+    writeSelectedBoard(selected)
+  },
+
+  selectCustom: (id) => {
+    const selected: SelectedBoard = { source: 'custom', boardId: id }
+    set({ selected })
+    writeSelectedBoard(selected)
+  },
+
+  saveCustom: (name, profile) => {
+    const validation = validateBoardProfile(profile)
+    if (!validation.ok) return { ok: false, issues: validation.issues }
+    const id = createId('board')
+    const entry: CustomBoardEntry = {
+      id,
+      name: name.trim().slice(0, BOARD_NAME_MAX) || profile.boardName || 'Custom board',
+      createdAt: nowIso(),
+      profile,
+    }
+    const customBoards = [entry, ...get().customBoards]
+    const selected: SelectedBoard = { source: 'custom', boardId: id }
+    set({ customBoards, selected })
+    writeCustomBoards(customBoards)
+    writeSelectedBoard(selected)
+    captureFlowEvent('custom_board_saved')
+    return { ok: true, id }
+  },
+
+  renameCustom: (id, name) => {
+    const trimmed = name.trim().slice(0, BOARD_NAME_MAX)
+    if (trimmed.length === 0) return
+    const customBoards = get().customBoards.map((b) => (b.id === id ? { ...b, name: trimmed } : b))
+    set({ customBoards })
+    writeCustomBoards(customBoards)
+  },
+
+  deleteCustom: (id) => {
+    const customBoards = get().customBoards.filter((b) => b.id !== id)
+    const current = get().selected
+    const selected =
+      current && current.source === 'custom' && current.boardId === id ? null : current
+    set({ customBoards, selected })
+    writeCustomBoards(customBoards)
+    if (selected !== current) writeSelectedBoard(selected)
+  },
+}))

--- a/src/stores/board-config/board-config.store.ts
+++ b/src/stores/board-config/board-config.store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { BoardProfile } from '@canshift/core'
+import { getBoardProfile, type BoardProfile } from '@canshift/core'
 import { validateBoardProfile } from '../../lib/board-profile'
 import { createId } from '../../utils/id'
 import { captureFlowEvent } from '../../lib/posthog'
@@ -33,12 +33,14 @@ export const useBoardConfigStore = create<BoardConfigState>()((set, get) => ({
   selected: readSelectedBoard(),
 
   selectCatalog: (boardId) => {
+    if (!getBoardProfile(boardId)) return
     const selected: SelectedBoard = { source: 'catalog', boardId }
     set({ selected })
     writeSelectedBoard(selected)
   },
 
   selectCustom: (id) => {
+    if (!get().customBoards.some((b) => b.id === id)) return
     const selected: SelectedBoard = { source: 'custom', boardId: id }
     set({ selected })
     writeSelectedBoard(selected)

--- a/src/stores/board-config/storage.ts
+++ b/src/stores/board-config/storage.ts
@@ -1,0 +1,87 @@
+import type { BoardProfile } from '@canshift/core'
+
+export const CUSTOM_BOARDS_KEY = 'canshift.tuner.board-profiles'
+export const SELECTED_BOARD_KEY = 'canshift.tuner.selected-board'
+
+export interface CustomBoardEntry {
+  id: string
+  name: string
+  createdAt: string
+  profile: BoardProfile
+}
+
+export type SelectedBoard = { source: 'catalog' | 'custom'; boardId: string }
+
+const safeGet = (key: string): string | null => {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+const safeSet = (key: string, value: string): boolean => {
+  try {
+    localStorage.setItem(key, value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const isEntry = (value: unknown): value is CustomBoardEntry => {
+  if (typeof value !== 'object' || value === null) return false
+  const e = value as Record<string, unknown>
+  if (typeof e.id !== 'string' || typeof e.name !== 'string' || typeof e.createdAt !== 'string') {
+    return false
+  }
+  const profile = e.profile
+  return (
+    typeof profile === 'object' &&
+    profile !== null &&
+    typeof (profile as Record<string, unknown>).boardId === 'string'
+  )
+}
+
+export const readCustomBoards = (): CustomBoardEntry[] => {
+  const raw = safeGet(CUSTOM_BOARDS_KEY)
+  if (raw === null) return []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  return Array.isArray(parsed) ? parsed.filter(isEntry) : []
+}
+
+export const writeCustomBoards = (entries: CustomBoardEntry[]): boolean =>
+  safeSet(CUSTOM_BOARDS_KEY, JSON.stringify(entries))
+
+export const readSelectedBoard = (): SelectedBoard | null => {
+  const raw = safeGet(SELECTED_BOARD_KEY)
+  if (raw === null) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const s = parsed as Record<string, unknown>
+  if ((s.source !== 'catalog' && s.source !== 'custom') || typeof s.boardId !== 'string')
+    return null
+  return { source: s.source, boardId: s.boardId }
+}
+
+export const writeSelectedBoard = (selected: SelectedBoard | null): void => {
+  if (selected === null) {
+    try {
+      localStorage.removeItem(SELECTED_BOARD_KEY)
+    } catch {
+      void 0
+    }
+    return
+  }
+  safeSet(SELECTED_BOARD_KEY, JSON.stringify(selected))
+}


### PR DESCRIPTION
Closes #43
Refs CANShift/canshift-firmware#68

Slice H of the runtime-board-config pivot: a new **Board config** view (`/board`, under the DEVICE nav group) where the user picks a known board from core's catalog or builds a custom one, producing a validated `BoardProfile` and its serialized blob. This slice only **selects/builds** a profile — writing it during flash is #44 (slice I), which consumes the profile through the hook added here.

## UI / flow

- **Board picker** (`BoardPicker`) — lists core's `BOARD_PROFILES` (name + chip · LCD · touch summary) as keyboard-navigable radio cards, plus any saved custom boards (with delete). Selecting one sets the resolved profile.
- **Custom-profile builder** (`CustomBoardBuilder`) — a grouped form matching the `BoardProfile` shape (Identity / LCD / Backlight / Touch / CAN / Storage / Connectivity), built from shadcn primitives (`Input`, `Switch`, `Select`, `Button`). Enums (chip family, LCD driver, touch driver, CAN controller) come from core's exported tuples; the draft seeds from a known board so pins/resolution start sane and the user edits + renames. "Save custom board" validates and, on failure, lists the exact field issues; on success it persists and selects the board.
- **Resolved-profile preview** on the route shows the serialized `.canshift` board blob for the current selection.

## Logic (core-backed, unit-tested)

- `lib/board-profile.ts` — `validateBoardProfile(profile)` validates via `BoardProfileWireSchema.safeParse(boardProfileToWire(...))` and returns the serialized blob from `serializeBoardProfile`, or a list of readable field issues; `blankBoardDraft()` seeds a draft from the catalog.
- `stores/board-config/` — a Zustand store + guarded-localStorage layer persisting custom boards (`canshift.tuner.board-profiles`) and the current selection, project-independent like templates. `saveCustom` refuses invalid profiles (stores nothing) and returns issues.
- `hooks/useResolvedBoardProfile.ts` — **the seam for #44**: resolves the selected board (catalog via `getBoardProfile`, or a stored custom profile), re-validates, and exposes `{ source, profile, blob }`. #44 reads this to write the profile during flash; no flash wiring here.

## Tests

- `lib/board-profile.test.ts` — non-empty catalog; a catalog profile validates + serializes + round-trips through `parseBoardProfile`; a completed custom draft validates; an invalid draft (bad enum / empty id) yields issues.
- `stores/board-config/board-config.store.test.ts` — catalog selection persists; valid custom board saves + persists + selects (localStorage round-trip); invalid custom board is refused and stores nothing; deleting the selected board clears the selection.

## Checks
- `npm run typecheck` — clean
- `npm run lint` — no issues
- `npm test` — 205 passed
- `npm run format:check` — clean
- `npm run build` — builds (against core 2.6.0)

## Verification note — what's covered vs. what needs hardware

The catalog listing, custom-profile validation (happy + invalid), serialization, and localStorage persistence are all unit-tested against the real core 2.6.0 module, and the app typechecks/builds. Per the issue, this slice is the select/build UI only — **the actual profile write happens during flash in #44 and needs a real device**, so there's no flash/WebSerial surface here to verify.

I also could not do a live browser smoke of the `/board` page: the Playwright/Helium backend has been unresponsive for six sessions running (navigate times out while the dev server serves 200), and I'm holding to not driving the user's real Chrome. A manual pass on the Vercel preview covers the picker + builder interaction; it needs no device. The Playwright backend really needs a restart on your side — it has blocked live verification since the #10 task.