### PR TITLE
chore(tuner): hold typescript and tailwind-merge majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,18 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'typescript-eslint'
         update-types: ['version-update:semver-major']
+      # TypeScript 7 is blocked upstream, not by our code: ts-jest has no
+      # release that accepts it, and TS 7 no longer exposes the JS compiler
+      # API ts-jest needs. Tracked in canshift-core#68.
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
+      # tailwind-merge majors track Tailwind majors — its class map is rebuilt
+      # per Tailwind scale, so a lone bump mis-merges classes with no type
+      # error and no failing test. Move it with tailwindcss.
+      - dependency-name: 'tailwind-merge'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'tailwindcss'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## What

Dependabot's weekly run opened five PRs. Three were patch/minor and are merged (#84 tsx, #85 immer, #86 typescript-eslint). The other two are majors that must not land, and nothing in `dependabot.yml` stopped them being proposed:

**typescript 5.9.3 → 7.0.2** (#83) — fails `lint` and `typecheck` outright. TypeScript 7 is blocked upstream, not by our code: `ts-jest` has no release that accepts it, and TS 7 no longer exposes the JS compiler API `ts-jest` reaches for. Tracked in CANShift/canshift-core#68 (jest → vitest is the unblock).

**tailwind-merge 2.6.1 → 3.6.0** (#87) — **all checks green**, and wrong. `tailwind-merge` v3 is built for Tailwind v4; this repo is on `tailwindcss@^3.4.19`. The library's internal class map is regenerated per Tailwind scale, so running v3 against Tailwind 3 mis-merges classes in `cn()` — no type error, no failing test, just quietly wrong class precedence in every component. Exactly the bump that a green CI run does not protect against.

## How

Four entries. `typescript` with the upstream reason recorded, and `tailwind-merge` + `tailwindcss` together so the pair can only move as one deliberate PR — pinning only `tailwind-merge` would leave the same trap open from the other side.

Config only; no dependency versions change. #83 and #87 get closed with the reasoning on them.

## Test plan

`dependabot.yml` is not consumed by CI, so the required `lint` / `typecheck` / `test` / `build` checks only confirm the working tree is untouched.