### PR TITLE
chore(tuner): resolve audit quick-win findings

### DIFF
--- a/api/firmware-download.ts
+++ b/api/firmware-download.ts
@@ -8,10 +8,37 @@ const REPO = 'canshift-firmware'
 const TAG_RE = /^v?\d+\.\d+\.\d+([.-][a-z0-9.-]+)?$/i
 const ASSET_RE = /^[a-z0-9._-]+\.bin$/i
 
-const respond = (status: number, body: string): Response =>
+const RATE_LIMIT = 20
+const WINDOW_MS = 60_000
+const MAX_ASSET_BYTES = 16 * 1024 * 1024
+
+const hits = new Map<string, { count: number; resetAt: number }>()
+
+const clientIp = (req: Request): string =>
+  (req.headers.get('x-forwarded-for') ?? '').split(',')[0].trim() || 'unknown'
+
+const pruneExpired = (now: number): void => {
+  for (const [key, value] of hits) {
+    if (now > value.resetAt) hits.delete(key)
+  }
+}
+
+const rateLimited = (ip: string): boolean => {
+  const now = Date.now()
+  const entry = hits.get(ip)
+  if (entry && now <= entry.resetAt) {
+    entry.count += 1
+    return entry.count > RATE_LIMIT
+  }
+  if (hits.size > 10_000) pruneExpired(now)
+  hits.set(ip, { count: 1, resetAt: now + WINDOW_MS })
+  return false
+}
+
+const respond = (status: number, body: string, headers: HeadersInit = {}): Response =>
   new Response(body, {
     status,
-    headers: { 'Content-Type': 'text/plain' },
+    headers: { 'Content-Type': 'text/plain', ...headers },
   })
 
 const handler = async (req: Request): Promise<Response> => {
@@ -21,6 +48,12 @@ const handler = async (req: Request): Promise<Response> => {
 
   if (!tag || !TAG_RE.test(tag)) return respond(400, 'bad_tag')
   if (!asset || !ASSET_RE.test(asset)) return respond(400, 'bad_asset')
+
+  if (rateLimited(clientIp(req))) {
+    return respond(429, 'rate_limited', {
+      'Retry-After': (WINDOW_MS / 1000).toString(),
+    })
+  }
 
   const target = `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/${asset}`
 
@@ -35,11 +68,13 @@ const handler = async (req: Request): Promise<Response> => {
     return respond(upstream.status, `upstream_failed_${upstream.status.toString()}`)
   }
 
+  const length = upstream.headers.get('content-length')
+  if (length && Number(length) > MAX_ASSET_BYTES) return respond(502, 'asset_too_large')
+
   const passHeaders = new Headers({
     'Content-Type': 'application/octet-stream',
     'Cache-Control': 'public, max-age=3600',
   })
-  const length = upstream.headers.get('content-length')
   if (length) passHeaders.set('Content-Length', length)
 
   return new Response(upstream.body, {

--- a/src/components/can-bus/CanFrameRow.tsx
+++ b/src/components/can-bus/CanFrameRow.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties } from 'react'
 import { forwardRef, memo, useEffect, useState } from 'react'
 import type { CanFrameStats } from '../../hooks/useCanScanner'
 import { MONO_FONT } from '../../lib/typography'
+import { formatFrameIdHex } from '../../utils/frame-id'
 
 export interface CanFrameRowProps {
   frame: CanFrameStats
@@ -21,7 +22,7 @@ export const CanFrameRow = memo(
   forwardRef<HTMLTableRowElement, CanFrameRowProps>(
     ({ frame, mappedName, learnScore, expanded, dataIndex, onToggle, onPromote }, ref) => {
       const [stale, setStale] = useState(() => isStale(frame.lastSeenMs))
-      const idHex = formatCanId(frame.id)
+      const idHex = formatFrameIdHex(frame.id)
 
       useEffect(() => {
         const remaining = STALE_AFTER_MS - (performance.now() - frame.lastSeenMs)
@@ -78,12 +79,6 @@ export const CanFrameRow = memo(
   )
 )
 CanFrameRow.displayName = 'CanFrameRow'
-
-const formatCanId = (id: number): string => {
-  const extended = id > 0x7ff
-  const width = extended ? 8 : 3
-  return `0x${id.toString(16).toUpperCase().padStart(width, '0')}`
-}
 
 const formatCount = (n: number): string => {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -1,5 +1,6 @@
 import posthog from 'posthog-js'
 import { isObservabilityEnabled, useObservabilityStore } from '../stores/observability.store'
+import { scrubProps } from './scrub'
 
 let initialized = false
 
@@ -33,7 +34,11 @@ export const initPostHog = (): void => {
 
 export const captureFlowEvent = (name: string, props: Record<string, unknown> = {}): void => {
   if (!initialized || !isObservabilityEnabled()) return
-  posthog.capture(name, { ...props, app: 'canshift-tuner', tunerVersion: __TUNER_VERSION__ })
+  posthog.capture(name, {
+    ...scrubProps(props),
+    app: 'canshift-tuner',
+    tunerVersion: __TUNER_VERSION__,
+  })
 }
 
 export const isPostHogReady = (): boolean => initialized

--- a/src/lib/scrub.test.ts
+++ b/src/lib/scrub.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { scrubText } from './sentry'
+import { scrubProps, scrubText } from './scrub'
 
-describe('sentry scrubbing', () => {
+describe('scrubText', () => {
   it('replaces CAN payload hex sequences with a placeholder', () => {
     expect(scrubText('frame 0A 1B 2C 3D 4E arrived')).toBe('frame [payload] arrived')
     expect(scrubText('bytes 0a:1b:2c:3d')).toBe('bytes [payload]')
@@ -19,8 +19,17 @@ describe('sentry scrubbing', () => {
 
   it('keeps ordinary messages intact', () => {
     expect(scrubText('Burn failed: port_busy')).toBe('Burn failed: port_busy')
-    expect(scrubText('Device did not come back after reboot')).toBe(
-      'Device did not come back after reboot'
-    )
+  })
+})
+
+describe('scrubProps', () => {
+  it('scrubs string values while passing non-strings through', () => {
+    expect(
+      scrubProps({ frame: 'promoted 0x360', count: 3, enabled: true, name: '"secret_signal"' })
+    ).toEqual({ frame: 'promoted [frame-id]', count: 3, enabled: true, name: '[name]' })
+  })
+
+  it('returns an empty object unchanged', () => {
+    expect(scrubProps({})).toEqual({})
   })
 })

--- a/src/lib/scrub.ts
+++ b/src/lib/scrub.ts
@@ -1,0 +1,17 @@
+const HEX_PAYLOAD = /\b(?:[0-9A-Fa-f]{2}[\s:]){3,}[0-9A-Fa-f]{2}\b/g
+const FRAME_ID = /\b0[xX][0-9A-Fa-f]{1,8}\b/g
+const QUOTED_NAME = /"[^"]{1,120}"|'[^']{1,120}'|“[^”]{1,120}”/g
+
+export const scrubText = (text: string): string =>
+  text
+    .replace(HEX_PAYLOAD, '[payload]')
+    .replace(FRAME_ID, '[frame-id]')
+    .replace(QUOTED_NAME, '[name]')
+
+export const scrubProps = (props: Record<string, unknown>): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(props).map(([key, value]) => [
+      key,
+      typeof value === 'string' ? scrubText(value) : value,
+    ])
+  )

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,18 +1,9 @@
 import * as Sentry from '@sentry/react'
-import { isObservabilityEnabled, useObservabilityStore } from '../stores/observability.store'
+import { isObservabilityEnabled } from '../stores/observability.store'
 import { useDeviceStore } from '../stores/device.store'
-
-const HEX_PAYLOAD = /\b(?:[0-9A-Fa-f]{2}[\s:]){3,}[0-9A-Fa-f]{2}\b/g
-const FRAME_ID = /\b0[xX][0-9A-Fa-f]{1,8}\b/g
-const QUOTED_NAME = /"[^"]{1,120}"|'[^']{1,120}'|\u201C[^\u201D]{1,120}\u201D/g
+import { scrubText } from './scrub'
 
 let initialized = false
-
-export const scrubText = (text: string): string =>
-  text
-    .replace(HEX_PAYLOAD, '[payload]')
-    .replace(FRAME_ID, '[frame-id]')
-    .replace(QUOTED_NAME, '[name]')
 
 export const scrubEvent = (event: Sentry.ErrorEvent): Sentry.ErrorEvent => {
   delete event.request
@@ -39,20 +30,15 @@ export const initSentry = (): void => {
     dsn,
     release: `canshift-tuner@${__TUNER_VERSION__}`,
     environment: import.meta.env.MODE,
-    enabled: isObservabilityEnabled(),
     sendDefaultPii: false,
-    beforeSend: scrubEvent,
-    beforeBreadcrumb: scrubBreadcrumb,
+    beforeSend: (event) => (isObservabilityEnabled() ? scrubEvent(event) : null),
+    beforeBreadcrumb: (breadcrumb) =>
+      isObservabilityEnabled() ? scrubBreadcrumb(breadcrumb) : null,
   })
   initialized = true
 
   useDeviceStore.subscribe((state) => {
     Sentry.setTag('firmware.version', state.firmwareVersion ?? 'disconnected')
-  })
-
-  useObservabilityStore.subscribe((state) => {
-    const client = Sentry.getClient()
-    if (client) client.getOptions().enabled = state.enabled
   })
 }
 

--- a/src/routes/CanBusRoute.tsx
+++ b/src/routes/CanBusRoute.tsx
@@ -1,15 +1,14 @@
 import { useCallback, useMemo, useState } from 'react'
 import type { CSSProperties } from 'react'
-import type { SignalDef } from '@canshift/core'
 import { useCanScanner } from '../hooks/useCanScanner'
-import type { CanFrameStats } from '../hooks/useCanScanner'
 import { CanFrameTable } from '../components/can-bus/CanFrameTable'
 import { CanScanToolbar } from '../components/can-bus/CanScanToolbar'
 import type { SortKey } from '../components/can-bus/SortBar'
 import { useDeviceStore } from '../stores/device.store'
 import { useSignalStore } from '../stores/signal.store'
 import { useLogStore } from '../stores/log.store'
-import { parseHexFrameId } from '../utils/frame-id'
+import { formatFrameIdHex, parseHexFrameId } from '../utils/frame-id'
+import { buildDraftSignal, sortFrames } from '../utils/can-frames'
 
 const CanBusRoute = () => {
   const connected = useDeviceStore((s) => s.connected)
@@ -85,57 +84,6 @@ const CanBusRoute = () => {
       />
     </div>
   )
-}
-
-const sortFrames = (
-  frames: CanFrameStats[],
-  key: SortKey,
-  learnScores: ReadonlyMap<number, number> | null
-): CanFrameStats[] => {
-  const sorted = frames.slice()
-  switch (key) {
-    case 'id':
-      sorted.sort((a, b) => a.id - b.id)
-      break
-    case 'lastSeen':
-      sorted.sort((a, b) => b.lastSeenMs - a.lastSeenMs)
-      break
-    case 'rate':
-      sorted.sort((a, b) => b.rateHz - a.rateHz)
-      break
-    case 'count':
-      sorted.sort((a, b) => b.count - a.count)
-      break
-    case 'activity':
-      sorted.sort(
-        (a, b) => (learnScores?.get(b.id) ?? 0) - (learnScores?.get(a.id) ?? 0) || a.id - b.id
-      )
-      break
-  }
-  return sorted
-}
-
-const formatFrameIdHex = (id: number): string => {
-  const extended = id > 0x7ff
-  const width = extended ? 8 : 3
-  return `0x${id.toString(16).toUpperCase().padStart(width, '0')}`
-}
-
-const buildDraftSignal = (id: number, existingCount: number): SignalDef => {
-  return {
-    name: `scan_signal_${String(existingCount + 1)}`,
-    canFrameId: formatFrameIdHex(id),
-    startByte: 0,
-    byteLength: 1,
-    bigEndian: false,
-    signed: false,
-    scale: 1,
-    offset: 0,
-    unit: '',
-    min: 0,
-    max: 255,
-    timeoutMs: 2_000,
-  }
 }
 
 const containerStyle: CSSProperties = {

--- a/src/routes/EcuRoute.tsx
+++ b/src/routes/EcuRoute.tsx
@@ -11,6 +11,7 @@ import { XmlImportZone } from '../components/ecu/XmlImportZone'
 import { SignalPreviewTable } from '../components/ecu/SignalPreviewTable'
 import { ApplyConfirmDialog } from '../components/ecu/ApplyConfirmDialog'
 import { MONO_FONT } from '../lib/typography'
+import { prettyProfileKey } from '../utils/profile-key'
 
 type Source =
   | { kind: 'none' }
@@ -209,11 +210,6 @@ const EcuRoute = () => {
       />
     </div>
   )
-}
-
-const prettyProfileKey = (key: string): string => {
-  const [, rest = key] = key.split(':')
-  return rest.replace(/[-_]/g, ' ')
 }
 
 const containerStyle: CSSProperties = {

--- a/src/stores/observability.store.test.ts
+++ b/src/stores/observability.store.test.ts
@@ -28,11 +28,11 @@ const memoryStorage = (): Storage => {
 describe('observability store', () => {
   beforeEach(() => {
     globalThis.localStorage = memoryStorage()
-    useObservabilityStore.setState({ enabled: true })
+    useObservabilityStore.setState({ enabled: false })
   })
 
-  it('reads enabled from empty storage (default)', () => {
-    expect(readStoredObservability()).toBe(true)
+  it('defaults to disabled on empty storage (opt-in, #29.2)', () => {
+    expect(readStoredObservability()).toBe(false)
   })
 
   it('rehydrates a stored opt-out on startup', () => {

--- a/src/stores/observability.store.ts
+++ b/src/stores/observability.store.ts
@@ -4,9 +4,9 @@ const STORAGE_KEY = 'canshift.tuner.observability'
 
 export const readStoredObservability = (): boolean => {
   try {
-    return localStorage.getItem(STORAGE_KEY) !== 'off'
+    return localStorage.getItem(STORAGE_KEY) === 'on'
   } catch {
-    return true
+    return false
   }
 }
 

--- a/src/utils/can-frames.test.ts
+++ b/src/utils/can-frames.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import type { CanFrameStats } from '../hooks/useCanScanner'
+import { buildDraftSignal, sortFrames } from './can-frames'
+
+const frame = (over: Partial<CanFrameStats>): CanFrameStats => ({
+  id: 0x100,
+  firstSeenMs: 0,
+  lastSeenMs: 0,
+  count: 0,
+  rateHz: 0,
+  lastDlc: 8,
+  lastPayload: [],
+  byteValueCounts: [],
+  ...over,
+})
+
+const ids = (frames: CanFrameStats[]): number[] => frames.map((f) => f.id)
+
+describe('sortFrames', () => {
+  const a = frame({ id: 0x200, lastSeenMs: 10, rateHz: 5, count: 100 })
+  const b = frame({ id: 0x100, lastSeenMs: 30, rateHz: 1, count: 300 })
+  const c = frame({ id: 0x300, lastSeenMs: 20, rateHz: 9, count: 200 })
+  const frames = [a, b, c]
+
+  it('sorts by id ascending', () => {
+    expect(ids(sortFrames(frames, 'id', null))).toEqual([0x100, 0x200, 0x300])
+  })
+
+  it('sorts by lastSeen descending', () => {
+    expect(ids(sortFrames(frames, 'lastSeen', null))).toEqual([0x100, 0x300, 0x200])
+  })
+
+  it('sorts by rate descending', () => {
+    expect(ids(sortFrames(frames, 'rate', null))).toEqual([0x300, 0x200, 0x100])
+  })
+
+  it('sorts by count descending', () => {
+    expect(ids(sortFrames(frames, 'count', null))).toEqual([0x100, 0x300, 0x200])
+  })
+
+  it('sorts by learn activity, falling back to id for ties', () => {
+    const scores = new Map([
+      [0x200, 9],
+      [0x100, 9],
+      [0x300, 1],
+    ])
+    expect(ids(sortFrames(frames, 'activity', scores))).toEqual([0x100, 0x200, 0x300])
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [a, b, c]
+    sortFrames(input, 'id', null)
+    expect(ids(input)).toEqual([0x200, 0x100, 0x300])
+  })
+})
+
+describe('buildDraftSignal', () => {
+  it('names the signal from the existing count and formats the frame id', () => {
+    const draft = buildDraftSignal(0x360, 2)
+    expect(draft.name).toBe('scan_signal_3')
+    expect(draft.canFrameId).toBe('0x360')
+  })
+
+  it('produces a byte-0 single-byte default binding', () => {
+    const draft = buildDraftSignal(0x100, 0)
+    expect(draft).toMatchObject({ startByte: 0, byteLength: 1, min: 0, max: 255, timeoutMs: 2_000 })
+  })
+})

--- a/src/utils/can-frames.ts
+++ b/src/utils/can-frames.ts
@@ -1,0 +1,44 @@
+import type { SignalDef } from '@canshift/core'
+import type { CanFrameStats } from '../hooks/useCanScanner'
+import type { SortKey } from '../components/can-bus/SortBar'
+import { formatFrameIdHex } from './frame-id'
+
+const DRAFT_SIGNAL_TIMEOUT_MS = 2_000
+const DRAFT_SIGNAL_MAX = 255
+
+export const sortFrames = (
+  frames: CanFrameStats[],
+  key: SortKey,
+  learnScores: ReadonlyMap<number, number> | null
+): CanFrameStats[] => {
+  const sorted = frames.slice()
+  switch (key) {
+    case 'id':
+      return sorted.sort((a, b) => a.id - b.id)
+    case 'lastSeen':
+      return sorted.sort((a, b) => b.lastSeenMs - a.lastSeenMs)
+    case 'rate':
+      return sorted.sort((a, b) => b.rateHz - a.rateHz)
+    case 'count':
+      return sorted.sort((a, b) => b.count - a.count)
+    case 'activity':
+      return sorted.sort(
+        (a, b) => (learnScores?.get(b.id) ?? 0) - (learnScores?.get(a.id) ?? 0) || a.id - b.id
+      )
+  }
+}
+
+export const buildDraftSignal = (id: number, existingCount: number): SignalDef => ({
+  name: `scan_signal_${String(existingCount + 1)}`,
+  canFrameId: formatFrameIdHex(id),
+  startByte: 0,
+  byteLength: 1,
+  bigEndian: false,
+  signed: false,
+  scale: 1,
+  offset: 0,
+  unit: '',
+  min: 0,
+  max: DRAFT_SIGNAL_MAX,
+  timeoutMs: DRAFT_SIGNAL_TIMEOUT_MS,
+})

--- a/src/utils/frame-id.test.ts
+++ b/src/utils/frame-id.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { formatFrameIdHex, parseHexFrameId } from './frame-id'
+
+describe('parseHexFrameId', () => {
+  it('parses a prefixed hex id', () => {
+    expect(parseHexFrameId('0x370')).toBe(0x370)
+    expect(parseHexFrameId('0X1E005000')).toBe(0x1e005000)
+  })
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseHexFrameId('  0x7ff ')).toBe(0x7ff)
+  })
+
+  it('rejects a bare decimal-looking id instead of reading it as hex (#29.6)', () => {
+    expect(parseHexFrameId('123')).toBe(-1)
+  })
+
+  it('rejects unprefixed hex and garbage', () => {
+    expect(parseHexFrameId('1A')).toBe(-1)
+    expect(parseHexFrameId('0xZZ')).toBe(-1)
+    expect(parseHexFrameId('')).toBe(-1)
+  })
+})
+
+describe('formatFrameIdHex', () => {
+  it('pads standard 11-bit ids to three digits', () => {
+    expect(formatFrameIdHex(0x60)).toBe('0x060')
+    expect(formatFrameIdHex(0x7ff)).toBe('0x7FF')
+  })
+
+  it('pads extended ids to eight digits', () => {
+    expect(formatFrameIdHex(0x800)).toBe('0x00000800')
+    expect(formatFrameIdHex(0x1e005000)).toBe('0x1E005000')
+  })
+
+  it('round-trips with parseHexFrameId', () => {
+    expect(parseHexFrameId(formatFrameIdHex(0x123))).toBe(0x123)
+  })
+})

--- a/src/utils/frame-id.ts
+++ b/src/utils/frame-id.ts
@@ -1,4 +1,13 @@
+const HEX_FRAME_ID = /^0[xX][0-9A-Fa-f]+$/
+const EXTENDED_ID_THRESHOLD = 0x7ff
+
 export const parseHexFrameId = (raw: string): number => {
+  if (!HEX_FRAME_ID.test(raw.trim())) return -1
   const value = Number.parseInt(raw, 16)
   return Number.isNaN(value) ? -1 : value
+}
+
+export const formatFrameIdHex = (id: number): string => {
+  const width = id > EXTENDED_ID_THRESHOLD ? 8 : 3
+  return `0x${id.toString(16).toUpperCase().padStart(width, '0')}`
 }

--- a/src/utils/profile-key.test.ts
+++ b/src/utils/profile-key.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { prettyProfileKey } from './profile-key'
+
+describe('prettyProfileKey', () => {
+  it('drops the namespace prefix and humanizes separators', () => {
+    expect(prettyProfileKey('builtin:maxx-ecu')).toBe('maxx ecu')
+    expect(prettyProfileKey('user:my_custom_profile')).toBe('my custom profile')
+  })
+
+  it('handles a key with no namespace', () => {
+    expect(prettyProfileKey('haltech_elite')).toBe('haltech elite')
+  })
+})

--- a/src/utils/profile-key.ts
+++ b/src/utils/profile-key.ts
@@ -1,0 +1,4 @@
+export const prettyProfileKey = (key: string): string => {
+  const [, rest = key] = key.split(':')
+  return rest.replace(/[-_]/g, ' ')
+}


### PR DESCRIPTION
Closes #29. All six audit findings from 2026-08-03, bundled.

## 1 · firmware-download rate limit + size cap (security)
`api/firmware-download.ts` is an unauthenticated public edge endpoint streaming `.bin` from GitHub. Added a per-IP fixed-window limit (20 req / 60 s, best-effort in-memory with expiry pruning → `429` + `Retry-After`) and a `Content-Length` ceiling (`16 MB` → `502 asset_too_large`) so it can't be abused as a bandwidth proxy.

## 2 · analytics now opt-in on EU PostHog (privacy)
Per product decision: `readStoredObservability` defaults to **off** — telemetry only flows after the user enables it in About → Share anonymous diagnostics. Was opt-out (on by default), which for EU-hosted analytics is the wrong consent model.

## 3 · Sentry runtime opt-out actually works now (correctness)
The old `client.getOptions().enabled = …` subscription was a no-op (the SDK never re-reads it), so automatic captures kept flowing after opt-out. Replaced with consent enforced in `beforeSend` / `beforeBreadcrumb` (return `null` when disabled) — the SDK's supported runtime-disable path — and dropped the dead subscription.

## 4 · PostHog payloads scrubbed at the boundary (hardening)
Extracted the scrubber to `src/lib/scrub.ts` (`scrubText` + new `scrubProps`). `captureFlowEvent` now runs caller props through `scrubProps`, so a future caller passing a signal name / frame id can't leak car data. Current callers pass only enums — no live leak, this is structural.

## 5 · pure helpers out of route files (conventions)
Moved `sortFrames` + `buildDraftSignal` → `src/utils/can-frames.ts`, `prettyProfileKey` → `src/utils/profile-key.ts`, and consolidated the duplicated `formatFrameIdHex` / `formatCanId` into `src/utils/frame-id.ts`. All now unit-tested.

## 6 · strict hex frame ids (correctness)
`parseHexFrameId` required a `0x` prefix — a bare `"123"` used to parse as `0x123` and bind to the wrong frame silently; it now returns `-1`.

## Test plan
- New suites: `frame-id.test.ts`, `can-frames.test.ts`, `profile-key.test.ts`, `scrub.test.ts` (incl. `scrubProps`); updated `observability.store.test.ts` for the opt-in default.
- `typecheck` · `test` (all green) · `lint` · `format:check` · `build` all pass locally.