### PR TITLE
chore(tuner): bump @canshift/core to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^2.19.0",
+        "@canshift/core": "^3.0.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,12 +349,12 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-2.19.0.tgz",
-      "integrity": "sha512-NcFilvUTSTf0wfQTR3C8FXsQrf8Xuc/SL77dOqVrMmr+xUHSrLiS31Yu6KRzvN3H6JmhLCmKeBvj+iTrUeF7WQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-aOuCKYZZ01sftY5a0hefRpYhZarAv+RBpPdaPPPI5+mEhdQs9qe/dIcmks61R8XrIN2RKUjWm3o3b0jc6hJKZA==",
       "license": "UNLICENSED",
       "dependencies": {
-        "zod": "^3.23.8"
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -7685,9 +7685,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^2.19.0",
+    "@canshift/core": "^3.0.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",


### PR DESCRIPTION
Picks up CANShift/canshift-core#65 — the zod 4 migration — released as 3.0.0 rather than a minor because `DeviceConfigResult.issues` and `InputBindingsResult.issues` are publicly exported and their type changed.

This PR is the actual verification of that migration. The consumer analysis in the core PR was inspection; this is the tuner's own CI compiling and running against the published package.

## What was uncertain, and what the build says

`device-ipc.ts` calls `issue.path.join('.')` on issues from a core schema. In zod 4 `path` widens from `(string | number)[]` to `PropertyKey[]`, which can hold symbols. `join` exists on that type, so it compiles — confirmed by `tsc --noEmit` passing.

The runtime edge remains theoretical: `join` on an array containing a symbol throws, and zod does not emit symbol path segments for JSON input. Not worth guarding against speculatively; noted so the next person meeting a `Cannot convert a Symbol value to a string` knows where it would come from.

The tuner has no direct zod dependency, so it now resolves zod 4.4.3 through core alone — one copy, no duplicate in the bundle. Bundle size is unchanged at 376.67 kB.

## Test plan
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 47 files, 257 tests
- `npm run build` — clean
- Verified the resolved tree: `@canshift/core@3.0.0`, `zod@4.4.3`, a single zod copy in `vendor-core`
