### PR TITLE
feat(tuner): collapsible left nav and editor inspector

### DIFF
--- a/src/components/shell/CollapseRail.tsx
+++ b/src/components/shell/CollapseRail.tsx
@@ -1,0 +1,113 @@
+import type { CSSProperties } from 'react'
+
+type Side = 'left' | 'right'
+
+const Chevron = ({ dir }: { dir: Side }) => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+    style={{ transform: dir === 'left' ? 'rotate(180deg)' : undefined }}
+  >
+    <path
+      d="M9 6l6 6-6 6"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+interface CollapseRailProps {
+  side: Side
+  label: string
+  onExpand: () => void
+}
+
+export const CollapseRail = ({ side, label, onExpand }: CollapseRailProps) => (
+  <div style={railStyle(side)}>
+    <button
+      type="button"
+      onClick={onExpand}
+      title={`Expand ${label}`}
+      aria-label={`Expand ${label}`}
+      className="shell-nav-item"
+      style={railButtonStyle}
+    >
+      <Chevron dir={side === 'left' ? 'right' : 'left'} />
+    </button>
+    <span style={railLabelStyle}>{label}</span>
+  </div>
+)
+
+interface CollapseButtonProps {
+  side: Side
+  label: string
+  onCollapse: () => void
+}
+
+export const CollapseButton = ({ side, label, onCollapse }: CollapseButtonProps) => (
+  <button
+    type="button"
+    onClick={onCollapse}
+    title={`Collapse ${label}`}
+    aria-label={`Collapse ${label}`}
+    className="shell-nav-item"
+    style={collapseButtonStyle}
+  >
+    <Chevron dir={side === 'left' ? 'left' : 'right'} />
+  </button>
+)
+
+const railStyle = (side: Side): CSSProperties => ({
+  width: 30,
+  flexShrink: 0,
+  background: 'hsl(var(--brand-neutral-100))',
+  ...(side === 'left'
+    ? { borderRight: '2px solid var(--brand-divider)' }
+    : { borderLeft: '2px solid var(--brand-divider)' }),
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 12,
+  paddingTop: 10,
+})
+
+const railButtonStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 24,
+  height: 24,
+  border: 0,
+  background: 'transparent',
+  color: 'hsl(var(--brand-neutral-600))',
+  cursor: 'pointer',
+}
+
+const railLabelStyle: CSSProperties = {
+  writingMode: 'vertical-rl',
+  transform: 'rotate(180deg)',
+  fontSize: 10,
+  fontWeight: 800,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: 'hsl(var(--brand-neutral-600))',
+  userSelect: 'none',
+}
+
+const collapseButtonStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 26,
+  height: 26,
+  flexShrink: 0,
+  border: 0,
+  background: 'transparent',
+  color: 'hsl(var(--brand-neutral-600))',
+  cursor: 'pointer',
+}

--- a/src/components/shell/Sidebar.tsx
+++ b/src/components/shell/Sidebar.tsx
@@ -1,9 +1,11 @@
 import { NavLink, useLocation } from 'react-router-dom'
 import { resolveScreenProfile } from '@canshift/core'
 import { SidebarView, type SidebarLinkProps } from './SidebarView'
+import { CollapseRail } from './CollapseRail'
 import { useConnectionStore } from '../../stores/connection.store'
 import { useDashboardStore } from '../../stores/dashboard.store'
 import { useDeviceStore } from '../../stores/device.store'
+import { useUiStore } from '../../stores/ui.store'
 
 const RouterLink = ({ to, style, className, children, title }: SidebarLinkProps) => (
   <NavLink to={to} end={to === '/'} style={style} className={className ?? ''} title={title}>
@@ -17,8 +19,14 @@ const Sidebar = () => {
   const firmwareVersion = useDeviceStore((s) => s.firmwareVersion)
   const targetProfile = useDashboardStore((s) => s.config?.targetProfile)
   const location = useLocation()
+  const collapsed = useUiStore((s) => s.leftNavCollapsed)
+  const toggleLeftNav = useUiStore((s) => s.toggleLeftNav)
   const offline = status !== 'connected' && !simulationMode
   const targetLabel = resolveScreenProfile(targetProfile).name
+
+  if (collapsed) {
+    return <CollapseRail side="left" label="Menu" onExpand={toggleLeftNav} />
+  }
 
   return (
     <SidebarView
@@ -27,6 +35,7 @@ const Sidebar = () => {
       targetLabel={targetLabel}
       firmwareVersion={firmwareVersion}
       LinkComponent={RouterLink}
+      onCollapse={toggleLeftNav}
     />
   )
 }

--- a/src/components/shell/SidebarView.tsx
+++ b/src/components/shell/SidebarView.tsx
@@ -1,5 +1,6 @@
 import type { ComponentType, CSSProperties, ReactNode } from 'react'
 import { MONO_FONT } from '../../lib/typography'
+import { CollapseButton } from './CollapseRail'
 
 export type SidebarRoute =
   | '/'
@@ -77,6 +78,7 @@ export interface SidebarViewProps {
   targetLabel: string | null
   firmwareVersion: string | null
   LinkComponent?: ComponentType<SidebarLinkProps>
+  onCollapse?: () => void
 }
 
 const DefaultLink: ComponentType<SidebarLinkProps> = ({
@@ -97,8 +99,14 @@ export const SidebarView = ({
   targetLabel,
   firmwareVersion,
   LinkComponent = DefaultLink,
+  onCollapse,
 }: SidebarViewProps) => (
   <nav aria-label="Primary" style={navStyle}>
+    {onCollapse && (
+      <div style={collapseHeaderStyle}>
+        <CollapseButton side="left" label="Menu" onCollapse={onCollapse} />
+      </div>
+    )}
     <div style={scrollAreaStyle}>
       {SIDEBAR_GROUPS.map((group, groupIdx) => (
         <div key={group.label ?? 'top'}>
@@ -173,6 +181,12 @@ const navStyle: CSSProperties = {
   borderRight: '2px solid var(--brand-divider)',
   display: 'flex',
   flexDirection: 'column',
+}
+
+const collapseHeaderStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  padding: '8px 8px 0',
 }
 
 const scrollAreaStyle: CSSProperties = {

--- a/src/routes/RightSidebar.tsx
+++ b/src/routes/RightSidebar.tsx
@@ -1,5 +1,7 @@
 import { lazy, Suspense, useState } from 'react'
 import type { CSSProperties } from 'react'
+import { CollapseRail, CollapseButton } from '../components/shell/CollapseRail'
+import { useUiStore } from '../stores/ui.store'
 
 const PropertyPanel = lazy(() => import('../components/editor/PropertyPanel'))
 const SignalsPanel = lazy(() => import('../components/editor/SignalsPanel'))
@@ -25,55 +27,66 @@ const PanelFallback = () => <div style={fallbackStyle}>Loading…</div>
 
 export const RightSidebar = ({ pageId }: RightSidebarProps) => {
   const [tab, setTab] = useState<Tab>('properties')
+  const collapsed = useUiStore((s) => s.inspectorCollapsed)
+  const toggleInspector = useUiStore((s) => s.toggleInspector)
+
+  if (collapsed) {
+    return <CollapseRail side="right" label="Inspector" onExpand={toggleInspector} />
+  }
 
   return (
     <aside style={asideStyle}>
-      <div role="tablist" aria-label="Editor sidebar tabs" style={tabListStyle}>
-        {TABS.map((t) => {
-          const isActive = tab === t.id
-          return (
-            <button
-              key={t.id}
-              type="button"
-              role="tab"
-              aria-selected={isActive}
-              onClick={() => {
-                setTab(t.id)
-              }}
-              className={isActive ? undefined : 'shell-nav-item'}
-              style={tabStyle(isActive)}
-            >
-              {t.label}
-              {isActive && <span aria-hidden="true" style={tabBarStyle} />}
-            </button>
-          )
-        })}
+      <div style={gutterStyle}>
+        <CollapseButton side="right" label="Inspector" onCollapse={toggleInspector} />
       </div>
-      {tab === 'properties' && pageId !== undefined && (
-        <Suspense fallback={<PanelFallback />}>
-          <PropertyPanel pageId={pageId} />
-        </Suspense>
-      )}
-      {tab === 'widgets' && pageId !== undefined && (
-        <Suspense fallback={<PanelFallback />}>
-          <WidgetListPanel pageId={pageId} />
-        </Suspense>
-      )}
-      {tab === 'signals' && (
-        <Suspense fallback={<PanelFallback />}>
-          <SignalsPanel pageId={pageId} />
-        </Suspense>
-      )}
-      {tab === 'library' && pageId !== undefined && (
-        <Suspense fallback={<PanelFallback />}>
-          <WidgetPalette pageId={pageId} />
-        </Suspense>
-      )}
-      {tab === 'history' && (
-        <Suspense fallback={<PanelFallback />}>
-          <HistoryPanel />
-        </Suspense>
-      )}
+      <div style={contentColStyle}>
+        <div role="tablist" aria-label="Editor sidebar tabs" style={tabListStyle}>
+          {TABS.map((t) => {
+            const isActive = tab === t.id
+            return (
+              <button
+                key={t.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => {
+                  setTab(t.id)
+                }}
+                className={isActive ? undefined : 'shell-nav-item'}
+                style={tabStyle(isActive)}
+              >
+                {t.label}
+                {isActive && <span aria-hidden="true" style={tabBarStyle} />}
+              </button>
+            )
+          })}
+        </div>
+        {tab === 'properties' && pageId !== undefined && (
+          <Suspense fallback={<PanelFallback />}>
+            <PropertyPanel pageId={pageId} />
+          </Suspense>
+        )}
+        {tab === 'widgets' && pageId !== undefined && (
+          <Suspense fallback={<PanelFallback />}>
+            <WidgetListPanel pageId={pageId} />
+          </Suspense>
+        )}
+        {tab === 'signals' && (
+          <Suspense fallback={<PanelFallback />}>
+            <SignalsPanel pageId={pageId} />
+          </Suspense>
+        )}
+        {tab === 'library' && pageId !== undefined && (
+          <Suspense fallback={<PanelFallback />}>
+            <WidgetPalette pageId={pageId} />
+          </Suspense>
+        )}
+        {tab === 'history' && (
+          <Suspense fallback={<PanelFallback />}>
+            <HistoryPanel />
+          </Suspense>
+        )}
+      </div>
     </aside>
   )
 }
@@ -82,6 +95,25 @@ const asideStyle: CSSProperties = {
   width: 320,
   flexShrink: 0,
   borderLeft: '2px solid var(--brand-divider)',
+  display: 'flex',
+  flexDirection: 'row',
+  minHeight: 0,
+  overflow: 'hidden',
+}
+
+const gutterStyle: CSSProperties = {
+  flexShrink: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  paddingTop: 8,
+  borderRight: '1px solid var(--brand-divider)',
+  background: 'hsl(var(--brand-neutral-100))',
+}
+
+const contentColStyle: CSSProperties = {
+  flex: 1,
+  minWidth: 0,
   display: 'flex',
   flexDirection: 'column',
   minHeight: 0,

--- a/src/stores/ui.store.ts
+++ b/src/stores/ui.store.ts
@@ -1,11 +1,34 @@
 import { create } from 'zustand'
 
+const LEFT_NAV_KEY = 'cs-left-nav-collapsed'
+const INSPECTOR_KEY = 'cs-inspector-collapsed'
+
+const readCollapsed = (key: string): boolean => {
+  try {
+    return localStorage.getItem(key) === '1'
+  } catch {
+    return false
+  }
+}
+
+const writeCollapsed = (key: string, value: boolean): void => {
+  try {
+    localStorage.setItem(key, value ? '1' : '0')
+  } catch {
+    return
+  }
+}
+
 interface UiState {
   burnDeniedAt: number | null
   signalBurnDenied: () => void
   unboundBurnConfirm: number | null
   requestUnboundBurnConfirm: (count: number) => void
   clearUnboundBurnConfirm: () => void
+  leftNavCollapsed: boolean
+  toggleLeftNav: () => void
+  inspectorCollapsed: boolean
+  toggleInspector: () => void
 }
 
 export const useUiStore = create<UiState>((set) => ({
@@ -19,5 +42,21 @@ export const useUiStore = create<UiState>((set) => ({
   },
   clearUnboundBurnConfirm: () => {
     set({ unboundBurnConfirm: null })
+  },
+  leftNavCollapsed: readCollapsed(LEFT_NAV_KEY),
+  toggleLeftNav: () => {
+    set((s) => {
+      const next = !s.leftNavCollapsed
+      writeCollapsed(LEFT_NAV_KEY, next)
+      return { leftNavCollapsed: next }
+    })
+  },
+  inspectorCollapsed: readCollapsed(INSPECTOR_KEY),
+  toggleInspector: () => {
+    set((s) => {
+      const next = !s.inspectorCollapsed
+      writeCollapsed(INSPECTOR_KEY, next)
+      return { inspectorCollapsed: next }
+    })
   },
 }))


### PR DESCRIPTION
## What

Adds collapse toggles to both lateral panels so the editor canvas reclaims space on narrow windows (the fixed 236px nav + 320px inspector were squeezing the 320×240 preview until it overflowed under the inspector).

Closes #54.

## Changes

- `ui.store`: `leftNavCollapsed` / `inspectorCollapsed` flags with toggles, persisted to `localStorage` (`cs-left-nav-collapsed`, `cs-inspector-collapsed`).
- New `components/shell/CollapseRail.tsx` — a reusable 30px rail (expand chevron + vertical label) and a `CollapseButton`, both with inline SVG chevrons (matching the codebase's no-icon-lib convention).
- Left nav (`Sidebar` → `SidebarView`): collapse chevron in the nav header; collapsed state renders the rail.
- Inspector (`RightSidebar`): collapse chevron in a thin left gutter so the five tabs keep their width; collapsed state renders the rail.

## Test plan

- `npm run typecheck` ✓ · `npm run lint` ✓ · `npm run format:check` ✓ · `npm test` → 244 passed ✓ · `npm run build` ✓
- Manual: collapse/expand each side, reload to confirm persistence (browser check not run in this environment — pure React state + CSS layout, no behavioural risk).

## Note

Independent of the top-bar mockup work (firmware #101 / core #46).