### PR TITLE
chore(tuner): bump @canshift/core to 2.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^2.17.0",
+        "@canshift/core": "^2.18.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.17.0.tgz",
-      "integrity": "sha512-w88JEq/7N29T+2pNyiIELlNCKGg3ZShtaK76nmU24+LR0ZY7cW28YaDYZ78wtJdFM/S+UmEfCD2byOcy/4Dzqg==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.18.0.tgz",
+      "integrity": "sha512-NwRgKW6QEXyHucVsNS/nhpcbUMygvp/u6XDY1syQYf9r0/UjdfX3GHGxBG9FvibQ7tW4nWLT6TbU29WSTYTEaw==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^2.17.0",
+    "@canshift/core": "^2.18.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",


### PR DESCRIPTION
Picks up the three CAN XML import fixes from CANShift/canshift-core#50, which is where the ECU profile importer in this app gets its parser.

Across the 37 profiles in [janimm/RealDash-extras](https://github.com/janimm/RealDash-extras):

| | signals | warnings |
|---|---|---|
| before | 2694 | 143 |
| after | 2787 | 7 |

- Bit indices above 7 are re-based onto their carrier byte instead of dropping the signal — this alone recovers 89 signals, including every Adaptronic digital input and flag above bit 7
- The `Ambiguous frame id` warnings are gone; bareword ids are decimal by spec, so the parser was warning about its own correct behaviour
- Three-byte values are accepted (Toyota, Flagtronics, BMW profiles), and a genuinely unsupported width now says `must be 1, 2, 3 or 4 bytes` rather than `Invalid input`

What is left across the whole library is 5 cross-signal expressions (deferred to v2) and 2 five-byte GM fields that cannot fit the decoder's `u32`.

## Test plan
- `npm run typecheck`, `npm run lint`, `npm run build` — clean
- `npm test` — 45 files, 245 tests