### PR TITLE
chore(tuner): bump @canshift/core to 2.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^2.16.0",
+        "@canshift/core": "^2.17.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.16.0.tgz",
-      "integrity": "sha512-H4euI8P+kTifd/nIegHSERdM/p4npv3FuMZmj3O3LbUHjBLs85L3UKIrL9XmccMO816jgJg0B7OyB9YDAza9hw==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.17.0.tgz",
+      "integrity": "sha512-w88JEq/7N29T+2pNyiIELlNCKGg3ZShtaK76nmU24+LR0ZY7cW28YaDYZ78wtJdFM/S+UmEfCD2byOcy/4Dzqg==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^2.16.0",
+    "@canshift/core": "^2.17.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",


### PR DESCRIPTION
Picks up the `1.28.0 → 1.29.0` track top bar migration (CANShift/canshift-core#47, closes CANShift/canshift-core#48).

Every config the tuner loads already runs through `migrateConfig` — the autosave in `parseAutosave`, named projects, `.canshift` imports, configs read back from a device. Bumping the dependency is all that is needed for the legacy flag bar to be rewritten to the track bar on load.

Verified against the published package:

```
target 1.29.0 | applied [ '1.28.0 → 1.29.0' ]
[{"type":"label","text":"CAN"…},{"type":"canRate"…},{"type":"label","text":"MAP"…},
 {"type":"signal","signal":"map_number","format":"%.0f"…},{"type":"trackBadge"…}]
```

A bar the user customised is left untouched — the migration only rewrites a layout byte-identical to the old default.

## Test plan
- `npm run typecheck`, `npm run lint`, `npm run build` — clean
- `npm test` — 45 files, 245 tests
- Migration exercised end-to-end against `@canshift/core@2.17.0` as above