### PR TITLE
feat(tuner): provision board profile over USB during the flash flow

### DIFF
--- a/src/components/firmware/BoardProfileProvision.tsx
+++ b/src/components/firmware/BoardProfileProvision.tsx
@@ -1,0 +1,136 @@
+import type { CSSProperties } from 'react'
+import { Link } from 'react-router-dom'
+import { useProvisionBoardProfile } from '../../hooks/useProvisionBoardProfile'
+import { MONO_FONT } from '../../lib/typography'
+
+export const BoardProfileProvision = () => {
+  const { resolved, linked, canProvision, state, provision } = useProvisionBoardProfile()
+
+  return (
+    <div style={wrapperStyle}>
+      <span style={labelStyle}>Board profile</span>
+
+      {resolved === null ? (
+        <span style={noteStyle}>
+          Pick a board on the{' '}
+          <Link to="/board" style={linkStyle}>
+            Board config
+          </Link>{' '}
+          page to provision it after flashing.
+        </span>
+      ) : (
+        <>
+          <span style={summaryStyle}>
+            {resolved.profile.boardName} ({resolved.source})
+          </span>
+          <div style={actionsRowStyle}>
+            <button
+              type="button"
+              className="shell-link-button"
+              disabled={!canProvision}
+              onClick={provision}
+              style={buttonStyle(!canProvision)}
+            >
+              {state.kind === 'writing' ? 'WRITING…' : 'PROVISION BOARD PROFILE'}
+            </button>
+            {!linked && <span style={noteStyle}>Connect the dash to provision over USB.</span>}
+          </div>
+          <span style={hintStyle}>
+            A full flash wipes NVS — provision the board profile so the dash boots configured. On an
+            already-running dash this saves the profile and reboots it.
+          </span>
+        </>
+      )}
+
+      {state.kind === 'ok' && (
+        <div style={successCardStyle}>
+          Board profile saved.
+          {state.restart ? ' The dash is rebooting — reconnect from Welcome when it returns.' : ''}
+        </div>
+      )}
+      {state.kind === 'invalid' && (
+        <div style={errorCardStyle}>
+          The firmware rejected this profile (invalid_board_profile). Re-check the board definition
+          on the Board config page.
+        </div>
+      )}
+      {state.kind === 'error' && (
+        <div style={errorCardStyle}>Board profile write failed — {state.message}.</div>
+      )}
+    </div>
+  )
+}
+
+const wrapperStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+  padding: '16px 24px',
+  borderTop: '1px solid hsl(var(--brand-neutral-200))',
+}
+
+const labelStyle: CSSProperties = {
+  fontWeight: 800,
+  fontSize: 10,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  color: 'hsl(var(--brand-neutral-600))',
+}
+
+const summaryStyle: CSSProperties = {
+  fontFamily: MONO_FONT,
+  fontSize: 12,
+  color: 'hsl(var(--brand-text))',
+}
+
+const actionsRowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+  flexWrap: 'wrap',
+}
+
+const buttonStyle = (disabled: boolean): CSSProperties => ({
+  padding: '11px 20px',
+  background: 'none',
+  border: '1px solid hsl(var(--brand-neutral-400))',
+  fontWeight: 800,
+  fontSize: 13,
+  letterSpacing: '0.07em',
+  color: disabled ? 'hsl(var(--brand-neutral-500))' : 'hsl(var(--brand-text))',
+  cursor: disabled ? 'not-allowed' : 'pointer',
+})
+
+const noteStyle: CSSProperties = {
+  fontSize: 12,
+  lineHeight: 1.5,
+  color: 'hsl(var(--brand-neutral-700))',
+}
+
+const hintStyle: CSSProperties = {
+  fontSize: 11,
+  lineHeight: 1.5,
+  color: 'hsl(var(--brand-neutral-600))',
+}
+
+const linkStyle: CSSProperties = {
+  color: 'hsl(var(--brand-accent))',
+  textDecoration: 'underline',
+}
+
+const successCardStyle: CSSProperties = {
+  padding: '10px 14px',
+  border: '1px solid hsl(var(--success))',
+  fontSize: 12,
+  lineHeight: 1.5,
+  color: 'hsl(var(--brand-text))',
+}
+
+const errorCardStyle: CSSProperties = {
+  padding: '10px 14px',
+  border: '1px solid hsl(var(--brand-accent))',
+  background: 'color-mix(in srgb, hsl(var(--brand-accent)) 8%, transparent)',
+  fontSize: 12,
+  lineHeight: 1.5,
+  color: 'hsl(var(--brand-text))',
+}

--- a/src/hooks/useProvisionBoardProfile.ts
+++ b/src/hooks/useProvisionBoardProfile.ts
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { usbService } from '../transport'
+import { useDeviceStore } from '../stores/device.store'
+import { useLogStore } from '../stores/log.store'
+import { boardProfileBlob, type BoardProfileWriteResult } from '../lib/firmware/board-provision'
+import { useResolvedBoardProfile, type ResolvedBoardProfile } from './useResolvedBoardProfile'
+
+export type ProvisionState =
+  | { kind: 'idle' }
+  | { kind: 'writing' }
+  | { kind: 'ok'; restart: boolean }
+  | { kind: 'invalid' }
+  | { kind: 'error'; message: string }
+
+export interface UseProvisionBoardProfile {
+  resolved: ResolvedBoardProfile | null
+  linked: boolean
+  canProvision: boolean
+  state: ProvisionState
+  provision: () => void
+  reset: () => void
+}
+
+export const useProvisionBoardProfile = (): UseProvisionBoardProfile => {
+  const resolved = useResolvedBoardProfile()
+  const connected = useDeviceStore((s) => s.connected)
+  const simulationMode = useDeviceStore((s) => s.simulationMode)
+  const log = useLogStore((s) => s.push)
+  const [state, setState] = useState<ProvisionState>({ kind: 'idle' })
+
+  const linked = connected && !simulationMode
+  const canProvision = resolved !== null && linked && state.kind !== 'writing'
+
+  const provision = () => {
+    if (!resolved || !linked) return
+    setState({ kind: 'writing' })
+    log('info', `Provisioning board profile “${resolved.profile.boardName}” over USB`)
+    void usbService
+      .setBoardProfile(boardProfileBlob(resolved.profile))
+      .then((result: BoardProfileWriteResult) => {
+        if (result.kind === 'ok') {
+          setState({ kind: 'ok', restart: result.restart })
+          log(
+            'success',
+            result.restart
+              ? 'Board profile saved — the dash is rebooting to apply it'
+              : 'Board profile saved'
+          )
+          return
+        }
+        if (result.kind === 'invalid') {
+          setState({ kind: 'invalid' })
+          log('error', 'Firmware rejected the board profile (invalid_board_profile)')
+          return
+        }
+        setState({ kind: 'error', message: result.error })
+        log('error', `Board profile write failed: ${result.error}`)
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err)
+        setState({ kind: 'error', message })
+        log('error', `Board profile write failed: ${message}`)
+      })
+  }
+
+  const reset = () => {
+    setState({ kind: 'idle' })
+  }
+
+  return { resolved, linked, canProvision, state, provision, reset }
+}

--- a/src/lib/firmware/board-provision.test.ts
+++ b/src/lib/firmware/board-provision.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { BOARD_PROFILES, parseBoardProfile } from '@canshift/core'
+import { boardProfileBlob, interpretBoardProfileAck } from './board-provision'
+
+const sampleProfile = () => {
+  const profile = BOARD_PROFILES[0]
+  if (!profile) throw new Error('catalog is empty')
+  return profile
+}
+
+describe('boardProfileBlob', () => {
+  it('assembles the versioned board-profile envelope from a profile', () => {
+    const blob = boardProfileBlob(sampleProfile())
+    expect(blob.magic).toBe('CANSHIFT_BOARD')
+    expect(blob.schema).toBe('board-profile')
+    expect(blob.formatVersion).toBe(1)
+    expect(blob.profile.board_id).toBe(sampleProfile().boardId)
+  })
+
+  it('produces a blob that core can parse back to the same board', () => {
+    const blob = boardProfileBlob(sampleProfile())
+    const parsed = parseBoardProfile(JSON.stringify(blob))
+    expect(parsed.kind).toBe('ok')
+    if (parsed.kind === 'ok') expect(parsed.profile.boardId).toBe(sampleProfile().boardId)
+  })
+})
+
+describe('interpretBoardProfileAck', () => {
+  it('maps an ok+restart reply to a reboot result', () => {
+    expect(interpretBoardProfileAck({ ok: true, data: { status: 'ok', restart: true } })).toEqual({
+      kind: 'ok',
+      restart: true,
+    })
+  })
+
+  it('maps an ok reply without restart to a non-reboot result', () => {
+    expect(interpretBoardProfileAck({ ok: true, data: { status: 'ok' } })).toEqual({
+      kind: 'ok',
+      restart: false,
+    })
+  })
+
+  it('maps invalid_board_profile to the invalid result, from either the ack or the payload', () => {
+    expect(interpretBoardProfileAck({ ok: false, error: 'invalid_board_profile' })).toEqual({
+      kind: 'invalid',
+    })
+    expect(
+      interpretBoardProfileAck({ ok: true, data: { error: 'invalid_board_profile' } })
+    ).toEqual({ kind: 'invalid' })
+  })
+
+  it('maps a transport failure to an error result', () => {
+    expect(interpretBoardProfileAck({ ok: false, error: 'timeout' })).toEqual({
+      kind: 'error',
+      error: 'timeout',
+    })
+  })
+})

--- a/src/lib/firmware/board-provision.ts
+++ b/src/lib/firmware/board-provision.ts
@@ -1,0 +1,32 @@
+import { serializeBoardProfile, type BoardProfile, type BoardProfileBlob } from '@canshift/core'
+
+export const INVALID_BOARD_PROFILE = 'invalid_board_profile'
+
+export type BoardProfileWriteResult =
+  { kind: 'ok'; restart: boolean } | { kind: 'invalid' } | { kind: 'error'; error: string }
+
+export const boardProfileBlob = (profile: BoardProfile): BoardProfileBlob =>
+  JSON.parse(serializeBoardProfile(profile)) as BoardProfileBlob
+
+interface BoardProfileAck {
+  ok: boolean
+  error?: string
+  data?: Record<string, unknown>
+}
+
+export const interpretBoardProfileAck = (result: BoardProfileAck): BoardProfileWriteResult => {
+  if (!result.ok) {
+    const error = result.error ?? 'unknown_error'
+    return error.includes(INVALID_BOARD_PROFILE) ? { kind: 'invalid' } : { kind: 'error', error }
+  }
+  const data = result.data ?? {}
+  if (typeof data.error === 'string') {
+    return data.error.includes(INVALID_BOARD_PROFILE)
+      ? { kind: 'invalid' }
+      : { kind: 'error', error: data.error }
+  }
+  if (data.status !== undefined && data.status !== 'ok') {
+    return { kind: 'error', error: `unexpected status: ${String(data.status)}` }
+  }
+  return { kind: 'ok', restart: data.restart === true }
+}

--- a/src/routes/FirmwareRoute.tsx
+++ b/src/routes/FirmwareRoute.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { BuildChooser } from '../components/firmware/BuildChooser'
 import { BoardSelector } from '../components/firmware/BoardSelector'
+import { BoardProfileProvision } from '../components/firmware/BoardProfileProvision'
 import { FirmwareSidePanel } from '../components/firmware/FirmwareSidePanel'
 import { FlashActions } from '../components/firmware/FlashActions'
 import { KeyFigures } from '../components/firmware/KeyFigures'
@@ -112,6 +113,7 @@ const FirmwareRoute = () => {
             mergedAsset={mergedAsset}
             {...(expectedChip !== undefined ? { expectedChip } : {})}
           />
+          <BoardProfileProvision />
         </div>
         <FirmwareSidePanel
           release={

--- a/src/transport/opcodes.ts
+++ b/src/transport/opcodes.ts
@@ -8,6 +8,7 @@ export const CMD_CALIBRATE_TOUCH = 0x08
 export const CMD_SET_DAY_NIGHT = 0x09
 export const CMD_GET_INPUT_BINDINGS = 0x0b
 export const CMD_PUT_INPUT_BINDINGS = 0x0c
+export const CMD_SET_BOARD_PROFILE = 0x0d
 export const CMD_QUERY_VERSION = 0x10
 export const CMD_PING = 0x11
 export const CMD_CAN_SCAN_START = 0x20
@@ -57,6 +58,11 @@ export const KNOWN_OPCODES: readonly KnownOpcode[] = [
     id: CMD_PUT_INPUT_BINDINGS,
     name: 'CMD_PUT_INPUT_BINDINGS',
     description: 'Write input bindings',
+  },
+  {
+    id: CMD_SET_BOARD_PROFILE,
+    name: 'CMD_SET_BOARD_PROFILE',
+    description: 'Persist board profile to NVS (reboots)',
   },
   {
     id: CMD_QUERY_VERSION,

--- a/src/transport/usb-service.ts
+++ b/src/transport/usb-service.ts
@@ -1,4 +1,4 @@
-import type { DashboardConfig, ScreenSettings } from '@canshift/core'
+import type { BoardProfileBlob, DashboardConfig, ScreenSettings } from '@canshift/core'
 import { validateDashboard } from '@canshift/core'
 
 import {
@@ -9,11 +9,16 @@ import {
   CMD_QUERY_VERSION,
   CMD_REBOOT,
   CMD_SCREEN_SETTINGS,
+  CMD_SET_BOARD_PROFILE,
   CMD_SET_DAY_NIGHT,
   CMD_TOGGLE_DAY_NIGHT,
 } from './opcodes'
 import type { FirmwareIdentityResult, PingResult, RawAck, UsbResult } from './types'
 import { toUsbResult } from './types'
+import {
+  interpretBoardProfileAck,
+  type BoardProfileWriteResult,
+} from '../lib/firmware/board-provision'
 import { getSerialClient } from './webserial-client'
 
 const OK: UsbResult = { success: true }
@@ -52,6 +57,15 @@ export const usbService = {
   pushScreenSettings: async (settings: ScreenSettings): Promise<UsbResult> => {
     const result = await getSerialClient().send(CMD_SCREEN_SETTINGS, { ...settings })
     return toUsbResult(result)
+  },
+
+  setBoardProfile: async (blob: BoardProfileBlob): Promise<BoardProfileWriteResult> => {
+    const result = await getSerialClient().send(
+      CMD_SET_BOARD_PROFILE,
+      { payload: blob },
+      { scaleWithPayload: true, timeoutMs: 5_000 }
+    )
+    return interpretBoardProfileAck(result)
   },
 
   ping: async (timeoutMs = 1_500): Promise<PingResult> => {


### PR DESCRIPTION
Closes #44
Refs CANShift/canshift-firmware#68

Slice I: the flasher can now write the resolved board profile (from #43's picker/builder) to a device, so a board boots configured. This implements the **warm write** path from the firmware contract (#86) and wires it into the /firmware flow; it consumes `useResolvedBoardProfile` from #43.

## Flow

- The /firmware page gains a **Board profile** provision step (`BoardProfileProvision`), fed by `useResolvedBoardProfile()` (the selected catalog board or a custom-built one, with its serialized blob).
- **Warm write** (preferred, over the live USB link): "Provision board profile" sends `CMD_SET_BOARD_PROFILE` (0x0D) as `{ payload: <versioned blob object> }` — the `serializeBoardProfile` envelope `{ magic: "CANSHIFT_BOARD", schema: "board-profile", formatVersion: 1, profile: <wire> }`. Firmware validates, persists to NVS, replies `{ status: "ok", restart: true }` and reboots; the UI reports the reboot and the existing reconnect flow takes over.
- **After a full flash** (which wipes NVS) the step tells the user to provision so the dash boots configured; on an already-running dash it saves + reboots directly.
- **Errors are explicit:** `invalid_board_profile` → a distinct "firmware rejected the profile" card; any transport failure → an error card; both also logged.
- The anti-brick chip guard from #42 is untouched (still hard-blocks a cross-arch flash).

## Code

- `transport/opcodes.ts` — `CMD_SET_BOARD_PROFILE = 0x0D` (+ known-opcode entry).
- `lib/firmware/board-provision.ts` (pure, tested) — `boardProfileBlob(profile)` assembles the versioned blob object from core's serializer, and `interpretBoardProfileAck(result)` maps the firmware reply to `{ ok, restart } | invalid | error`.
- `transport/usb-service.ts` — `setBoardProfile(blob)` sends the warm-write command (mirroring `pushConfig`'s `{ payload }` framing) and interprets the ack.
- `hooks/useProvisionBoardProfile.ts` — resolves the profile, gates on a live USB link, runs the write, tracks idle/writing/ok/invalid/error.

## Tests

`lib/firmware/board-provision.test.ts` — blob assembly (magic/schema/formatVersion/wire board_id) and a round-trip through `parseBoardProfile`; ack interpretation for ok+restart, ok-without-restart, `invalid_board_profile` (from either the ack or the payload), and a transport failure.

## Checks
- `npm run typecheck` — clean
- `npm run lint` — no issues
- `npm test` — 213 passed
- `npm run format:check` — clean
- `npm run build` — builds (against core 2.6.0)

## Scope + verification notes (honest)

- **Warm write is implemented; the cold single-session write is not.** The issue lists a cold path (esptool writes the universal `.bin` + the blob to a `boardcfg`/NVS partition image at 0x9000 in one esptool session). That needs building an NVS partition binary in-browser — a substantial esptool addition — and I scoped this slice to the warm-write provision step, which already delivers "device boots configured" (provision runs after a full flash, once the dash reboots). Flagging the cold single-session bake as a follow-up.
- **The actual NVS write + reboot round trip needs a real device.** The blob assembly, command shape, and every ack/error branch are unit-tested against real core 2.6.0, and the transport wrapper mirrors the established `pushConfig` path — but the end-to-end write + reboot is hardware-gated (the board is currently dead), so it's unverified live. This matches the issue's "hardware-gated end-to-end" verification note.
- I also couldn't browser-smoke the provision UI: the Playwright/Helium backend has been unresponsive for seven sessions (navigate times out while the dev server serves 200), and I'm holding to not driving your real Chrome. The provision button/summary/disabled-when-disconnected states are sim-verifiable on the Vercel preview.