### PR TITLE
fix(tuner): blank the sidebar TARGET row when no device is connected

### DIFF
--- a/src/components/shell/Sidebar.tsx
+++ b/src/components/shell/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { NavLink, useLocation } from 'react-router-dom'
-import { resolveScreenProfile } from '@canshift/core'
 import { SidebarView, type SidebarLinkProps } from './SidebarView'
+import { resolveTargetLabel } from './target-label'
 import { CollapseRail } from './CollapseRail'
 import { useConnectionStore } from '../../stores/connection.store'
 import { useDashboardStore } from '../../stores/dashboard.store'
@@ -22,7 +22,7 @@ const Sidebar = () => {
   const collapsed = useUiStore((s) => s.leftNavCollapsed)
   const toggleLeftNav = useUiStore((s) => s.toggleLeftNav)
   const offline = status !== 'connected' && !simulationMode
-  const targetLabel = resolveScreenProfile(targetProfile).name
+  const targetLabel = resolveTargetLabel(offline, targetProfile)
 
   if (collapsed) {
     return <CollapseRail side="left" label="Menu" onExpand={toggleLeftNav} />

--- a/src/components/shell/target-label.test.ts
+++ b/src/components/shell/target-label.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTargetLabel } from './target-label'
+
+describe('sidebar TARGET label', () => {
+  it('is blank while offline, even when the config names a profile', () => {
+    expect(resolveTargetLabel(true, 'crowpanel-28')).toBeNull()
+  })
+
+  it('is blank when connected but the config names no profile', () => {
+    expect(resolveTargetLabel(false, undefined)).toBeNull()
+  })
+
+  it('names the profile when connected and the config sets one', () => {
+    expect(resolveTargetLabel(false, 'crowpanel-28')).toBe('CrowPanel 2.8"')
+  })
+})

--- a/src/components/shell/target-label.ts
+++ b/src/components/shell/target-label.ts
@@ -1,0 +1,7 @@
+import { resolveScreenProfile, type ScreenProfileId } from '@canshift/core'
+
+export const resolveTargetLabel = (
+  offline: boolean,
+  targetProfile: ScreenProfileId | undefined
+): string | null =>
+  offline || targetProfile === undefined ? null : resolveScreenProfile(targetProfile).name


### PR DESCRIPTION
Closes #63.

With nothing plugged in, the sidebar footer read:

```
TARGET     CrowPanel 2.8"
FIRMWARE   —
```

Two rows side by side contradicting each other. FIRMWARE honestly reported "unknown"; TARGET named a specific board as if it had been detected.

`resolveScreenProfile` falls back to `DEFAULT_SCREEN_PROFILE_ID` whenever its argument is undefined, so the row always rendered a concrete name — frequently a library default nobody had chosen. A user with a generic ILI9341 wired up saw "CrowPanel 2.8"" and no reason to doubt it.

The row now means what its label implies: connected hardware. It reads `—` unless a device (or simulation) is live *and* the config names a profile, matching the FIRMWARE row directly below it.

`resolveTargetLabel` is a separate module rather than an inline expression because the tuner's vitest runs in node with no DOM, so a rendering test is not available — a pure function is what can actually be covered here.

## Test plan
- `npm test` — 46 files, 248 tests; three new cases (offline with a profile, connected without one, connected with one)
- `npm run typecheck`, `npm run lint`, `npm run build` — clean