### PR TITLE
fix(tuner): let the release proxy serve manifest.json

### DIFF
--- a/api/firmware-download.test.ts
+++ b/api/firmware-download.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import handler from './firmware-download'
+
+const MEGABYTE = 1024 * 1024
+const MAX_ASSET_BYTES = 16 * MEGABYTE
+
+let ipCounter = 0
+
+const request = (query: string): Request => {
+  ipCounter += 1
+  return new Request(`https://tuner.canshift.app/api/firmware-download?${query}`, {
+    headers: { 'x-forwarded-for': `10.0.0.${String(ipCounter)}` },
+  })
+}
+
+const upstream = (body: BodyInit, headers: HeadersInit = {}): void => {
+  vi.stubGlobal('fetch', () => Promise.resolve(new Response(body, { status: 200, headers })))
+}
+
+const streamOfMegabytes = (count: number): ReadableStream<Uint8Array> => {
+  let sent = 0
+  return new ReadableStream<Uint8Array>({
+    pull: (controller) => {
+      if (sent >= count) {
+        controller.close()
+        return
+      }
+      sent += 1
+      controller.enqueue(new Uint8Array(MEGABYTE))
+    },
+  })
+}
+
+describe('firmware-download proxy', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('serves a .bin asset as an octet stream', async () => {
+    upstream(new Uint8Array([0xe9, 0x01]))
+    const res = await handler(request('tag=v1.2.3&asset=canshift-crowpanel_28-v1.2.3-merged.bin'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('application/octet-stream')
+  })
+
+  it('serves manifest.json instead of rejecting it as a bad asset', async () => {
+    upstream('{"schema":1}')
+    const res = await handler(request('tag=v1.2.3&asset=manifest.json'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('application/json')
+    await expect(res.text()).resolves.toBe('{"schema":1}')
+  })
+
+  it('rejects an asset extension that is neither .bin nor .json', async () => {
+    upstream('nope')
+    const res = await handler(request('tag=v1.2.3&asset=firmware.elf'))
+    expect(res.status).toBe(400)
+    await expect(res.text()).resolves.toBe('bad_asset')
+  })
+
+  it('rejects a traversal attempt in the tag', async () => {
+    upstream('nope')
+    const res = await handler(request('tag=1.0.0-..&asset=merged.bin'))
+    expect(res.status).toBe(400)
+    await expect(res.text()).resolves.toBe('bad_tag')
+  })
+
+  it('refuses an upstream that announces more than the cap', async () => {
+    upstream(new Uint8Array([0]), { 'content-length': String(MAX_ASSET_BYTES + 1) })
+    const res = await handler(request('tag=v1.2.3&asset=merged.bin'))
+    expect(res.status).toBe(502)
+    await expect(res.text()).resolves.toBe('asset_too_large')
+  })
+
+  it('errors the stream when an upstream without content-length outgrows the cap', async () => {
+    upstream(streamOfMegabytes(MAX_ASSET_BYTES / MEGABYTE + 1))
+    const res = await handler(request('tag=v1.2.3&asset=merged.bin'))
+    expect(res.status).toBe(200)
+    await expect(res.arrayBuffer()).rejects.toThrow()
+  })
+})

--- a/api/firmware-download.ts
+++ b/api/firmware-download.ts
@@ -6,7 +6,10 @@ const OWNER = 'CANShift'
 const REPO = 'canshift-firmware'
 
 const TAG_RE = /^v?\d+\.\d+\.\d+([.-][a-z0-9.-]+)?$/i
-const ASSET_RE = /^[a-z0-9._-]+\.bin$/i
+const ASSET_RE = /^[a-z0-9._-]+\.(bin|json)$/i
+
+const assetContentType = (asset: string): string =>
+  asset.toLowerCase().endsWith('.json') ? 'application/json' : 'application/octet-stream'
 
 const RATE_LIMIT = 20
 const WINDOW_MS = 60_000
@@ -86,7 +89,7 @@ const handler = async (req: Request): Promise<Response> => {
   if (length && Number(length) > MAX_ASSET_BYTES) return respond(502, 'asset_too_large')
 
   const passHeaders = new Headers({
-    'Content-Type': 'application/octet-stream',
+    'Content-Type': assetContentType(asset),
     'Cache-Control': 'public, max-age=3600',
   })
   if (length) passHeaders.set('Content-Length', length)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,10 @@ const CORE_SIBLING_READY =
 const FIRMWARE_OWNER = 'CANShift'
 const FIRMWARE_REPO = 'canshift-firmware'
 const FIRMWARE_TAG_RE = /^v?\d+\.\d+\.\d+([.-][a-z0-9.-]+)?$/i
-const FIRMWARE_ASSET_RE = /^[a-z0-9._-]+\.bin$/i
+const FIRMWARE_ASSET_RE = /^[a-z0-9._-]+\.(bin|json)$/i
+
+const firmwareAssetContentType = (asset: string): string =>
+  asset.toLowerCase().endsWith('.json') ? 'application/json' : 'application/octet-stream'
 
 const firmwareDownloadDevProxy = (): Plugin => ({
   name: 'firmware-download-dev-proxy',
@@ -52,7 +55,7 @@ const firmwareDownloadDevProxy = (): Plugin => ({
             res.end(`upstream_failed_${upstream.status.toString()}`)
             return
           }
-          res.setHeader('Content-Type', 'application/octet-stream')
+          res.setHeader('Content-Type', firmwareAssetContentType(asset))
           const length = upstream.headers.get('content-length')
           if (length) res.setHeader('Content-Length', length)
           Readable.fromWeb(upstream.body as NodeReadableStream<Uint8Array>).pipe(res)


### PR DESCRIPTION
Closes #80.

## What

`useFirmwareManifest` fetches the release manifest through the same proxy as the binaries, and the proxy only accepted `.bin`:

```ts
// api/firmware-download.ts
const ASSET_RE = /^[a-z0-9._-]+\.bin$/i
if (!asset || !ASSET_RE.test(asset)) return respond(400, 'bad_asset')
```

`findManifestAsset()` matches the asset named exactly `manifest.json`, so every manifest fetch answered `400 bad_asset`, the hook settled on `{ kind: 'error', message: 'HTTP 400' }`, and the board list that drives artifact selection was never populated. The whole board-detection path was dead. `vite.config.ts` carries the same regex, so dev behaved identically — no firmware release has been published yet, which is the only reason this had not surfaced.

## How

- `ASSET_RE` accepts `.bin` and `.json`, in `api/firmware-download.ts` and in the vite dev proxy, kept in sync.
- The response `Content-Type` was hard-coded to `application/octet-stream`. The hook reads it with `response.text()` so it worked, but a `.json` asset now gets `application/json` on both paths.

## The reason this shipped broken

`useFirmwareManifest.test.ts` only exercises `resolveManifestForRelease`, the pure state resolver — nothing ever went near the proxy, on either side.

This adds `api/firmware-download.test.ts`, the first test of the handler at all, driving the real default export with a stubbed upstream:

- a `.bin` asset is served as an octet stream
- **`manifest.json` is served, with `application/json`** — the regression guard for this bug
- an extension that is neither is rejected `400 bad_asset`
- `1.0.0-..` is rejected `400 bad_tag`
- an upstream announcing more than `MAX_ASSET_BYTES` is refused `502`
- an upstream with no `content-length` that outgrows the cap mid-stream has its body errored — this also covers the `TransformStream` cap added in #79, which had no direct test

Each case uses a distinct `x-forwarded-for` so the module-level rate limiter does not leak between tests.

Not adding a `useFirmwareManifest` render test: the repo has no jsdom and no testing-library, and standing that up is not a size/S bugfix. The failure was in the allow-list and it is now covered there.

## Test plan

278 tests / 50 files green. `typecheck`, `lint`, `format:check`, `build` all pass. Not verified end to end against a real release — `canshift-firmware` has none published yet.