### PR TITLE
docs: drop the icon banner from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # canshift-tuner
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset=".github/icons/tuner-dark.svg">
-  <img src=".github/icons/tuner.svg" alt="" height="72">
-</picture>
-
 Betaflight-style web configurator for CANShift dashes. Hosted on Vercel, talks
 to the firmware via **WebSerial** over the CH340 UART that already serves as
 the upload / serial port.


### PR DESCRIPTION
Removes the `<picture>` banner at the top of the README.

The SVGs under `.github/icons/` stay: only `<name>.svg` and `<name>-dark.svg` were used here, and they belong to a nine-variant set (appicon, avatar, maskable, onaccent, currentcolor, small) consumed elsewhere. Deleting two of the nine would leave the set incoherent for no gain.

Text-only change.