### PR TITLE
refactor(tuner): route gauge preview math through @canshift/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^2.7.0",
+        "@canshift/core": "^2.12.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.7.0.tgz",
-      "integrity": "sha512-JwBuhbDRAHQl2BVyhLVzYsW8m3NO2EMmmfFwecC03288p45ooZYWxBWN7Tmwy5SHB/xeHO8VcTrIBWHK201osQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.12.0.tgz",
+      "integrity": "sha512-xX1n341cQhthGhPd7IqGyP/grzBpH71P0ovgyiBKMKn1uFhP8Fx87FmsX0GUonAWGDaScsb+Q2tWeJu+ocsHdg==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^2.7.0",
+    "@canshift/core": "^2.12.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/components/editor/widget-previews/gauge-math.ts
+++ b/src/components/editor/widget-previews/gauge-math.ts
@@ -1,45 +1,13 @@
 import type { Widget } from '@canshift/core'
+import {
+  GAUGE_ARC,
+  VALUE_FRAC_FONT_RATIO,
+  gaugeArcPath,
+  gaugeGradientColorAt,
+} from '@canshift/core'
 import { thresholdPct } from '../widgetPreview.styles'
 
-const GRADIENT_GREEN = { r: 0x00, g: 0xcc, b: 0x44 }
-const GRADIENT_ORANGE = { r: 0xff, g: 0x88, b: 0x00 }
-const GRADIENT_RED = { r: 0xff, g: 0x44, b: 0x44 }
-
-const clamp01 = (value: number): number => {
-  if (value < 0) return 0
-  if (value > 1) return 1
-  return value
-}
-
-const lerpChannel = (a: number, b: number, t: number): number => {
-  const v = a + (b - a) * t
-  if (v < 0) return 0
-  if (v > 255) return 255
-  return Math.round(v)
-}
-
-const rgbToHex = (r: number, g: number, b: number): string => {
-  const hex = (n: number): string => n.toString(16).padStart(2, '0')
-  return `#${hex(r)}${hex(g)}${hex(b)}`
-}
-
-export const interpolateGreenOrangeRed = (pct: number): string => {
-  const p = clamp01(pct)
-  if (p <= 0.5) {
-    const t = p * 2
-    return rgbToHex(
-      lerpChannel(GRADIENT_GREEN.r, GRADIENT_ORANGE.r, t),
-      lerpChannel(GRADIENT_GREEN.g, GRADIENT_ORANGE.g, t),
-      lerpChannel(GRADIENT_GREEN.b, GRADIENT_ORANGE.b, t)
-    )
-  }
-  const t = (p - 0.5) * 2
-  return rgbToHex(
-    lerpChannel(GRADIENT_ORANGE.r, GRADIENT_RED.r, t),
-    lerpChannel(GRADIENT_ORANGE.g, GRADIENT_RED.g, t),
-    lerpChannel(GRADIENT_ORANGE.b, GRADIENT_RED.b, t)
-  )
-}
+export const interpolateGreenOrangeRed = (pct: number): string => gaugeGradientColorAt(pct)
 
 export const DEMO_PCT = 0.65
 
@@ -72,12 +40,7 @@ export const splitDecimal = (s: string): { int: string; frac: string } => {
   return { int: s.slice(0, dot), frac: s.slice(dot) }
 }
 
-export const FRAC_FONT_SCALE = 0.7
-
-const svgPt = (cx: number, cy: number, r: number, angleDeg: number) => {
-  const rad = (angleDeg * Math.PI) / 180
-  return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) }
-}
+export const FRAC_FONT_SCALE = VALUE_FRAC_FONT_RATIO
 
 export const gaugeArcD = (
   cx: number,
@@ -85,16 +48,11 @@ export const gaugeArcD = (
   r: number,
   fromPct: number,
   toPct: number
-): string => {
-  const START_DEG = 135
-  const SWEEP_DEG = 270
-  const fromAngle = START_DEG + fromPct * SWEEP_DEG
-  const toAngle = START_DEG + toPct * SWEEP_DEG
-  const from = svgPt(cx, cy, r, fromAngle)
-  const to = svgPt(cx, cy, r, toAngle)
-  const sweep = (toPct - fromPct) * SWEEP_DEG
-  const largeArc = sweep > 180 ? 1 : 0
-  const rStr = String(r)
-  const laStr = String(largeArc)
-  return `M ${from.x.toFixed(2)} ${from.y.toFixed(2)} A ${rStr} ${rStr} 0 ${laStr} 1 ${to.x.toFixed(2)} ${to.y.toFixed(2)}`
-}
+): string =>
+  gaugeArcPath(
+    cx,
+    cy,
+    r,
+    GAUGE_ARC.rotationDeg + fromPct * GAUGE_ARC.sweepDeg,
+    GAUGE_ARC.rotationDeg + toPct * GAUGE_ARC.sweepDeg
+  )


### PR DESCRIPTION
Consolidation pass. The gauge preview's `gauge-math.ts` re-implemented color interpolation and arc geometry that core already owns (and mobile consumes). Now it delegates to core — single source of truth, no drift risk.

## Change
- `@canshift/core` `^2.7.0 → ^2.12.0`.
- `gauge-math.ts` is now a thin adapter over core:
  - `interpolateGreenOrangeRed` → `gaugeGradientColorAt` (verified byte-identical output at every point).
  - `gaugeArcD(cx,cy,r,fromPct,toPct)` → `gaugeArcPath(...)` with `GAUGE_ARC.rotationDeg + pct*sweepDeg` (byte-identical arc `d`, e.g. `M 21.72 78.28 A 40 40 0 0 1 75.98 19.58` for 0→0.65).
  - `FRAC_FONT_SCALE` → `VALUE_FRAC_FONT_RATIO`.
  - Removed the hand-rolled `GRADIENT_*` / `lerpChannel` / `rgbToHex` / `svgPt` and the local arc/angle constants.
- Kept the preview-specific bits (`effectiveValue`, `isDangerState`, `splitDecimal`, `DEMO_PCT`), so the four consumer components are unchanged.

Directly serves the design-authority rule: firmware visuals are canonical (core mirrors them); the tuner preview adapts.

## Test plan
`typecheck` (clean — the 2.7→2.12 bump introduced no breaks) · `test` (244) · `lint` · `format:check` · `build` all green. Arc + color outputs verified identical to the previous implementation.