### PR TITLE
chore(tuner): route every advisory catch through bestEffort

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,19 @@ Browser configurator for CANShift dashes (org: github.com/CANShift). Vite + Reac
 - Observability: PostHog lives behind env (`VITE_POSTHOG_KEY`) _and_ behind consent — telemetry is opt-in, so nothing may load or beacon until `isObservabilityEnabled()` is true; scrub car data (payloads, frame ids, names) from anything sent.
 - Flasher reads releases from CANShift/canshift-firmware.
 
+## Code shape
+
+Non-negotiable. Reviewed on every PR, ahead of feature count.
+
+- Guard clauses first. Nesting depth 2 max — a third level means extract a named function.
+- One `try` per function. Never a `try` inside a `try`, a `catch` or a `finally`. No empty catch, no catch that only logs, no wrapper that rethrows unchanged. Every other `catch` must return a value, set state or recover — if it can only log, it is advisory and goes through the shared `bestEffort` helper, which is the single place a log-only catch is allowed to live (teardown, optional device capabilities, listener isolation).
+- Errors are typed — an error class or a discriminated Result union. Transport codes are humanised at the UI boundary; a raw wire code (`ack_timeout`, `read_failed`) must never render to the user.
+- Stacked `cond && <X/>`, chained `else if` and `kind === 'a' ? … : kind === 'b' ? …` are a union that lost its type. Use a `Record<Kind, …>` lookup table — `WidgetPreview.tsx` and `widget-editor-panel.tsx` are the reference implementations.
+- ~30 lines per function, ~300 per file. Past that, split before adding.
+- Third copy gets extracted. Cross-file boilerplate (localStorage access, JSON parsing, error→string) lives in one shared helper under `src/lib/` and is imported, never re-typed. Storage keys come from one `STORAGE_KEYS` map.
+- A constant must be read by the code it names. Unimported stores, components and exports get deleted, not kept "for later".
+- CI gates must cover every file extension in the repo. A green check that silently skipped files is a broken gate.
+
 ## Workflow
 
 - Branch `type/short-description`; Conventional Commits, subject only.

--- a/src/transport/__tests__/webserial-client.test.ts
+++ b/src/transport/__tests__/webserial-client.test.ts
@@ -273,6 +273,33 @@ describe('SerialClient — single-instance behaviour', () => {
   })
 })
 
+describe('SerialClient — status listener isolation', () => {
+  it('keeps notifying the remaining listeners when one throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const fake = makeFakePort()
+    const client = new SerialClient({ disableReconnect: true })
+    const seen: string[] = []
+
+    client.onStatus(() => {
+      throw new Error('listener blew up')
+    })
+    client.onStatus((status) => {
+      seen.push(status)
+    })
+
+    await client.connect(fake.port)
+    await flush()
+
+    expect(seen).toContain('connected')
+    expect(
+      warn.mock.calls.filter(([msg]) => typeof msg === 'string' && msg.includes('status listener'))
+    ).not.toHaveLength(0)
+
+    client.disconnect()
+    warn.mockRestore()
+  })
+})
+
 describe('SerialClient — rx buffer overflow', () => {
   it('drops a newline-free flood and resyncs on the next complete frame', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)

--- a/src/transport/webserial-client.ts
+++ b/src/transport/webserial-client.ts
@@ -88,7 +88,7 @@ const bestEffort = async (label: string, op: () => unknown): Promise<void> => {
   try {
     await op()
   } catch (err) {
-    console.warn(`[serial] ${label} failed during teardown — continuing`, err)
+    console.warn(`[serial] ${label} failed — continuing`, err)
   }
 }
 
@@ -191,9 +191,8 @@ export class SerialClient {
     this.clearStaleAckFlush()
     this.drainQueueWithError('disconnected')
     const readLoopPromise = this.readLoop
-    if (this.active) {
-      this.active.reader.cancel().catch(() => undefined)
-    }
+    const own = this.active
+    if (own) void bestEffort('reader.cancel', () => own.reader.cancel())
     void (readLoopPromise ?? Promise.resolve()).finally(() => {
       this.setStatus('disconnected')
     })
@@ -228,11 +227,9 @@ export class SerialClient {
       }
     ).setSignals
     if (typeof setSignals !== 'function') return
-    try {
-      await setSignals.call(port, { dataTerminalReady: false, requestToSend: false })
-    } catch (err) {
-      console.warn('[serial] setSignals failed', err)
-    }
+    await bestEffort('setSignals', () =>
+      setSignals.call(port, { dataTerminalReady: false, requestToSend: false })
+    )
   }
 
   private async requestPort(): Promise<SerialPort | null> {
@@ -280,7 +277,7 @@ export class SerialClient {
     this.lastError = undefined
     this.setStatus('connected')
 
-    this.readLoop = this.runReadLoop(own).catch(() => undefined)
+    this.readLoop = bestEffort('readLoop', () => this.runReadLoop(own))
   }
 
   private async runReadLoop(own: PortHandles): Promise<void> {
@@ -554,11 +551,9 @@ export class SerialClient {
     this.status = next
     if (error !== undefined) this.lastError = error
     for (const listener of this.statusListeners) {
-      try {
+      void bestEffort('status listener', () => {
         listener(next, this.lastError)
-      } catch (err) {
-        console.warn('[serial] status listener threw', err)
-      }
+      })
     }
   }
 }


### PR DESCRIPTION
## What

Adds the **Code shape** section to this repo's `CLAUDE.md`, mirroring the one in canshift-mobile, and makes `webserial-client.ts` comply with the rule it introduces:

> No empty catch, no catch that only logs, no wrapper that rethrows unchanged.

Four sites in that file broke it, three of which pre-date the teardown work in #90:

| Site | Was |
| --- | --- |
| `disconnect()` | `reader.cancel().catch(() => undefined)` — an empty catch |
| `openPort()` | `this.runReadLoop(own).catch(() => undefined)` — an empty catch |
| `deassertResetSignals()` | `try` / `catch` that only warned |
| `setStatus()` | `try` / `catch` per listener that only warned |

All four now go through the existing `bestEffort(label, op)` helper, so there is exactly one place in the file where a log-only catch lives.

Every `catch` that remains earns its keep: `safeJsonParse` returns `null` and the caller drops the frame, `requestPort` returns `null` and the caller raises `no_port_selected`, `openPort` and `runReadLoop` set `lastError`, `dispatchSend` resolves the ack with the failure, and `scheduleReconnect` recovers.

## One wording change to the rule

The line as drafted said *"Teardown goes through the shared `bestEffort` helper"*. Two of the four sites are not teardown — `setSignals` is an optional device capability on the **open** path, and the `setStatus` loop is listener isolation. Both are still "this can only be logged", so rather than leave the rule contradicted by the code I widened it to name the category instead of the moment:

> if it can only log, it is advisory and goes through the shared `bestEffort` helper, which is the single place a log-only catch is allowed to live (teardown, optional device capabilities, listener isolation)

Revert that line if you meant `bestEffort` to stay strictly teardown-only — the three non-teardown sites then need somewhere else to go, and I'd want your call on where. The helper's warning text dropped "during teardown" to match either way.

## Test plan

One new case: **a throwing status listener does not stop the others** — two listeners registered, the first throws, the second still receives `connected`, and the failure is logged rather than swallowed. That guarantee existed before but was never covered, and this PR changes the mechanism delivering it.

281 tests / 50 files green. `typecheck`, `lint`, `format:check`, `build` all pass. Not exercised against a real CH340 — no board available.