### PR TITLE
chore: bump @canshift/core to 2.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^2.12.0",
+        "@canshift/core": "^2.14.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.12.0.tgz",
-      "integrity": "sha512-xX1n341cQhthGhPd7IqGyP/grzBpH71P0ovgyiBKMKn1uFhP8Fx87FmsX0GUonAWGDaScsb+Q2tWeJu+ocsHdg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.14.0.tgz",
+      "integrity": "sha512-aLFPlzY7K2DXoYfe9J8qMQduJ/tnx0Ht/YAfbtR9Zkq21FCg6aEI0JmLvuvBJBl0BahvK0nk4h5sKVij01U/kA==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^2.12.0",
+    "@canshift/core": "^2.14.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",


### PR DESCRIPTION
Picks up core 2.14.0 (red device UI accent, #44). The generated `tokens.generated.css` `--accent` was already `0 100% 64%` (red), so the bump produces no token diff here — this just realigns the pinned dependency; the app's accent is unchanged.

## Test plan
- `npm run typecheck` / `format:check` — clean
- `npm test` — 244 pass
- Build validated in CI (local prebuild strips core devDeps)