### PR TITLE
fix(tuner): cover the whole firmware download with the timeout and require a checksum

### DIFF
--- a/api/firmware-download.ts
+++ b/api/firmware-download.ts
@@ -35,6 +35,20 @@ const rateLimited = (ip: string): boolean => {
   return false
 }
 
+const cappedStream = (): TransformStream<Uint8Array, Uint8Array> => {
+  let forwarded = 0
+  return new TransformStream({
+    transform: (chunk, controller) => {
+      forwarded += chunk.byteLength
+      if (forwarded > MAX_ASSET_BYTES) {
+        controller.error(new Error('asset_too_large'))
+        return
+      }
+      controller.enqueue(chunk)
+    },
+  })
+}
+
 const respond = (status: number, body: string, headers: HeadersInit = {}): Response =>
   new Response(body, {
     status,
@@ -46,8 +60,8 @@ const handler = async (req: Request): Promise<Response> => {
   const tag = url.searchParams.get('tag')
   const asset = url.searchParams.get('asset')
 
-  if (!tag || !TAG_RE.test(tag)) return respond(400, 'bad_tag')
-  if (!asset || !ASSET_RE.test(asset)) return respond(400, 'bad_asset')
+  if (!tag || !TAG_RE.test(tag) || tag.includes('..')) return respond(400, 'bad_tag')
+  if (!asset || !ASSET_RE.test(asset) || asset.includes('..')) return respond(400, 'bad_asset')
 
   if (rateLimited(clientIp(req))) {
     return respond(429, 'rate_limited', {
@@ -77,7 +91,7 @@ const handler = async (req: Request): Promise<Response> => {
   })
   if (length) passHeaders.set('Content-Length', length)
 
-  return new Response(upstream.body, {
+  return new Response(upstream.body.pipeThrough(cappedStream()), {
     status: 200,
     headers: passHeaders,
   })

--- a/src/lib/firmware/download.test.ts
+++ b/src/lib/firmware/download.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ReleaseAsset } from '@canshift/core'
+import { downloadFirmwareAsset, firmwareAssetProxyUrl } from './download'
+import { computeSha256Hex } from './hash'
+import { FIRMWARE_MAX_BYTES } from './local-firmware'
+
+const DOWNLOAD_URL =
+  'https://github.com/CANShift/canshift-firmware/releases/download/v1.2.3/canshift-crowpanel_28-v1.2.3-merged.bin'
+
+const IMAGE = new Uint8Array([0xe9, 0x01, 0x02, 0x03])
+
+const assetWith = (overrides: Partial<ReleaseAsset> = {}): ReleaseAsset => ({
+  name: 'canshift-crowpanel_28-v1.2.3-merged.bin',
+  downloadUrl: DOWNLOAD_URL,
+  sizeBytes: IMAGE.byteLength,
+  ...overrides,
+})
+
+const streamOf = (chunks: Uint8Array[], signal: AbortSignal, close: boolean): ReadableStream =>
+  new ReadableStream<Uint8Array>({
+    start: (controller) => {
+      for (const chunk of chunks) controller.enqueue(chunk)
+      if (close) {
+        controller.close()
+        return
+      }
+      signal.addEventListener('abort', () => {
+        controller.error(new DOMException('Aborted', 'AbortError'))
+      })
+    },
+  })
+
+const mockFetch = (chunks: Uint8Array[], close = true): void => {
+  vi.stubGlobal('fetch', (_url: string, init?: { signal?: AbortSignal }) => {
+    const signal = init?.signal ?? new AbortController().signal
+    return Promise.resolve(new Response(streamOf(chunks, signal, close), { status: 200 }))
+  })
+}
+
+describe('firmwareAssetProxyUrl', () => {
+  it('maps a release URL onto the proxy', () => {
+    expect(firmwareAssetProxyUrl(DOWNLOAD_URL)).toBe(
+      '/api/firmware-download?tag=v1.2.3&asset=canshift-crowpanel_28-v1.2.3-merged.bin'
+    )
+  })
+
+  it('rejects a URL that is not shaped like a release asset', () => {
+    expect(() => firmwareAssetProxyUrl('https://github.com/CANShift')).toThrow(/Unrecognised/)
+  })
+})
+
+describe('downloadFirmwareAsset', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('returns the image when the published digest matches', async () => {
+    const sha256 = await computeSha256Hex(IMAGE)
+    mockFetch([IMAGE])
+    const firmware = await downloadFirmwareAsset(assetWith({ digest: `sha256:${sha256}` }))
+    expect(firmware.sha256).toBe(sha256)
+    expect(firmware.size).toBe(IMAGE.byteLength)
+  })
+
+  it('reports progress against the announced size', async () => {
+    const sha256 = await computeSha256Hex(IMAGE)
+    mockFetch([IMAGE.slice(0, 2), IMAGE.slice(2)])
+    const seen: [number, number][] = []
+    await downloadFirmwareAsset(assetWith({ digest: sha256 }), (loaded, total) => {
+      seen.push([loaded, total])
+    })
+    expect(seen).toEqual([
+      [2, 4],
+      [4, 4],
+    ])
+  })
+
+  it('rejects an asset published without a digest', async () => {
+    mockFetch([IMAGE])
+    await expect(downloadFirmwareAsset(assetWith())).rejects.toThrow(/No checksum published/)
+  })
+
+  it('rejects an asset whose digest is not a sha256 hex string', async () => {
+    mockFetch([IMAGE])
+    await expect(downloadFirmwareAsset(assetWith({ digest: 'sha256:nope' }))).rejects.toThrow(
+      /Unusable checksum/
+    )
+  })
+
+  it('rejects an image whose bytes do not match the digest', async () => {
+    const wrong = await computeSha256Hex(new Uint8Array([0xe9, 0xff]))
+    mockFetch([IMAGE])
+    await expect(downloadFirmwareAsset(assetWith({ digest: wrong }))).rejects.toThrow(
+      /Checksum mismatch/
+    )
+  })
+
+  it('aborts a stream that outgrows the size cap regardless of the announced size', async () => {
+    const megabyte = new Uint8Array(1024 * 1024)
+    megabyte[0] = 0xe9
+    const chunks = Array.from({ length: FIRMWARE_MAX_BYTES / megabyte.byteLength + 1 }, () =>
+      megabyte.slice()
+    )
+    mockFetch(chunks)
+    await expect(
+      downloadFirmwareAsset(assetWith({ digest: 'sha256:' + 'a'.repeat(64) }))
+    ).rejects.toThrow(/Download exceeded/)
+  })
+
+  it('aborts a body that stalls mid-transfer', async () => {
+    vi.useFakeTimers()
+    mockFetch([IMAGE.slice(0, 2)], false)
+    const pending = downloadFirmwareAsset(assetWith({ digest: 'sha256:' + 'a'.repeat(64) }))
+    const assertion = expect(pending).rejects.toThrow(/stalled/)
+    await vi.advanceTimersByTimeAsync(20_000)
+    await assertion
+  })
+
+  it('does not accept an empty body', async () => {
+    mockFetch([])
+    await expect(
+      downloadFirmwareAsset(assetWith({ digest: 'sha256:' + 'a'.repeat(64) }))
+    ).rejects.toThrow(/Downloaded firmware is empty/)
+  })
+})

--- a/src/lib/firmware/download.ts
+++ b/src/lib/firmware/download.ts
@@ -5,7 +5,9 @@ import { FIRMWARE_MAX_BYTES, LocalFirmwareError } from './local-firmware'
 import type { LocalFirmware } from './local-firmware'
 
 const DIGEST_PREFIX = 'sha256:'
-const FETCH_TIMEOUT_MS = 30_000
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/
+const HEADERS_TIMEOUT_MS = 30_000
+const STALL_TIMEOUT_MS = 15_000
 
 export type DownloadProgress = (loaded: number, total: number) => void
 
@@ -23,6 +25,26 @@ export const firmwareAssetProxyUrl = (downloadUrl: string): string => {
   return `${PROXY_PATH}?${params.toString()}`
 }
 
+const expectedDigestHex = (asset: ReleaseAsset): string => {
+  const raw = asset.digest
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new Error(
+      `No checksum published for ${asset.name} — refusing to flash an image that cannot be verified.`
+    )
+  }
+  const hex = (raw.startsWith(DIGEST_PREFIX) ? raw.slice(DIGEST_PREFIX.length) : raw).toLowerCase()
+  if (!SHA256_HEX_RE.test(hex)) {
+    throw new Error(`Unusable checksum published for ${asset.name}: ${raw}`)
+  }
+  return hex
+}
+
+const oversized = (received: number): LocalFirmwareError =>
+  new LocalFirmwareError(
+    'too-large',
+    `Download exceeded ${String(FIRMWARE_MAX_BYTES)} bytes (${String(received)} received) — aborted.`
+  )
+
 export const downloadFirmwareAsset = async (
   asset: ReleaseAsset,
   onProgress?: DownloadProgress
@@ -34,42 +56,58 @@ export const downloadFirmwareAsset = async (
     )
   }
 
+  const expected = expectedDigestHex(asset)
   const proxyUrl = firmwareAssetProxyUrl(asset.downloadUrl)
 
   const controller = new AbortController()
-  const timer = setTimeout(() => {
+  let timedOut = false
+  const abortAsTimeout = (): void => {
+    timedOut = true
     controller.abort()
-  }, FETCH_TIMEOUT_MS)
+  }
+  let watchdog = setTimeout(abortAsTimeout, HEADERS_TIMEOUT_MS)
+  const arm = (ms: number): void => {
+    clearTimeout(watchdog)
+    watchdog = setTimeout(abortAsTimeout, ms)
+  }
 
-  let response: Response
+  let bytes: Uint8Array
   try {
-    response = await fetch(proxyUrl, { signal: controller.signal })
+    const response = await fetch(proxyUrl, { signal: controller.signal })
+    if (!response.ok) {
+      throw new Error(`Download failed: HTTP ${String(response.status)}`)
+    }
+    arm(STALL_TIMEOUT_MS)
+    bytes = await readWithProgress(
+      response,
+      asset.sizeBytes,
+      () => {
+        arm(STALL_TIMEOUT_MS)
+      },
+      onProgress
+    )
+  } catch (err) {
+    if (timedOut) {
+      throw new Error(
+        `Download stalled — no data for ${String(STALL_TIMEOUT_MS / 1000)} s. Check the connection and retry.`,
+        { cause: err }
+      )
+    }
+    throw err
   } finally {
-    clearTimeout(timer)
+    clearTimeout(watchdog)
   }
 
-  if (!response.ok) {
-    throw new Error(`Download failed: HTTP ${String(response.status)}`)
-  }
-
-  const bytes = await readWithProgress(response, asset.sizeBytes, onProgress)
   if (bytes.byteLength === 0) {
     throw new LocalFirmwareError('empty', 'Downloaded firmware is empty.')
   }
 
   verifyImageMagic(bytes)
   const sha256 = await computeSha256Hex(bytes)
-
-  const expected = asset.digest
-  if (typeof expected === 'string') {
-    const expectedHex = expected.startsWith(DIGEST_PREFIX)
-      ? expected.slice(DIGEST_PREFIX.length).toLowerCase()
-      : expected.toLowerCase()
-    if (expectedHex !== sha256) {
-      throw new Error(
-        `Checksum mismatch — expected ${expectedHex.slice(0, 12)}…, got ${sha256.slice(0, 12)}…`
-      )
-    }
+  if (expected !== sha256) {
+    throw new Error(
+      `Checksum mismatch — expected ${expected.slice(0, 12)}…, got ${sha256.slice(0, 12)}…`
+    )
   }
 
   return { name: asset.name, size: bytes.byteLength, bytes, sha256 }
@@ -78,11 +116,13 @@ export const downloadFirmwareAsset = async (
 const readWithProgress = async (
   response: Response,
   expectedSize: number,
+  onChunk: () => void,
   onProgress?: DownloadProgress
 ): Promise<Uint8Array> => {
   const reader = response.body?.getReader()
   if (!reader) {
     const buffer = await response.arrayBuffer()
+    if (buffer.byteLength > FIRMWARE_MAX_BYTES) throw oversized(buffer.byteLength)
     onProgress?.(buffer.byteLength, expectedSize)
     return new Uint8Array(buffer)
   }
@@ -91,8 +131,13 @@ const readWithProgress = async (
   while (true) {
     const { done, value } = await reader.read()
     if (done) break
-    chunks.push(value)
     received += value.byteLength
+    if (received > FIRMWARE_MAX_BYTES) {
+      await reader.cancel()
+      throw oversized(received)
+    }
+    chunks.push(value)
+    onChunk()
     onProgress?.(received, expectedSize)
   }
   const out = new Uint8Array(received)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,12 +34,12 @@ const firmwareDownloadDevProxy = (): Plugin => ({
       const url = new URL(req.url ?? '', 'http://localhost')
       const tag = url.searchParams.get('tag')
       const asset = url.searchParams.get('asset')
-      if (!tag || !FIRMWARE_TAG_RE.test(tag)) {
+      if (!tag || !FIRMWARE_TAG_RE.test(tag) || tag.includes('..')) {
         res.statusCode = 400
         res.end('bad_tag')
         return
       }
-      if (!asset || !FIRMWARE_ASSET_RE.test(asset)) {
+      if (!asset || !FIRMWARE_ASSET_RE.test(asset) || asset.includes('..')) {
         res.statusCode = 400
         res.end('bad_asset')
         return


### PR DESCRIPTION
Closes #69.

## What

Three gaps on the path between a GitHub release and `esptool.writeFlash`.

**The timeout only covered the headers.** `clearTimeout` sat in a `finally` on the `fetch()` call, so the abort timer was gone before `readWithProgress()` streamed a single byte. A connection that stalled mid-body never aborted — frozen progress bar, no error, no retry, no way out short of a page reload.

**The size guard trusted the GitHub API.** `FIRMWARE_MAX_BYTES` was checked against `asset.sizeBytes` (metadata), while the read loop accumulated chunks into an unbounded array.

**The checksum was optional.** When `asset.digest` was absent the download was accepted on `verifyImageMagic()` alone — one magic byte standing between a truncated transfer and a flash.

## How

`src/lib/firmware/download.ts`:

- One `AbortController` with a re-armed watchdog: 30 s for the headers, then 15 s per chunk, re-armed on every chunk. `controller.signal` reaches the body read, so a dead transfer aborts while a slow-but-alive one is left alone. A watchdog abort is reported as `Download stalled — no data for 15 s.` rather than a bare `AbortError`.
- `FIRMWARE_MAX_BYTES` is enforced on `received` inside the read loop — the reader is cancelled the moment it is crossed — and on the bufferless `arrayBuffer()` fallback.
- The digest is mandatory. `expectedDigestHex()` accepts `sha256:<hex>` or a bare hex string, and refuses anything else: an asset published without a digest fails with `No checksum published for <name> — refusing to flash an image that cannot be verified.`

`api/firmware-download.ts` had the mirror-image size hole — it forwarded the upstream body unconditionally and only checked `MAX_ASSET_BYTES` when upstream sent a `Content-Length`. The body now goes through a counting `TransformStream` that errors past the cap. `..` is rejected in both the tag and the asset name (harmless today given the fixed host, but it costs nothing); the vite dev proxy gets the same two guards so dev and prod validate identically.

## Deviation from the issue

The issue proposed falling back to a sha256 in the release `manifest.json` when `asset.digest` is missing. That manifest carries no checksums — `.github/workflows/release.yml` in canshift-firmware builds it from the static `boards.json`, in a job that never sees the artifacts, and the parsed shape is `{id, chip, display, touch, artifacts: {merged, firmware, spiffs}}` — filenames only. There is nothing to fall back to, so wiring the fallback now would be a branch that can never be taken.

Making it mandatory from `asset.digest` alone is safe here: GitHub populates `digest` on every newly uploaded release asset, and canshift-firmware has no published releases yet, so every asset the flasher will ever see carries one. Filed CANShift/canshift-firmware#119 to emit per-artifact checksums in the manifest; the fallback becomes worth adding once that lands.

## Test plan

New `src/lib/firmware/download.test.ts` — 10 cases over a mocked `fetch` whose stream honours the abort signal:

- digest match returns the image; progress is reported against the announced size
- asset with no digest is rejected; malformed digest is rejected; byte mismatch is rejected
- a stream that outgrows the cap aborts even when `sizeBytes` announced 4 bytes
- a body that stalls after the first chunk aborts on the watchdog (fake timers)
- an empty body is rejected
- proxy-URL mapping and its rejection path

Full suite: 267 tests / 48 files green. `typecheck`, `lint`, `format:check`, `build` all pass.