### PR TITLE
fix(tuner): gate PostHog and Vercel Analytics behind consent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Browser configurator for CANShift dashes (org: github.com/CANShift). Vite + Reac
 - Components live under `src/components/<area>/` with a props interface; check `src/components/ui/` (shadcn) before writing bespoke UI. Arrow functions, no comments, no nested ifs.
 - Zero comments policy; TS strict; wire-format JSON stays snake_case via boundary mappers.
 - Never write "RealDash" outside the literal `<RealDashCAN>` parser tag.
-- Observability: PostHog lives behind env (`VITE_POSTHOG_KEY`); scrub car data (payloads, frame ids, names) from anything sent; opt-out must keep working.
+- Observability: PostHog lives behind env (`VITE_POSTHOG_KEY`) _and_ behind consent — telemetry is opt-in, so nothing may load or beacon until `isObservabilityEnabled()` is true; scrub car data (payloads, frame ids, names) from anything sent.
 - Flasher reads releases from CANShift/canshift-firmware.
 
 ## Workflow

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ the upload / serial port.
   switch as one unit; the CAN scan and Learn mode keep running across views.
 - Burn gate — unbound widgets render the device's `--` placeholder, are
   counted in the toolbar, and prompt once before burning.
-- Observability with a visible opt-out (About view): PostHog flow events;
+- Observability is opt-in (About view, off by default): nothing is loaded or
+  requested until the toggle is on. Once on, PostHog flow events only —
   payloads, frame ids and names are scrubbed client-side.
 
 ## Dev
@@ -42,7 +43,7 @@ npm run build
 ```
 
 Optional env: `VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST` (analytics) — no-op when
-unset.
+unset, and no-op until the user opts in.
 
 WebSerial requires Chrome / Edge / Brave / Opera. Firefox + Safari users get
 a friendly fallback message.

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -1,19 +1,11 @@
 import posthog from 'posthog-js'
-import { isObservabilityEnabled, useObservabilityStore } from '../stores/observability.store'
+import { isObservabilityEnabled } from '../stores/observability.store'
 import { scrubProps } from './scrub'
 
-let initialized = false
+let started = false
 
-const syncConsent = (enabled: boolean): void => {
-  if (enabled) {
-    if (posthog.has_opted_out_capturing()) posthog.opt_in_capturing()
-  } else if (!posthog.has_opted_out_capturing()) {
-    posthog.opt_out_capturing()
-  }
-}
-
-export const initPostHog = (): void => {
-  if (initialized) return
+export const startPostHog = (): void => {
+  if (started) return
   const key = import.meta.env.VITE_POSTHOG_KEY
   if (!key) return
   const host = import.meta.env.VITE_POSTHOG_HOST ?? 'https://eu.i.posthog.com'
@@ -25,20 +17,23 @@ export const initPostHog = (): void => {
     persistence: 'localStorage',
     person_profiles: 'identified_only',
   })
-  syncConsent(isObservabilityEnabled())
-  useObservabilityStore.subscribe((state) => {
-    syncConsent(state.enabled)
-  })
-  initialized = true
+  started = true
+}
+
+export const setPostHogCapturing = (enabled: boolean): void => {
+  if (!started) return
+  if (enabled) {
+    if (posthog.has_opted_out_capturing()) posthog.opt_in_capturing()
+  } else if (!posthog.has_opted_out_capturing()) {
+    posthog.opt_out_capturing()
+  }
 }
 
 export const captureFlowEvent = (name: string, props: Record<string, unknown> = {}): void => {
-  if (!initialized || !isObservabilityEnabled()) return
+  if (!started || !isObservabilityEnabled()) return
   posthog.capture(name, {
     ...scrubProps(props),
     app: 'canshift-tuner',
     tunerVersion: __TUNER_VERSION__,
   })
 }
-
-export const isPostHogReady = (): boolean => initialized

--- a/src/lib/telemetry.test.ts
+++ b/src/lib/telemetry.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const posthogMock = vi.hoisted(() => ({
+  init: vi.fn(),
+  capture: vi.fn(),
+  opt_in_capturing: vi.fn(),
+  opt_out_capturing: vi.fn(),
+  has_opted_out_capturing: vi.fn(() => false),
+}))
+
+const injectMock = vi.hoisted(() => vi.fn())
+
+vi.mock('posthog-js', () => ({ default: posthogMock }))
+vi.mock('@vercel/analytics', () => ({ inject: injectMock }))
+
+const memoryStorage = (): Storage => {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => {
+      map.clear()
+    },
+    getItem: (k: string) => map.get(k) ?? null,
+    key: (i: number) => [...map.keys()][i] ?? null,
+    removeItem: (k: string) => {
+      map.delete(k)
+    },
+    setItem: (k: string, v: string) => {
+      map.set(k, v)
+    },
+  }
+}
+
+const loadTelemetry = async () => {
+  vi.stubEnv('VITE_POSTHOG_KEY', 'phc_test')
+  vi.resetModules()
+  const store = await import('../stores/observability.store')
+  const telemetry = await import('./telemetry')
+  return { ...store, ...telemetry }
+}
+
+describe('telemetry consent gate', () => {
+  beforeEach(() => {
+    globalThis.localStorage = memoryStorage()
+    posthogMock.has_opted_out_capturing.mockReturnValue(false)
+    vi.clearAllMocks()
+  })
+
+  it('starts nothing while the store is off, key set or not', async () => {
+    const { initTelemetry } = await loadTelemetry()
+    initTelemetry()
+    expect(posthogMock.init).not.toHaveBeenCalled()
+    expect(injectMock).not.toHaveBeenCalled()
+  })
+
+  it('starts both beacons when consent is already stored', async () => {
+    localStorage.setItem('canshift.tuner.observability', 'on')
+    const { initTelemetry } = await loadTelemetry()
+    initTelemetry()
+    expect(posthogMock.init).toHaveBeenCalledTimes(1)
+    expect(injectMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('starts both beacons when the user opts in later', async () => {
+    const { initTelemetry, useObservabilityStore } = await loadTelemetry()
+    initTelemetry()
+    useObservabilityStore.getState().setEnabled(true)
+    expect(posthogMock.init).toHaveBeenCalledTimes(1)
+    expect(injectMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('opts capturing out again when the user opts back out', async () => {
+    const { initTelemetry, useObservabilityStore } = await loadTelemetry()
+    initTelemetry()
+    useObservabilityStore.getState().setEnabled(true)
+    useObservabilityStore.getState().setEnabled(false)
+    expect(posthogMock.opt_out_capturing).toHaveBeenCalledTimes(1)
+    expect(posthogMock.init).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops web-analytics events while consent is off', async () => {
+    const { initTelemetry, useObservabilityStore } = await loadTelemetry()
+    initTelemetry()
+    useObservabilityStore.getState().setEnabled(true)
+    const beforeSend = injectMock.mock.calls[0]?.[0]?.beforeSend as (e: unknown) => unknown
+    const event = { type: 'pageview', url: 'https://canshift.app/' }
+    expect(beforeSend(event)).toBe(event)
+    useObservabilityStore.getState().setEnabled(false)
+    expect(beforeSend(event)).toBeNull()
+  })
+})

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,29 @@
+import { inject } from '@vercel/analytics'
+import { isObservabilityEnabled, useObservabilityStore } from '../stores/observability.store'
+import { setPostHogCapturing, startPostHog } from './posthog'
+
+let subscribed = false
+let webAnalyticsStarted = false
+
+const startWebAnalytics = (): void => {
+  if (webAnalyticsStarted) return
+  inject({ beforeSend: (event) => (isObservabilityEnabled() ? event : null) })
+  webAnalyticsStarted = true
+}
+
+const applyConsent = (enabled: boolean): void => {
+  if (enabled) {
+    startPostHog()
+    startWebAnalytics()
+  }
+  setPostHogCapturing(enabled)
+}
+
+export const initTelemetry = (): void => {
+  applyConsent(isObservabilityEnabled())
+  if (subscribed) return
+  useObservabilityStore.subscribe((state) => {
+    applyConsent(state.enabled)
+  })
+  subscribed = true
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,10 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
-import { inject } from '@vercel/analytics'
-import { initPostHog } from './lib/posthog'
+import { initTelemetry } from './lib/telemetry'
 import './index.css'
 
-inject()
-initPostHog()
+initTelemetry()
 
 const root = document.getElementById('root')
 if (!root) throw new Error('Root element not found')


### PR DESCRIPTION
Closes #70.

## What

Telemetry is opt-in by decision (#49), but both beacons fired before consent was ever consulted: `posthog.init()` ran from `main.tsx` whenever `VITE_POSTHOG_KEY` was set — hitting `/flags` and persisting a `distinct_id` — and `inject()` ran unconditionally, outside the About toggle entirely.

Both are now hard-gated on `isObservabilityEnabled()`. With the store at `false`, nothing loads, nothing is requested, nothing is stored.

## How

- New `src/lib/telemetry.ts` owns the gate: it applies the stored consent on startup, subscribes to the store once, and starts each beacon lazily the first time consent turns on.
- `src/lib/posthog.ts` splits into `startPostHog()` (init, once) and `setPostHogCapturing(enabled)` (opt in / out once started). `initPostHog()` and its unused `isPostHogReady()` export are gone.
- Vercel Web Analytics has no opt-out API, so `inject()` is passed `beforeSend: (event) => (isObservabilityEnabled() ? event : null)` — the script is never loaded before consent, and every event is dropped if the user toggles back off.
- `main.tsx` now calls `initTelemetry()` only.
- README described this as "a visible opt-out"; since #49 it is opt-**in**, and that wording was a compliance statement contradicting the code. Corrected, along with the matching rule in `CLAUDE.md`.

## Test plan

`src/lib/telemetry.test.ts` (5 cases), with `posthog-js` and `@vercel/analytics` mocked and `VITE_POSTHOG_KEY` set throughout:

- store off → neither `posthog.init` nor `inject` is called
- consent already stored on → both start once
- consent turned on later → both start once
- toggled on then off → `opt_out_capturing` fires, `init` is not re-run
- `beforeSend` returns the event while consent is on, `null` after it is turned off

Full suite: 262 tests / 48 files green. `typecheck`, `lint`, `format:check`, `build` all pass.