### PR TITLE
refactor(tuner): decompose Canvas.tsx render body

### DIFF
--- a/src/components/editor/Canvas.tsx
+++ b/src/components/editor/Canvas.tsx
@@ -1,6 +1,6 @@
 import { useRef, useCallback, useMemo, useState } from 'react'
 import type { CSSProperties, ReactNode } from 'react'
-import type { PageConfig, PagePalette, TopBarConfig, Widget } from '@canshift/core'
+import type { PageConfig, TopBarConfig, Widget } from '@canshift/core'
 import {
   LAYOUT_GRID,
   isSpanOverflowing,
@@ -9,7 +9,6 @@ import {
   resolveScreenProfile,
 } from '@canshift/core'
 import { useDashboardStore } from '../../stores/dashboard.store'
-import { useDeviceStore } from '../../stores/device.store'
 import { useSignalStore } from '../../stores/signal.store'
 import { defaultWidgetForSignal, SIGNAL_DRAG_MIME } from '../../utils/default-widget'
 import { autoPlace } from '../../utils/layout'
@@ -30,9 +29,9 @@ import { useClipboardWidgets } from '../../hooks/useClipboardWidgets'
 import { useRubberBandSelection } from '../../hooks/useRubberBandSelection'
 import { useRevLimiterFlash } from '../../hooks/useRevLimiterFlash'
 import { useSwipeGestures } from '../../hooks/useSwipeGestures'
-import { DEFAULT_PAGE_PALETTE } from '@canshift/core'
+import { useEffectivePalette } from '../../hooks/useEffectivePalette'
+import { useCanvasDialogs } from '../../hooks/useCanvasDialogs'
 
-import { DAY_PALETTE_DEFAULT, DAY_BG_DEFAULT } from '../../constants/theme'
 import { MONO_FONT } from '../../lib/typography'
 
 const SCALE = 1.5
@@ -74,11 +73,8 @@ const Canvas = ({ page, topBar, pageIndex, pageStrip, inspector }: CanvasProps) 
   const redoLabel = useDashboardStore((s) => s.future[0]?.label)
   const canRedo = useDashboardStore((s) => s.future.length > 0)
 
-  const dayTheme = useDashboardStore((s) => s.config?.dayTheme)
-  const nightTheme = useDashboardStore((s) => s.config?.nightTheme)
   const pages = useDashboardStore((s) => s.config?.pages ?? EMPTY_PAGES)
 
-  const deviceIsDayMode = useDeviceStore((s) => s.isDayMode)
   const containerRef = useRef<HTMLDivElement>(null)
   const zoomRef = useRef<number>(1)
   zoomRef.current = zoom
@@ -104,22 +100,14 @@ const Canvas = ({ page, topBar, pageIndex, pageStrip, inspector }: CanvasProps) 
   const kbdRef = useRef({ pageId: page.id, pageWidgets: page.widgets })
   kbdRef.current = { pageId: page.id, pageWidgets: page.widgets }
 
-  const activeDayMode = deviceIsDayMode ?? false
+  const {
+    isDayMode: activeDayMode,
+    palette: effectivePalette,
+    bgColor: effectiveBgColor,
+  } = useEffectivePalette(page)
 
-  const effectivePalette: PagePalette = useMemo(
-    () =>
-      activeDayMode
-        ? (dayTheme?.palette ?? DAY_PALETTE_DEFAULT)
-        : (nightTheme?.palette ?? page.palette ?? DEFAULT_PAGE_PALETTE),
-    [activeDayMode, dayTheme?.palette, nightTheme?.palette, page.palette]
-  )
-  const effectiveBgColor: string = activeDayMode
-    ? (dayTheme?.bgColor ?? DAY_BG_DEFAULT)
-    : (nightTheme?.bgColor ?? page.backgroundColor)
-
-  const [settingsOpen, setSettingsOpen] = useState(false)
-  const [diagOpen, setDiagOpen] = useState(false)
-  const [shortcutsOpen, setShortcutsOpen] = useState(false)
+  const { settingsOpen, diagOpen, shortcutsOpen, setSettingsOpen, setDiagOpen, setShortcutsOpen } =
+    useCanvasDialogs()
 
   const { revLimiting, flashPhase, startRevLimiter } = useRevLimiterFlash()
 

--- a/src/hooks/useCanvasDialogs.test.ts
+++ b/src/hooks/useCanvasDialogs.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { dialogReducer, INITIAL_DIALOG_STATE } from './useCanvasDialogs'
+
+describe('dialogReducer', () => {
+  it('opens a dialog without touching the others', () => {
+    const next = dialogReducer(INITIAL_DIALOG_STATE, { key: 'diagOpen', value: true })
+    expect(next).toEqual({ settingsOpen: false, diagOpen: true, shortcutsOpen: false })
+  })
+
+  it('resolves a functional updater against the current value', () => {
+    const opened = dialogReducer(INITIAL_DIALOG_STATE, { key: 'settingsOpen', value: true })
+    const toggled = dialogReducer(opened, { key: 'settingsOpen', value: (o) => !o })
+    expect(toggled.settingsOpen).toBe(false)
+  })
+
+  it('returns the same reference when the value is unchanged (no needless render)', () => {
+    const next = dialogReducer(INITIAL_DIALOG_STATE, { key: 'shortcutsOpen', value: false })
+    expect(next).toBe(INITIAL_DIALOG_STATE)
+  })
+})

--- a/src/hooks/useCanvasDialogs.ts
+++ b/src/hooks/useCanvasDialogs.ts
@@ -1,0 +1,49 @@
+import { useMemo, useReducer } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+
+export type DialogKey = 'settingsOpen' | 'diagOpen' | 'shortcutsOpen'
+
+export type DialogState = Record<DialogKey, boolean>
+
+export interface DialogAction {
+  key: DialogKey
+  value: SetStateAction<boolean>
+}
+
+export const INITIAL_DIALOG_STATE: DialogState = {
+  settingsOpen: false,
+  diagOpen: false,
+  shortcutsOpen: false,
+}
+
+export const dialogReducer = (state: DialogState, { key, value }: DialogAction): DialogState => {
+  const next = typeof value === 'function' ? value(state[key]) : value
+  return state[key] === next ? state : { ...state, [key]: next }
+}
+
+export interface CanvasDialogs extends DialogState {
+  setSettingsOpen: Dispatch<SetStateAction<boolean>>
+  setDiagOpen: Dispatch<SetStateAction<boolean>>
+  setShortcutsOpen: Dispatch<SetStateAction<boolean>>
+}
+
+export const useCanvasDialogs = (): CanvasDialogs => {
+  const [state, dispatch] = useReducer(dialogReducer, INITIAL_DIALOG_STATE)
+
+  const setters = useMemo(
+    () => ({
+      setSettingsOpen: (value: SetStateAction<boolean>) => {
+        dispatch({ key: 'settingsOpen', value })
+      },
+      setDiagOpen: (value: SetStateAction<boolean>) => {
+        dispatch({ key: 'diagOpen', value })
+      },
+      setShortcutsOpen: (value: SetStateAction<boolean>) => {
+        dispatch({ key: 'shortcutsOpen', value })
+      },
+    }),
+    []
+  )
+
+  return { ...state, ...setters }
+}

--- a/src/hooks/useEffectivePalette.test.ts
+++ b/src/hooks/useEffectivePalette.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import type { PagePalette } from '@canshift/core'
+import { DEFAULT_PAGE_PALETTE } from '@canshift/core'
+import { DAY_PALETTE_DEFAULT, DAY_BG_DEFAULT } from '../constants/theme'
+import { resolveBgColor, resolvePalette } from './useEffectivePalette'
+
+const day = { accent: '#111111' } as unknown as PagePalette
+const night = { accent: '#222222' } as unknown as PagePalette
+const pagePalette = { accent: '#333333' } as unknown as PagePalette
+
+describe('resolvePalette', () => {
+  it('prefers the day palette in day mode, falling back to the day default', () => {
+    expect(resolvePalette(true, day, night, pagePalette)).toBe(day)
+    expect(resolvePalette(true, undefined, night, pagePalette)).toBe(DAY_PALETTE_DEFAULT)
+  })
+
+  it('prefers night then page then the shared default in night mode', () => {
+    expect(resolvePalette(false, day, night, pagePalette)).toBe(night)
+    expect(resolvePalette(false, day, undefined, pagePalette)).toBe(pagePalette)
+    expect(resolvePalette(false, day, undefined, undefined)).toBe(DEFAULT_PAGE_PALETTE)
+  })
+})
+
+describe('resolveBgColor', () => {
+  it('prefers the day bg in day mode, falling back to the day default', () => {
+    expect(resolveBgColor(true, '#aaa', '#bbb', '#ccc')).toBe('#aaa')
+    expect(resolveBgColor(true, undefined, '#bbb', '#ccc')).toBe(DAY_BG_DEFAULT)
+  })
+
+  it('prefers night then the page bg in night mode', () => {
+    expect(resolveBgColor(false, '#aaa', '#bbb', '#ccc')).toBe('#bbb')
+    expect(resolveBgColor(false, '#aaa', undefined, '#ccc')).toBe('#ccc')
+  })
+})

--- a/src/hooks/useEffectivePalette.ts
+++ b/src/hooks/useEffectivePalette.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react'
+import type { PageConfig, PagePalette } from '@canshift/core'
+import { DEFAULT_PAGE_PALETTE } from '@canshift/core'
+import { useDashboardStore } from '../stores/dashboard.store'
+import { useDeviceStore } from '../stores/device.store'
+import { DAY_PALETTE_DEFAULT, DAY_BG_DEFAULT } from '../constants/theme'
+
+export interface EffectivePalette {
+  isDayMode: boolean
+  palette: PagePalette
+  bgColor: string
+}
+
+export const resolvePalette = (
+  isDayMode: boolean,
+  dayPalette: PagePalette | undefined,
+  nightPalette: PagePalette | undefined,
+  pagePalette: PagePalette | undefined
+): PagePalette =>
+  isDayMode
+    ? (dayPalette ?? DAY_PALETTE_DEFAULT)
+    : (nightPalette ?? pagePalette ?? DEFAULT_PAGE_PALETTE)
+
+export const resolveBgColor = (
+  isDayMode: boolean,
+  dayBgColor: string | undefined,
+  nightBgColor: string | undefined,
+  pageBgColor: string
+): string => (isDayMode ? (dayBgColor ?? DAY_BG_DEFAULT) : (nightBgColor ?? pageBgColor))
+
+export const useEffectivePalette = (page: PageConfig): EffectivePalette => {
+  const dayTheme = useDashboardStore((s) => s.config?.dayTheme)
+  const nightTheme = useDashboardStore((s) => s.config?.nightTheme)
+  const isDayMode = useDeviceStore((s) => s.isDayMode) ?? false
+
+  const palette = useMemo(
+    () => resolvePalette(isDayMode, dayTheme?.palette, nightTheme?.palette, page.palette),
+    [isDayMode, dayTheme?.palette, nightTheme?.palette, page.palette]
+  )
+
+  const bgColor = resolveBgColor(
+    isDayMode,
+    dayTheme?.bgColor,
+    nightTheme?.bgColor,
+    page.backgroundColor
+  )
+
+  return { isDayMode, palette, bgColor }
+}


### PR DESCRIPTION
Closes #28. Incremental, no behavior change — the two extractions proposed in the issue.

## Changes
- **`useEffectivePalette(page)`** (`src/hooks/useEffectivePalette.ts`) — pulls day/night palette + background resolution out of the render body. Pure resolvers `resolvePalette` / `resolveBgColor` back the hook and keep the exact same memoization (palette memoized on `[isDayMode, dayTheme.palette, nightTheme.palette, page.palette]`, bg recomputed per render as before).
- **`useCanvasDialogs()`** (`src/hooks/useCanvasDialogs.ts`) — collapses the three `settingsOpen` / `diagOpen` / `shortcutsOpen` `useState` booleans into one `useReducer`. Returns `Dispatch<SetStateAction<boolean>>`-compatible setters (functional updaters supported), so `useCanvasKeyboard`, `useSwipeGestures`, and `ShortcutsDialog` call sites are unchanged.

Canvas no longer reads `dayTheme` / `nightTheme` / `isDayMode` directly (dropped the now-dead `useDeviceStore` import).

## Tests (repo pattern: test the extracted pure core, no `renderHook`)
- `dialogReducer` — open/close isolation, functional-updater resolution, same-reference no-op on unchanged value.
- `resolvePalette` / `resolveBgColor` — day/night precedence and every fallback.

## Test plan
`typecheck` · `test` (220 pass, incl. the two new suites) · `lint` · `format:check` · `build` all green. Behaviour-preserving: logic is byte-for-byte the same, only relocated.