### PR TITLE
fix(tuner): restore the autosave only when it holds unsaved work

### DIFF
--- a/src/stores/dashboard.store.ts
+++ b/src/stores/dashboard.store.ts
@@ -8,7 +8,7 @@ import { createPagesSlice } from './dashboard/pages.slice'
 import { createSelectionSlice } from './dashboard/selection.slice'
 import { createThemeSlice } from './dashboard/theme.slice'
 import { createWidgetsSlice } from './dashboard/widgets.slice'
-import { readAutosave, startAutosave } from './dashboard/autosave'
+import { isRestorable, readAutosave, startAutosave } from './dashboard/autosave'
 import type { DashboardState } from './dashboard/types'
 
 export type { AlignDirection, DashboardState, LoadFromDeviceOrDemoResult } from './dashboard/types'
@@ -27,7 +27,7 @@ export const useDashboardStore = create<DashboardState>()(
 )
 
 const restored = readAutosave()
-if (restored) {
+if (isRestorable(restored)) {
   useDashboardStore.setState({
     config: restored.config,
     isDirty: restored.isDirty,

--- a/src/stores/dashboard/autosave.test.ts
+++ b/src/stores/dashboard/autosave.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { CURRENT_SCHEMA_VERSION } from '@canshift/core'
-import { parseAutosave, serializeAutosave } from './autosave'
+import { isRestorable, parseAutosave, serializeAutosave } from './autosave'
 import { DEFAULT_SIM_CONFIG } from '../../config/default-sim-config'
 
 const source = () => ({
@@ -49,5 +49,16 @@ describe('autosave (#1849)', () => {
   it('keeps the current schema version after migration passthrough', () => {
     const restored = parseAutosave(serializeAutosave(source(), 1) ?? '')
     expect(restored?.config.version).toBe(CURRENT_SCHEMA_VERSION)
+  })
+
+  it('only restores a snapshot that holds unsaved work', () => {
+    const dirty = parseAutosave(serializeAutosave(source(), 1) ?? '')
+    expect(isRestorable(dirty)).toBe(true)
+
+    const clean = parseAutosave(serializeAutosave({ ...source(), isDirty: false }, 1) ?? '')
+    expect(clean).not.toBeNull()
+    expect(isRestorable(clean)).toBe(false)
+
+    expect(isRestorable(null)).toBe(false)
   })
 })

--- a/src/stores/dashboard/autosave.ts
+++ b/src/stores/dashboard/autosave.ts
@@ -104,6 +104,9 @@ export const readAutosave = (): AutosavePayload | null => {
   return payload
 }
 
+export const isRestorable = (payload: AutosavePayload | null): payload is AutosavePayload =>
+  payload !== null && payload.isDirty
+
 interface AutosaveStore {
   getState: () => AutosaveSource & { markAutosaved: (ts: number) => void }
   subscribe: (listener: () => void) => () => void


### PR DESCRIPTION
Simulation was never showing the base config: the top bar restyle changed `DEFAULT_SIM_CONFIG`, shipped to production, and still rendered the old `CAN | ALS LC FS TC | BLE` bar in the browser.

## Why

`dashboard.store.ts` restores the autosave at module load, unconditionally. That single line shadows every other config source:

- `useSimulationBootstrap` applies `DEFAULT_SIM_CONFIG` only `if (simulationMode && !hasConfig)` — never reached
- `bootstrapProjects` loads the active project only `if (config === null)` — never reached either

So a snapshot taken once, months ago, pins the editor forever. Any change to the default config is invisible to anyone who has ever opened the tuner.

## Change

The autosave exists to protect *in-progress edits* across a reload. When `isDirty` is false it holds nothing that isn't already reproducible — the config came from a project, a device, a demo or the default, and `applyLoadedConfig` cleared the flag. Restoring it in that state buys nothing and costs the default.

Restoring is now gated on `isDirty`, behind a named `isRestorable` predicate so the rule is explicit and testable rather than a bare field access someone later "fixes" back.

Fallthrough is unchanged and already correct: no restore leaves `config === null`, so `bootstrapProjects` reloads the active named project if there is one, and simulation falls back to `DEFAULT_SIM_CONFIG` otherwise. Unsaved work still survives a reload exactly as before.

## Test plan
- `npm test` — 45 files, 245 tests; new case covers dirty / clean / null
- `npm run typecheck`, `npm run lint`, `npm run build` — clean
- Manual: with a stale clean autosave in `canshift.tuner.autosave`, simulation now boots on the current default top bar; with a dirty one, the edits come back