### PR TITLE
chore(tuner): bump @canshift/core to 2.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^2.18.0",
+        "@canshift/core": "^2.19.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.18.0.tgz",
-      "integrity": "sha512-NwRgKW6QEXyHucVsNS/nhpcbUMygvp/u6XDY1syQYf9r0/UjdfX3GHGxBG9FvibQ7tW4nWLT6TbU29WSTYTEaw==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.19.0.tgz",
+      "integrity": "sha512-NcFilvUTSTf0wfQTR3C8FXsQrf8Xuc/SL77dOqVrMmr+xUHSrLiS31Yu6KRzvN3H6JmhLCmKeBvj+iTrUeF7WQ==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^2.18.0",
+    "@canshift/core": "^2.19.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",


### PR DESCRIPTION
Picks up CANShift/canshift-core#57 — frames declaring `canId` instead of `id` are now readable, and no frame is ever dropped without a warning.

`toyota_fj_can.xml` was importing as 0 signals with 0 warnings; the app reported `Catalogue load failed — no signals found` and there was nothing to explain it.

| profile | before | after |
|---|---|---|
| Toyota FJ Cruiser | 0 signals | 40 |
| BMW 335i | 3 signals | 29 |

## Test plan
- `npm run typecheck`, `npm run lint`, `npm run build` — clean
- `npm test` — 46 files, 248 tests