### PR TITLE
perf(tuner): serve hashed assets immutable and tighten the CSP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api.github.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://tmbk.ch; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api.github.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://tmbk.ch; worker-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api.github.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://*.ingest.de.sentry.io https://tmbk.ch; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api.github.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://tmbk.ch; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
@@ -16,6 +16,10 @@
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
         { "key": "Permissions-Policy", "value": "serial=(self)" }
       ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
     }
   ]
 }


### PR DESCRIPTION
Closes #73.

## What

Measured on production:

```
$ curl -sI https://tuner.canshift.app/assets/index-CGS_q7z3.js
cache-control: public, max-age=14400, must-revalidate
```

Every file under `/assets/` carries a Rollup content hash, so it is immutable by construction — a new build produces a new filename. The 4-hour TTL plus `must-revalidate` made returning visitors pay a revalidation round-trip across the whole chunk graph (vendor-react, vendor-radix, vendor-core, the app bundle).

The CSP also still allow-listed `https://*.ingest.de.sentry.io` in `connect-src`, four commits after Sentry was removed in `ba5b364`.

## How

One file, `vercel.json`:

- New `/assets/(.*)` block with `Cache-Control: public, max-age=31536000, immutable`. `index.html` is deliberately left on Vercel's default (`max-age=0, must-revalidate`) so a deploy is live immediately — it is the file that points at the new hashes.
- Dropped the Sentry wildcard from `connect-src`. A dead wildcard subdomain in a live CSP is the kind of thing nobody re-reads two years from now.
- `object-src 'none'` and `worker-src 'none'`, so both are stated rather than inherited.

## Deviation from the issue

The issue proposed `worker-src 'self' blob:` "(esptool-js)". That premise does not hold: `grep -rn "new Worker" node_modules/esptool-js src` finds nothing — esptool-js drives the serial port on the main thread, and the only `URL.createObjectURL` calls in the app (`project-file.ts`, `LiveDataRoute.tsx`) build download anchors, not workers.

Since today's policy has no `worker-src` at all, it falls back to `default-src 'self'` — blob workers are *already* blocked and nothing is broken by that. Shipping `'self' blob:` would therefore have loosened a live policy to serve a requirement that does not exist. `worker-src 'none'` states the current behaviour and tightens it slightly; if esptool-js ever moves to a worker, that becomes a deliberate one-line change.

## Test plan

`npm run build` clean; the required `lint` / `typecheck` / `test` / `build` checks cover the tree being otherwise untouched.

Header changes only take effect once deployed. The preview sits behind Vercel SSO deployment protection, so it cannot be verified with an unauthenticated `curl` — verify on production after merge:

```
curl -sI https://tuner.canshift.app/assets/<hashed>.js | grep -i cache-control
#   -> public, max-age=31536000, immutable
curl -sI https://tuner.canshift.app/ | grep -i -e cache-control -e content-security-policy
#   -> index.html still max-age=0, must-revalidate; no sentry.io in connect-src
```

then open the flasher once and confirm a clean console — no CSP violation reports.