### PR TITLE
fix(tuner): typecheck api routes in CI

### DIFF
--- a/api/firmware-download.ts
+++ b/api/firmware-download.ts
@@ -15,7 +15,7 @@ const MAX_ASSET_BYTES = 16 * 1024 * 1024
 const hits = new Map<string, { count: number; resetAt: number }>()
 
 const clientIp = (req: Request): string =>
-  (req.headers.get('x-forwarded-for') ?? '').split(',')[0].trim() || 'unknown'
+  (req.headers.get('x-forwarded-for') ?? '').split(',')[0]?.trim() || 'unknown'
 
 const pruneExpired = (now: number): void => {
   for (const [key, value] of hits) {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,7 +46,7 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ['*.mjs', '*.config.ts', 'scripts/*.ts', 'api/*.ts'],
+          allowDefaultProject: ['*.mjs', '*.config.ts', 'scripts/*.ts'],
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,6 @@
       "@hooks/*": ["src/hooks/*"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "api/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
The Vercel production build has been reporting a type error that no CI check could see:

```
api/firmware-download.ts(18,3): error TS2532: Object is possibly 'undefined'.
Build Completed
```

`npm run typecheck` is `tsc --noEmit` against `"include": ["src/**/*"]`, so `api/` was outside the project entirely. Vercel type-checks serverless functions on its own, non-blocking — the error printed and the deployment shipped anyway. That left the edge function behind the firmware flasher (rate limiting, asset proxying) unchecked by anything.

## Changes

- `api/**/*` added to the tsconfig `include`, so `typecheck` covers it
- `split(',')[0]` is `string | undefined` under `noUncheckedIndexedAccess`; optional-chained the `.trim()`. The trailing `|| 'unknown'` already handled the empty case, so behaviour is unchanged
- `api/*.ts` removed from the ESLint `allowDefaultProject` list — now that the files belong to the project service, keeping them there is a parsing error

## Test plan
- `npm run typecheck` — clean, and now actually covers `api/`
- `npm run lint` — clean
- `npm test` — 45 files, 244 tests
- `npm run build` — clean