### PR TITLE
feat(tuner): OBD-II DTC read/clear panel (Mode 03/04)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^2.6.0",
+        "@canshift/core": "^2.7.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-bjYKWuyZ6ptPwu+2TDAY/mNCLj4rUIM9tYnE8NclCv1Tibfs8XpM3+Zd7ymKefa9abotq/0RWg1CVZ2muRFCQw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-JwBuhbDRAHQl2BVyhLVzYsW8m3NO2EMmmfFwecC03288p45ooZYWxBWN7Tmwy5SHB/xeHO8VcTrIBWHK201osQ==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^2.6.0",
+    "@canshift/core": "^2.7.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/components/obd2/DtcClearConfirmDialog.tsx
+++ b/src/components/obd2/DtcClearConfirmDialog.tsx
@@ -1,0 +1,43 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../ui/alert-dialog'
+
+export interface DtcClearConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  codeCount: number
+  onConfirm: () => void
+}
+
+export const DtcClearConfirmDialog = ({
+  open,
+  onOpenChange,
+  codeCount,
+  onConfirm,
+}: DtcClearConfirmDialogProps) => {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Clear trouble codes?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This clears all {codeCount} stored code{codeCount === 1 ? '' : 's'} on the ECU (OBD-II
+            Mode 04) and turns off the check-engine light. Any code for an unresolved fault will
+            return on the next drive cycle.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>Clear codes</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/obd2/DtcPanel.tsx
+++ b/src/components/obd2/DtcPanel.tsx
@@ -1,24 +1,92 @@
+import { useState } from 'react'
 import type { CSSProperties } from 'react'
+import { dtcSystem } from '@canshift/core'
+import { useDtcStore } from '../../stores/dtc.store'
+import { useDeviceStore } from '../../stores/device.store'
+import { MONO_FONT } from '../../lib/typography'
+import { DtcClearConfirmDialog } from './DtcClearConfirmDialog'
 
-export const DtcPanel = () => (
-  <aside style={panelStyle}>
-    <div style={headerStyle}>TROUBLE CODES</div>
-    <div style={emptyStyle}>
-      No trouble codes read. Reading and clearing DTCs needs Mode 03/04 support on the device link —
-      tracked in #1883.
-    </div>
-    <div style={footerStyle}>
-      <button
-        type="button"
-        disabled
-        title="Requires Mode 04 support on the device link (#1883)"
-        style={clearButtonStyle}
-      >
-        CLEAR CODES
-      </button>
-    </div>
-  </aside>
-)
+interface DtcBodyProps {
+  ready: boolean
+  reading: boolean
+  hasRead: boolean
+  codes: string[]
+}
+
+const DtcBody = ({ ready, reading, hasRead, codes }: DtcBodyProps) => {
+  if (!ready) return <div style={emptyStyle}>Connect a dash (or use simulation) to read codes.</div>
+  if (reading) return <div style={emptyStyle}>Reading trouble codes…</div>
+  if (!hasRead) return <div style={emptyStyle}>Read to fetch stored codes over OBD-II Mode 03.</div>
+  if (codes.length === 0) return <div style={emptyStyle}>No stored trouble codes.</div>
+  return (
+    <ul style={listStyle}>
+      {codes.map((code) => (
+        <li key={code} style={rowStyle}>
+          <span style={codeStyle}>{code}</span>
+          <span style={systemStyle}>{dtcSystem(code)}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export const DtcPanel = () => {
+  const codes = useDtcStore((s) => s.codes)
+  const hasRead = useDtcStore((s) => s.hasRead)
+  const status = useDtcStore((s) => s.status)
+  const error = useDtcStore((s) => s.error)
+  const read = useDtcStore((s) => s.read)
+  const clear = useDtcStore((s) => s.clear)
+  const connected = useDeviceStore((s) => s.connected)
+  const simulationMode = useDeviceStore((s) => s.simulationMode)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+
+  const ready = connected || simulationMode
+  const busy = status !== 'idle'
+  const canRead = ready && !busy
+  const canClear = ready && !busy && codes.length > 0
+
+  return (
+    <aside style={panelStyle}>
+      <div style={headerStyle}>TROUBLE CODES</div>
+      <div style={bodyStyle}>
+        <DtcBody ready={ready} reading={status === 'reading'} hasRead={hasRead} codes={codes} />
+        {error && <div style={errorStyle}>Failed — {error}</div>}
+      </div>
+      <div style={footerStyle}>
+        <button
+          type="button"
+          onClick={() => {
+            void read()
+          }}
+          disabled={!canRead}
+          style={readButtonStyle(canRead)}
+        >
+          {status === 'reading' ? 'READING…' : 'READ DTCs'}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setConfirmOpen(true)
+          }}
+          disabled={!canClear}
+          style={clearButtonStyle(canClear)}
+        >
+          {status === 'clearing' ? 'CLEARING…' : 'CLEAR CODES'}
+        </button>
+      </div>
+      <DtcClearConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        codeCount={codes.length}
+        onConfirm={() => {
+          setConfirmOpen(false)
+          void clear()
+        }}
+      />
+    </aside>
+  )
+}
 
 const panelStyle: CSSProperties = {
   width: 360,
@@ -38,20 +106,76 @@ const headerStyle: CSSProperties = {
   color: 'hsl(var(--brand-neutral-600))',
 }
 
-const emptyStyle: CSSProperties = {
+const bodyStyle: CSSProperties = {
   flex: 1,
+  overflowY: 'auto',
+  display: 'flex',
+  flexDirection: 'column',
+}
+
+const emptyStyle: CSSProperties = {
   padding: '16px 20px',
   fontSize: 12,
   lineHeight: 1.5,
   color: 'hsl(var(--brand-neutral-500))',
 }
 
+const listStyle: CSSProperties = {
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+}
+
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'baseline',
+  justifyContent: 'space-between',
+  gap: 12,
+  padding: '10px 20px',
+  borderBottom: '1px solid hsl(var(--brand-neutral-300))',
+}
+
+const codeStyle: CSSProperties = {
+  fontFamily: MONO_FONT,
+  fontSize: 14,
+  fontWeight: 700,
+  color: 'hsl(var(--brand-accent))',
+  fontVariantNumeric: 'tabular-nums',
+}
+
+const systemStyle: CSSProperties = {
+  fontSize: 10,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  color: 'hsl(var(--brand-neutral-600))',
+}
+
+const errorStyle: CSSProperties = {
+  padding: '12px 20px',
+  fontSize: 12,
+  color: 'hsl(var(--brand-accent))',
+}
+
 const footerStyle: CSSProperties = {
+  display: 'flex',
+  gap: 10,
   padding: '14px 20px',
   borderTop: '1px solid hsl(var(--brand-neutral-300))',
 }
 
-const clearButtonStyle: CSSProperties = {
+const readButtonStyle = (enabled: boolean): CSSProperties => ({
+  padding: '6px 14px',
+  background: enabled ? 'hsl(var(--brand-accent))' : 'none',
+  border: '1px solid hsl(var(--brand-accent))',
+  fontWeight: 800,
+  fontSize: 11,
+  letterSpacing: '0.09em',
+  color: enabled ? '#fff' : 'hsl(var(--brand-neutral-500))',
+  cursor: enabled ? 'pointer' : 'not-allowed',
+  opacity: enabled ? 1 : 0.5,
+})
+
+const clearButtonStyle = (enabled: boolean): CSSProperties => ({
   padding: '6px 14px',
   background: 'none',
   border: '1px solid hsl(var(--brand-accent))',
@@ -59,6 +183,6 @@ const clearButtonStyle: CSSProperties = {
   fontSize: 11,
   letterSpacing: '0.09em',
   color: 'hsl(var(--brand-accent))',
-  cursor: 'not-allowed',
-  opacity: 0.5,
-}
+  cursor: enabled ? 'pointer' : 'not-allowed',
+  opacity: enabled ? 1 : 0.5,
+})

--- a/src/stores/dtc.store.test.ts
+++ b/src/stores/dtc.store.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, it, expect } from 'vitest'
+import { SIMULATED_DTCS, useDtcStore } from './dtc.store'
+import { useDeviceStore } from './device.store'
+
+describe('dtc store (simulation)', () => {
+  beforeEach(() => {
+    useDtcStore.setState({ codes: [], hasRead: false, status: 'idle', error: null })
+    useDeviceStore.setState({ simulationMode: true })
+  })
+
+  it('read() fills the simulated codes and marks hasRead', async () => {
+    await useDtcStore.getState().read()
+    const state = useDtcStore.getState()
+    expect(state.codes).toEqual(SIMULATED_DTCS)
+    expect(state.hasRead).toBe(true)
+    expect(state.status).toBe('idle')
+    expect(state.error).toBeNull()
+  })
+
+  it('clear() empties the list', async () => {
+    await useDtcStore.getState().read()
+    await useDtcStore.getState().clear()
+    const state = useDtcStore.getState()
+    expect(state.codes).toEqual([])
+    expect(state.hasRead).toBe(true)
+    expect(state.status).toBe('idle')
+  })
+})

--- a/src/stores/dtc.store.ts
+++ b/src/stores/dtc.store.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand'
+import { dtcIpc } from '../transport/dtc-ipc'
+import { useDeviceStore } from './device.store'
+
+export const SIMULATED_DTCS = ['P0301', 'P0420', 'C1234', 'U0100']
+
+export type DtcStatus = 'idle' | 'reading' | 'clearing'
+
+interface DtcState {
+  codes: string[]
+  hasRead: boolean
+  status: DtcStatus
+  error: string | null
+  read: () => Promise<void>
+  clear: () => Promise<void>
+}
+
+const isSimulation = (): boolean => useDeviceStore.getState().simulationMode
+
+export const useDtcStore = create<DtcState>()((set) => ({
+  codes: [],
+  hasRead: false,
+  status: 'idle',
+  error: null,
+
+  read: async () => {
+    set({ status: 'reading', error: null })
+    if (isSimulation()) {
+      set({ codes: SIMULATED_DTCS, hasRead: true, status: 'idle' })
+      return
+    }
+    const result = await dtcIpc.read()
+    if (result.ok) set({ codes: result.codes, hasRead: true, status: 'idle' })
+    else set({ status: 'idle', error: result.error ?? 'read_failed' })
+  },
+
+  clear: async () => {
+    set({ status: 'clearing', error: null })
+    if (isSimulation()) {
+      set({ codes: [], hasRead: true, status: 'idle' })
+      return
+    }
+    const cleared = await dtcIpc.clear()
+    if (!cleared.ok) {
+      set({ status: 'idle', error: cleared.error ?? 'clear_failed' })
+      return
+    }
+    const reread = await dtcIpc.read()
+    if (reread.ok) set({ codes: reread.codes, hasRead: true, status: 'idle' })
+    else set({ codes: [], hasRead: true, status: 'idle', error: reread.error ?? 'read_failed' })
+  },
+}))

--- a/src/transport/dtc-ipc.test.ts
+++ b/src/transport/dtc-ipc.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { parseDtcBytes } from './dtc-ipc'
+
+describe('parseDtcBytes', () => {
+  it('accepts a valid byte array', () => {
+    expect(parseDtcBytes([0x01, 0x33, 0x43, 0x01])).toEqual([0x01, 0x33, 0x43, 0x01])
+    expect(parseDtcBytes([])).toEqual([])
+  })
+
+  it('rejects non-arrays', () => {
+    expect(parseDtcBytes(undefined)).toBeNull()
+    expect(parseDtcBytes(null)).toBeNull()
+    expect(parseDtcBytes('0x01')).toBeNull()
+    expect(parseDtcBytes({ 0: 1 })).toBeNull()
+  })
+
+  it('rejects out-of-range or non-integer bytes', () => {
+    expect(parseDtcBytes([0x01, 256])).toBeNull()
+    expect(parseDtcBytes([-1, 0x01])).toBeNull()
+    expect(parseDtcBytes([0x01, 1.5])).toBeNull()
+    expect(parseDtcBytes([0x01, '2'])).toBeNull()
+  })
+})

--- a/src/transport/dtc-ipc.ts
+++ b/src/transport/dtc-ipc.ts
@@ -1,0 +1,53 @@
+import { decodeDtcList } from '@canshift/core'
+import { CMD_OBD_CLEAR_DTC, CMD_OBD_READ_DTC } from './opcodes'
+import { getSerialClient } from './webserial-client'
+
+const DTC_READ_TIMEOUT_MS = 5_000
+const DTC_CLEAR_TIMEOUT_MS = 3_000
+
+export interface DtcReadResult {
+  ok: boolean
+  codes: string[]
+  error?: string
+}
+
+export interface DtcClearResult {
+  ok: boolean
+  error?: string
+}
+
+export const parseDtcBytes = (value: unknown): number[] | null => {
+  if (!Array.isArray(value)) return null
+  const bytes: number[] = []
+  for (const entry of value) {
+    if (typeof entry !== 'number' || !Number.isInteger(entry) || entry < 0 || entry > 0xff) {
+      return null
+    }
+    bytes.push(entry)
+  }
+  return bytes
+}
+
+export const dtcIpc = {
+  read: async (): Promise<DtcReadResult> => {
+    const result = await getSerialClient().send(
+      CMD_OBD_READ_DTC,
+      {},
+      { timeoutMs: DTC_READ_TIMEOUT_MS }
+    )
+    if (!result.ok) return { ok: false, codes: [], error: result.error ?? 'unknown_error' }
+    const bytes = parseDtcBytes(result.data?.dtc_bytes)
+    if (bytes === null) return { ok: false, codes: [], error: 'invalid_dtc_response' }
+    return { ok: true, codes: decodeDtcList(bytes) }
+  },
+
+  clear: async (): Promise<DtcClearResult> => {
+    const result = await getSerialClient().send(
+      CMD_OBD_CLEAR_DTC,
+      {},
+      { timeoutMs: DTC_CLEAR_TIMEOUT_MS }
+    )
+    if (result.ok) return { ok: true }
+    return { ok: false, error: result.error ?? 'unknown_error' }
+  },
+}

--- a/src/transport/opcodes.ts
+++ b/src/transport/opcodes.ts
@@ -13,6 +13,8 @@ export const CMD_QUERY_VERSION = 0x10
 export const CMD_PING = 0x11
 export const CMD_CAN_SCAN_START = 0x20
 export const CMD_CAN_SCAN_STOP = 0x21
+export const CMD_OBD_READ_DTC = 0x22
+export const CMD_OBD_CLEAR_DTC = 0x23
 export const CMD_OTA_BEGIN = 0x30
 export const CMD_OTA_WRITE = 0x31
 export const CMD_OTA_END = 0x32
@@ -72,5 +74,11 @@ export const KNOWN_OPCODES: readonly KnownOpcode[] = [
   { id: CMD_PING, name: 'CMD_PING', description: 'Liveness probe — replies with uptime_ms' },
   { id: CMD_CAN_SCAN_START, name: 'CMD_CAN_SCAN_START', description: 'Start CAN scan' },
   { id: CMD_CAN_SCAN_STOP, name: 'CMD_CAN_SCAN_STOP', description: 'Stop CAN scan' },
+  {
+    id: CMD_OBD_READ_DTC,
+    name: 'CMD_OBD_READ_DTC',
+    description: 'Read stored DTCs (OBD-II Mode 03)',
+  },
+  { id: CMD_OBD_CLEAR_DTC, name: 'CMD_OBD_CLEAR_DTC', description: 'Clear DTCs (OBD-II Mode 04)' },
   { id: CMD_REBOOT, name: 'CMD_REBOOT', description: 'Reboot the dash' },
 ]


### PR DESCRIPTION
Closes #11. The tuner side of OBD-II Mode 03/04 (read/clear trouble codes). Consumes the DTC decode shipped in `@canshift/core@2.7.0` (#37). Cross-repo tracker CANShift/CANShift#1883.

## Changes
- **`@canshift/core` bumped `^2.6.0 → ^2.7.0`** (for `decodeDtcList` / `dtcSystem`).
- **`transport/opcodes.ts`** — `CMD_OBD_READ_DTC = 0x22`, `CMD_OBD_CLEAR_DTC = 0x23` (+ `KNOWN_OPCODES`). This is the wire contract firmware #14 will implement.
- **`transport/dtc-ipc.ts`** — `read()` sends `0x22`, validates the `dtc_bytes` response (pure `parseDtcBytes`) and decodes via core; `clear()` sends `0x23`.
- **`stores/dtc.store.ts`** — `codes` / `hasRead` / `status` / `error`, with a canned list under `simulationMode` so the panel is usable with no device.
- **`components/obd2/DtcPanel.tsx`** — wired: READ DTCs fills the list (each code tagged with `dtcSystem`), CLEAR CODES opens a confirm dialog (`DtcClearConfirmDialog`, shadcn AlertDialog) then clears and re-reads. Guard-clause sub-component for the body (no nested ternaries).

## Test plan
- `typecheck` · `test` (244 pass — new `dtc-ipc.test.ts` for `parseDtcBytes` validation, `dtc.store.test.ts` for the simulation read/clear path) · `lint` · `format:check` · `build` all green.
- **Verification note:** the feature is designed to be driven in **simulation** (READ → 4 canned DTCs, CLEAR → empty). I attempted an in-browser smoke but the Playwright MCP in this environment is pinned to Chrome (not installed) and I did not install/launch it per the repo's Helium/WebSerial-protection convention — so end-to-end was verified at the unit level (store sim path + parse) plus typecheck/build, not via a live click-through. On a real device the actions send `0x22`/`0x23`; they no-op gracefully until firmware #14 ships.

## Follow-up
- **firmware #14** — Mode 03/04 request/response over the OBD-II path, answering `0x22` with `{ dtc_bytes: [...] }` and `0x23` with an ack.