### PR TITLE
chore(tuner): lock the lint toolchain majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,18 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # The lint toolchain moves as one deliberate PR — @eslint/js ships the
+      # flat-config rule sets cut from a specific eslint core, so a lone major
+      # on either side is an engine/rule-set mismatch.
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@eslint/js'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@typescript-eslint/*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript-eslint'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Part of CANShift/canshift-mobile#71.

## What

`dependabot.yml` here has no `ignore` list at all, so nothing stops `@eslint/js` and `eslint` from moving apart. They are coherent today only by accident of both sitting on 10:

```
├─┬ @eslint/js@10.0.1
│ └── eslint@10.8.0 deduped
```

Mobile hit the failure mode this prevents: its config ignored `eslint` majors but not `@eslint/js`, which walked through to 10.0.1 against an eslint 9 engine and left an `invalid` peer that `npm run lint` happily ignored until it would have surfaced as a confusing rule error on an unrelated PR.

## How

Adds the four entries so the whole lint toolchain moves as one deliberate PR: `eslint`, `@eslint/js`, `@typescript-eslint/*` and the unscoped `typescript-eslint` meta-package — that last one matters because the scoped glob does not match it, which is the second hole mobile had.

Config only; no dependency versions change.

## Test plan

Nothing to run — `dependabot.yml` is not consumed by CI. `npm ls eslint @eslint/js typescript-eslint` still resolves to a single deduped `eslint@10.8.0` with no invalid peers. The required `lint` / `typecheck` / `test` / `build` checks confirm the working tree is untouched.