### PR TITLE
feat(tuner): mirror the canRate/lap top bar and match the Track mockup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^2.14.0",
+        "@canshift/core": "^2.16.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.14.0.tgz",
-      "integrity": "sha512-aLFPlzY7K2DXoYfe9J8qMQduJ/tnx0Ht/YAfbtR9Zkq21FCg6aEI0JmLvuvBJBl0BahvK0nk4h5sKVij01U/kA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.16.0.tgz",
+      "integrity": "sha512-H4euI8P+kTifd/nIegHSERdM/p4npv3FuMZmj3O3LbUHjBLs85L3UKIrL9XmccMO816jgJg0B7OyB9YDAza9hw==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^2.14.0",
+    "@canshift/core": "^2.16.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/components/editor/DashTopBar.tsx
+++ b/src/components/editor/DashTopBar.tsx
@@ -177,7 +177,7 @@ export const DashTopBar = ({
               whiteSpace: 'nowrap',
             }}
           >
-            LAP 4 · 1:38.42
+            {'LAP 4\u00A0\u00A0\u00A01:38.42'}
           </span>
         )
     }

--- a/src/components/editor/DashTopBar.tsx
+++ b/src/components/editor/DashTopBar.tsx
@@ -11,6 +11,7 @@ const PREVIEW_SIGNAL_VALUES: Record<string, number> = {
   coolant_temp_c: 88,
   oil_press_bar: 4.2,
   oil_temp_c: 95,
+  map_number: 1,
 }
 
 const formatPreviewSignal = (signal: string, format?: string): string => {
@@ -49,6 +50,7 @@ export const DashTopBar = ({
   const px = Math.round(h * TopBarMetrics.paddingRatio)
   const flagSquare = Math.round(TopBarMetrics.flagSquarePx * scale)
   const flagGap = Math.round(TopBarMetrics.flagGapPx * scale)
+  const dim = isDayMode ? '#5A5A5A' : '#BABABA'
 
   const handlePointerDown = (e: PointerEvent) => {
     swipeStartY.current = e.clientY
@@ -108,8 +110,8 @@ export const DashTopBar = ({
             key={key}
             style={{
               fontSize: fs,
-              color: '#666666',
-              letterSpacing: '0.04em',
+              color: dim,
+              letterSpacing: '0.1em',
               lineHeight: 1,
             }}
           >
@@ -122,8 +124,20 @@ export const DashTopBar = ({
         )
       case 'signal':
         return (
-          <span key={key} style={{ fontSize: fs, color: '#777777', lineHeight: 1 }}>
+          <span
+            key={key}
+            style={{ fontSize: fs, color: dim, letterSpacing: '0.1em', lineHeight: 1 }}
+          >
             {formatPreviewSignal(item.signal, item.format)}
+          </span>
+        )
+      case 'canRate':
+        return (
+          <span
+            key={key}
+            style={{ fontSize: fs, color: dim, letterSpacing: '0.1em', lineHeight: 1 }}
+          >
+            842 Hz
           </span>
         )
       case 'bleIcon':
@@ -152,7 +166,20 @@ export const DashTopBar = ({
       case 'modeFlag':
         return renderFlagBadge(key, item.text)
       case 'trackBadge':
-        return renderFlagBadge(key, 'TRACK')
+        return (
+          <span
+            key={key}
+            style={{
+              fontSize: fs,
+              color: dim,
+              letterSpacing: '0.1em',
+              lineHeight: 1,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            LAP 4 · 1:38.42
+          </span>
+        )
     }
   }
 

--- a/src/config/default-sim-config.ts
+++ b/src/config/default-sim-config.ts
@@ -20,62 +20,22 @@ const PARSED_SIM_CONFIG = DashboardConfigSchema.parse({
           position: 'left',
         },
         {
-          type: 'statusDot',
-          signal: 'any',
+          type: 'canRate',
           position: 'left',
         },
         {
-          type: 'modeFlag',
-          signal: 'flag_anti_lag',
-          text: 'ALS',
-          position: 'center',
-        },
-        {
-          type: 'separator',
-          position: 'center',
-        },
-        {
-          type: 'modeFlag',
-          signal: 'flag_launch_ctrl',
-          text: 'LC',
-          position: 'center',
-        },
-        {
-          type: 'separator',
-          position: 'center',
-        },
-        {
-          type: 'modeFlag',
-          signal: 'flag_flat_shift',
-          text: 'FS',
-          position: 'center',
-        },
-        {
-          type: 'separator',
-          position: 'center',
-        },
-        {
-          type: 'modeFlag',
-          signal: 'flag_traction_cut',
-          text: 'TC',
+          type: 'label',
+          text: 'MAP',
           position: 'center',
         },
         {
           type: 'signal',
           signal: 'map_number',
-          format: 'MAP%.0f',
-          position: 'right',
+          format: '%.0f',
+          position: 'center',
         },
         {
-          type: 'separator',
-          position: 'right',
-        },
-        {
-          type: 'bleIcon',
-          position: 'right',
-        },
-        {
-          type: 'themeToggle',
+          type: 'trackBadge',
           position: 'right',
         },
       ],


### PR DESCRIPTION
## What

Part 3/3 of the dash top-bar Track-mockup alignment (firmware CANShift/canshift-firmware#100 / PR #101 + #102, core PR #46 published as `@canshift/core@2.16.0`). This is the part that makes the Tuner canvas preview match the mockup.

## Changes

- Bumped `@canshift/core` → `^2.16.0` (adds the `canRate` top-bar kind).
- `DashTopBar` canvas mirror:
  - Flattened label + value colours to the mockup's uniform `dashDim` (`#BABABA` night / `#5A5A5A` day) with `letter-spacing: 0.1em`, mirroring the firmware canonical render (PR #102).
  - Added the `canRate` item (renders the bus rate, e.g. `842 Hz`).
  - `trackBadge` now renders the live lap readout (`LAP 4 · 1:38.42`) instead of the orange flag badge.
  - Added `map_number` to the preview values so the centre shows `MAP 1`.
- Recomposed `default-sim-config.ts`'s top bar to the mockup layout: `CAN` + `canRate` (left), `MAP` + `map_number` (center), `trackBadge` (right) — dropping the ALS/LC/FS/TC flags, BLE icon and theme toggle.

Font size stays 10px (`TopBarMetrics.labelFontPx`), per the decision to keep it legible rather than the mockup's ~6px-native nominal.

## Note

The lap separator here is the mockup's middle dot (`·`); the firmware canonical render (#102) uses spaces to avoid a baked-font glyph risk. Minor and easy to unify either way — flagging it.

## Test plan

- `npm run typecheck` ✓ · `npm run lint` ✓ · `npm run format:check` ✓ · `npm test` → 244 passed ✓ · `npm run build` ✓
- Visual: review the Vercel preview's dashboard canvas against `canshift-brand/docs/design/shots/tuner-wide.png` (no headless browser in this environment).