### PR TITLE
fix(tuner): report the transport teardown failure that locks the serial port

### DIFF
--- a/src/lib/firmware/flash.test.ts
+++ b/src/lib/firmware/flash.test.ts
@@ -1,5 +1,33 @@
-import { describe, expect, it } from 'vitest'
-import { assertChipMatchesBoard, flashFileArray, FlashError } from './flash'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  assertChipMatchesBoard,
+  flashFileArray,
+  FlashError,
+  handshakeFailureMessage,
+} from './flash'
+
+const esptoolStubs = vi.hoisted(() => ({
+  disconnect: vi.fn(() => Promise.resolve()),
+  main: vi.fn(() => Promise.resolve()),
+  writeFlash: vi.fn(() => Promise.resolve()),
+  softReset: vi.fn(() => Promise.resolve()),
+  chipName: 'ESP32',
+}))
+
+vi.mock('esptool-js', () => ({
+  Transport: class {
+    disconnect = esptoolStubs.disconnect
+  },
+  ESPLoader: class {
+    connect = vi.fn()
+    main = esptoolStubs.main
+    writeFlash = esptoolStubs.writeFlash
+    softReset = esptoolStubs.softReset
+    get chip() {
+      return { CHIP_NAME: esptoolStubs.chipName }
+    }
+  },
+}))
 
 describe('assertChipMatchesBoard', () => {
   it('throws on a cross-architecture mismatch even when the detected chip is itself supported', () => {
@@ -35,5 +63,89 @@ describe('flashFileArray', () => {
       { data: merged, address: 0x0 },
       { data: nvs, address: 0x9000 },
     ])
+  })
+})
+
+describe('handshakeFailureMessage', () => {
+  it('says nothing about the pre-reset when it ran', () => {
+    const msg = handshakeFailureMessage('timed out')
+    expect(msg).toContain('timed out')
+    expect(msg).not.toContain('pre-reset')
+  })
+
+  it('threads the pre-reset failure in, so the handshake error names the real cause', () => {
+    const msg = handshakeFailureMessage('timed out', 'this port cannot toggle DTR/RTS')
+    expect(msg).toContain('this port cannot toggle DTR/RTS')
+    expect(msg).toContain('fell back to the slower default reset')
+  })
+})
+
+describe('flashFirmware teardown', () => {
+  const makePort = (): SerialPort =>
+    ({
+      open: vi.fn(() => Promise.resolve()),
+      close: vi.fn(() => Promise.resolve()),
+      setSignals: vi.fn(() => Promise.resolve()),
+    }) as unknown as SerialPort
+
+  const run = async (port: SerialPort, log: string[]) => {
+    const { flashFirmware } = await import('./flash')
+    return flashFirmware({
+      port,
+      bytes: new Uint8Array([0xe9, 0x01]),
+      onProgress: () => undefined,
+      onLog: (line) => log.push(line),
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    esptoolStubs.disconnect.mockResolvedValue(undefined)
+    esptoolStubs.main.mockResolvedValue(undefined)
+    esptoolStubs.writeFlash.mockResolvedValue(undefined)
+    esptoolStubs.softReset.mockResolvedValue(undefined)
+    esptoolStubs.chipName = 'ESP32'
+  })
+
+  it('always releases the port', async () => {
+    const log: string[] = []
+    await run(makePort(), log)
+    expect(esptoolStubs.disconnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a failed port release instead of discarding it', async () => {
+    esptoolStubs.disconnect.mockRejectedValue(new Error('port already open'))
+    const log: string[] = []
+
+    await run(makePort(), log)
+
+    expect(log.some((line) => line.includes('Serial port release failed'))).toBe(true)
+    expect(log.some((line) => line.includes('port already open'))).toBe(true)
+  })
+
+  it('reports the failed release without masking the flash error that caused it', async () => {
+    esptoolStubs.writeFlash.mockRejectedValue(new Error('write timeout'))
+    esptoolStubs.disconnect.mockRejectedValue(new Error('port already open'))
+    const log: string[] = []
+
+    await expect(run(makePort(), log)).rejects.toThrow(FlashError)
+    expect(log.some((line) => line.includes('Serial port release failed'))).toBe(true)
+  })
+
+  it('names the pre-reset failure in the handshake error when the port cannot toggle signals', async () => {
+    esptoolStubs.main.mockRejectedValue(new Error('timed out waiting for packet header'))
+    const port = { open: vi.fn(() => Promise.resolve()), close: vi.fn(() => Promise.resolve()) }
+    const log: string[] = []
+
+    await expect(run(port as unknown as SerialPort, log)).rejects.toThrow(/cannot toggle DTR\/RTS/)
+  })
+
+  it('keeps flashing when the final soft reset fails, and says what to do', async () => {
+    esptoolStubs.softReset.mockRejectedValue(new Error('no response'))
+    const log: string[] = []
+
+    await run(makePort(), log)
+
+    expect(log.some((line) => line.includes('unplug/replug to restart the dash'))).toBe(true)
   })
 })

--- a/src/lib/firmware/flash.ts
+++ b/src/lib/firmware/flash.ts
@@ -1,6 +1,8 @@
 import { chipFamiliesMatch } from './board-resolution'
+import { bestEffort, type BestEffortReport } from '../../transport/best-effort'
 
 const FLASH_BAUD = 460_800
+const PRE_RESET_BAUD = 115_200
 const MERGED_FLASH_OFFSET = 0x0
 const NVS_FLASH_OFFSET = 0x9000
 
@@ -9,30 +11,14 @@ const SUPPORTED_CHIPS: readonly string[] = ['ESP32']
 const PRE_RESET_HOLD_MS = 250
 const PRE_RESET_SETTLE_MS = 600
 
+const ROM_BOOTLOADER_CONNECT_ATTEMPTS = 15
+
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+const errorText = (err: unknown): string => (err instanceof Error ? err.message : String(err))
 
 interface SignalCapablePort {
   setSignals?: (signals: { dataTerminalReady?: boolean; requestToSend?: boolean }) => Promise<void>
-}
-
-const forceRomBootloader = async (port: SerialPort, onLog: FlashLog): Promise<boolean> => {
-  const setSignals = (port as SignalCapablePort).setSignals
-  if (typeof setSignals !== 'function') return false
-  const send = (signals: { dataTerminalReady?: boolean; requestToSend?: boolean }) =>
-    setSignals.call(port, signals)
-  try {
-    onLog('Pre-reset: pulling EN low, IO0 low')
-    await send({ dataTerminalReady: false, requestToSend: true })
-    await sleep(PRE_RESET_HOLD_MS)
-    await send({ dataTerminalReady: true, requestToSend: false })
-    await sleep(PRE_RESET_SETTLE_MS)
-    await send({ dataTerminalReady: false, requestToSend: false })
-    onLog('Pre-reset complete — chip should be in ROM bootloader')
-    return true
-  } catch (err) {
-    onLog(`Pre-reset failed: ${err instanceof Error ? err.message : String(err)}`)
-    return false
-  }
 }
 
 let esptoolModulePromise: Promise<typeof import('esptool-js')> | null = null
@@ -41,6 +27,11 @@ const loadEsptool = (): Promise<typeof import('esptool-js')> => {
   esptoolModulePromise ??= import('esptool-js')
   return esptoolModulePromise
 }
+
+type Esptool = Awaited<ReturnType<typeof loadEsptool>>
+type EspTransport = InstanceType<Esptool['Transport']>
+type EspLoader = InstanceType<Esptool['ESPLoader']>
+type ConnectMode = 'no_reset' | 'default_reset'
 
 export type FlashProgress = (loaded: number, total: number) => void
 export type FlashLog = (line: string) => void
@@ -74,6 +65,17 @@ export class FlashError extends Error {
   }
 }
 
+export class UnsupportedChipError extends Error {
+  readonly detectedChip: string
+  constructor(detectedChip: string) {
+    super(
+      `Refusing to flash — detected ${detectedChip}, CANShift firmware is built only for classic ESP32. Writing it onto a different family will brick the device.`
+    )
+    this.name = 'UnsupportedChipError'
+    this.detectedChip = detectedChip
+  }
+}
+
 export const assertChipMatchesBoard = (
   expectedChip: string | undefined,
   detectedChip: string
@@ -86,15 +88,55 @@ export const assertChipMatchesBoard = (
   }
 }
 
-export class UnsupportedChipError extends Error {
-  readonly detectedChip: string
-  constructor(detectedChip: string) {
-    super(
-      `Refusing to flash — detected ${detectedChip}, CANShift firmware is built only for classic ESP32. Writing it onto a different family will brick the device.`
-    )
-    this.name = 'UnsupportedChipError'
-    this.detectedChip = detectedChip
+export interface PortPreparation {
+  mode: ConnectMode
+  fallbackReason?: string
+}
+
+export const handshakeFailureMessage = (detail: string, fallbackReason?: string): string => {
+  const preReset =
+    fallbackReason === undefined
+      ? ''
+      : ` The pre-reset into the ROM bootloader never ran (${fallbackReason}), so this fell back to the slower default reset — fix that first.`
+  return `ESP32 bootloader handshake failed (${detail}).${preReset} If the chip was detected and the failure happened after baud change, try a lower FLASH_BAUD. Otherwise hold BOOT, tap RESET, and retry.`
+}
+
+const reportTo =
+  (onLog: FlashLog): BestEffortReport =>
+  (message, err) => {
+    onLog(`${message}: ${errorText(err)}`)
   }
+
+const pulseRomBootloader = async (port: SerialPort, onLog: FlashLog): Promise<PortPreparation> => {
+  const setSignals = (port as SignalCapablePort).setSignals
+  if (typeof setSignals !== 'function') {
+    return { mode: 'default_reset', fallbackReason: 'this port cannot toggle DTR/RTS' }
+  }
+  const send = (signals: { dataTerminalReady?: boolean; requestToSend?: boolean }) =>
+    setSignals.call(port, signals)
+
+  onLog('Pre-reset: pulling EN low, IO0 low')
+  await send({ dataTerminalReady: false, requestToSend: true })
+  await sleep(PRE_RESET_HOLD_MS)
+  await send({ dataTerminalReady: true, requestToSend: false })
+  await sleep(PRE_RESET_SETTLE_MS)
+  await send({ dataTerminalReady: false, requestToSend: false })
+  onLog('Pre-reset complete — chip should be in ROM bootloader')
+  return { mode: 'no_reset' }
+}
+
+const preparePort = async (port: SerialPort, onLog: FlashLog): Promise<PortPreparation> => {
+  const report = reportTo(onLog)
+  let prepared: PortPreparation
+  try {
+    await port.open({ baudRate: PRE_RESET_BAUD })
+    prepared = await pulseRomBootloader(port, onLog)
+  } catch (err) {
+    report('Pre-reset', err)
+    prepared = { mode: 'default_reset', fallbackReason: errorText(err) }
+  }
+  await bestEffort('Pre-reset port close', () => port.close(), report)
+  return prepared
 }
 
 const makeTerminal = (onLog: FlashLog) => ({
@@ -105,7 +147,84 @@ const makeTerminal = (onLog: FlashLog) => ({
   write: (_data: string) => undefined,
 })
 
-const ROM_BOOTLOADER_CONNECT_ATTEMPTS = 15
+const createLoader = (
+  esptool: Esptool,
+  transport: EspTransport,
+  connectMode: ConnectMode,
+  onLog: FlashLog
+): EspLoader => {
+  const loader = new esptool.ESPLoader({
+    transport,
+    baudrate: FLASH_BAUD,
+    terminal: makeTerminal(onLog),
+    debugLogging: false,
+  })
+  const originalConnect = loader.connect.bind(loader)
+  loader.connect = (
+    mode = connectMode,
+    _attempts = ROM_BOOTLOADER_CONNECT_ATTEMPTS,
+    detecting = true
+  ) => originalConnect(mode, ROM_BOOTLOADER_CONNECT_ATTEMPTS, detecting)
+  return loader
+}
+
+const handshake = async (
+  loader: EspLoader,
+  preparation: PortPreparation,
+  expectedChip: string | undefined,
+  onLog: FlashLog
+): Promise<void> => {
+  try {
+    await loader.main(preparation.mode)
+  } catch (err) {
+    throw new FlashError(handshakeFailureMessage(errorText(err), preparation.fallbackReason), err)
+  }
+
+  const detectedChip = loader.chip.CHIP_NAME
+  onLog(`Detected chip: ${detectedChip}`)
+  assertChipMatchesBoard(expectedChip, detectedChip)
+  if (!SUPPORTED_CHIPS.includes(detectedChip)) throw new UnsupportedChipError(detectedChip)
+}
+
+const writeImages = async (
+  loader: EspLoader,
+  bytes: Uint8Array,
+  nvsImage: Uint8Array | undefined,
+  onProgress: FlashProgress,
+  onLog: FlashLog
+): Promise<void> => {
+  if (nvsImage) onLog(`Baking board profile into NVS at 0x${NVS_FLASH_OFFSET.toString(16)}`)
+  try {
+    await loader.writeFlash({
+      fileArray: flashFileArray(bytes, nvsImage),
+      flashMode: 'keep',
+      flashFreq: 'keep',
+      flashSize: 'keep',
+      eraseAll: false,
+      compress: true,
+      reportProgress: (_fileIndex, written, total) => {
+        if (total > 0) onProgress(written, total)
+      },
+    })
+  } catch (err) {
+    throw new FlashError(
+      err instanceof Error ? `Flash write failed: ${err.message}` : 'Flash write failed.',
+      err
+    )
+  }
+}
+
+const withTransport = async <T>(
+  transport: EspTransport,
+  report: BestEffortReport,
+  run: () => Promise<T>
+): Promise<T> => {
+  try {
+    return await run()
+  } finally {
+    await bestEffort('Serial port release', () => transport.disconnect(), report)
+  }
+}
 
 export const flashFirmware = async ({
   port,
@@ -115,88 +234,21 @@ export const flashFirmware = async ({
   onProgress,
   onLog,
 }: FlashOptions): Promise<void> => {
-  let preResetSucceeded = false
-  try {
-    await port.open({ baudRate: 115_200 })
-    preResetSucceeded = await forceRomBootloader(port, onLog)
-  } catch (err) {
-    onLog(`Pre-reset port open failed: ${err instanceof Error ? err.message : String(err)}`)
-  } finally {
-    try {
-      await port.close()
-    } catch (err) {
-      onLog(`Pre-reset port close failed: ${err instanceof Error ? err.message : String(err)}`)
-    }
-  }
+  const report = reportTo(onLog)
+  const preparation = await preparePort(port, onLog)
+  const esptool = await loadEsptool()
+  const transport = new esptool.Transport(port, false)
+  const loader = createLoader(esptool, transport, preparation.mode, onLog)
 
-  const connectMode = preResetSucceeded ? 'no_reset' : 'default_reset'
-
-  const { ESPLoader, Transport } = await loadEsptool()
-  const transport = new Transport(port, false)
-  try {
-    const loader = new ESPLoader({
-      transport,
-      baudrate: FLASH_BAUD,
-      terminal: makeTerminal(onLog),
-      debugLogging: false,
-    })
-
-    const originalConnect = loader.connect.bind(loader)
-    loader.connect = (
-      mode = connectMode,
-      _attempts = ROM_BOOTLOADER_CONNECT_ATTEMPTS,
-      detecting = true
-    ) => originalConnect(mode, ROM_BOOTLOADER_CONNECT_ATTEMPTS, detecting)
-
-    try {
-      await loader.main(connectMode)
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err)
-      throw new FlashError(
-        `ESP32 bootloader handshake failed (${detail}). If the chip was detected and the failure happened after baud change, try a lower FLASH_BAUD. Otherwise hold BOOT, tap RESET, and retry.`,
-        err
-      )
-    }
-
-    const detectedChip = loader.chip.CHIP_NAME
-    onLog(`Detected chip: ${detectedChip}`)
-    assertChipMatchesBoard(expectedChip, detectedChip)
-    if (!SUPPORTED_CHIPS.includes(detectedChip)) {
-      throw new UnsupportedChipError(detectedChip)
-    }
-
-    try {
-      if (nvsImage) {
-        onLog(`Baking board profile into NVS at 0x${NVS_FLASH_OFFSET.toString(16)}`)
+  await withTransport(transport, report, async () => {
+    await handshake(loader, preparation, expectedChip, onLog)
+    await writeImages(loader, bytes, nvsImage, onProgress, onLog)
+    await bestEffort(
+      'Reset',
+      () => loader.softReset(false),
+      (_message, err) => {
+        onLog(`Reset failed (${errorText(err)}) — unplug/replug to restart the dash.`)
       }
-      await loader.writeFlash({
-        fileArray: flashFileArray(bytes, nvsImage),
-        flashMode: 'keep',
-        flashFreq: 'keep',
-        flashSize: 'keep',
-        eraseAll: false,
-        compress: true,
-        reportProgress: (_fileIndex, written, total) => {
-          if (total > 0) onProgress(written, total)
-        },
-      })
-    } catch (err) {
-      throw new FlashError(
-        err instanceof Error ? `Flash write failed: ${err.message}` : 'Flash write failed.',
-        err
-      )
-    }
-
-    try {
-      await loader.softReset(false)
-    } catch {
-      onLog('Reset failed — unplug/replug to restart the dash.')
-    }
-  } finally {
-    try {
-      await transport.disconnect()
-    } catch {
-      void 0
-    }
-  }
+    )
+  })
 }

--- a/src/transport/__tests__/webserial-client.test.ts
+++ b/src/transport/__tests__/webserial-client.test.ts
@@ -11,8 +11,14 @@ interface FakePort {
   closeCalls: number
 }
 
+const closeOnce = (state: { controller: ReadableStreamDefaultController<Uint8Array> | null }) => {
+  const controller = state.controller
+  state.controller = null
+  controller?.close()
+}
+
 const makeFakePort = (): FakePort => {
-  let readableController: ReadableStreamDefaultController<Uint8Array> | null = null
+  const rx = { controller: null as ReadableStreamDefaultController<Uint8Array> | null }
   const written: string[] = []
   const decoder = new TextDecoder()
   const state = {
@@ -23,7 +29,7 @@ const makeFakePort = (): FakePort => {
 
   const readable = new ReadableStream<Uint8Array>({
     start(controller) {
-      readableController = controller
+      rx.controller = controller
     },
   })
 
@@ -40,9 +46,7 @@ const makeFakePort = (): FakePort => {
     close: vi.fn(async () => {
       state.closeCalls++
       state.closed = true
-      try {
-        readableController?.close()
-      } catch {}
+      closeOnce(rx)
     }),
     readable,
     writable,
@@ -52,12 +56,10 @@ const makeFakePort = (): FakePort => {
     port,
     pushBytes: (bytes) => {
       const encoded = typeof bytes === 'string' ? new TextEncoder().encode(bytes) : bytes
-      readableController?.enqueue(encoded)
+      rx.controller?.enqueue(encoded)
     },
     closeReader: () => {
-      try {
-        readableController?.close()
-      } catch {}
+      closeOnce(rx)
     },
     get written() {
       return written
@@ -362,17 +364,17 @@ describe('SerialClient — send queue', () => {
 })
 
 const makeReopenablePort = (): { port: SerialPort; dropConnection: () => void } => {
-  let controller: ReadableStreamDefaultController<Uint8Array> | null = null
+  const rx = { controller: null as ReadableStreamDefaultController<Uint8Array> | null }
   let readable = new ReadableStream<Uint8Array>({
     start(c) {
-      controller = c
+      rx.controller = c
     },
   })
   let writable = new WritableStream<Uint8Array>()
   const arm = (): void => {
     readable = new ReadableStream<Uint8Array>({
       start(c) {
-        controller = c
+        rx.controller = c
       },
     })
     writable = new WritableStream<Uint8Array>()
@@ -382,9 +384,7 @@ const makeReopenablePort = (): { port: SerialPort; dropConnection: () => void } 
       arm()
     }),
     close: vi.fn(async () => {
-      try {
-        controller?.close()
-      } catch {}
+      closeOnce(rx)
     }),
     get readable() {
       return readable
@@ -396,9 +396,7 @@ const makeReopenablePort = (): { port: SerialPort; dropConnection: () => void } 
   return {
     port,
     dropConnection: () => {
-      try {
-        controller?.close()
-      } catch {}
+      closeOnce(rx)
     },
   }
 }

--- a/src/transport/best-effort.test.ts
+++ b/src/transport/best-effort.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import { bestEffort } from './best-effort'
+
+describe('bestEffort', () => {
+  it('runs the operation and reports nothing when it succeeds', async () => {
+    const report = vi.fn()
+    const op = vi.fn(() => Promise.resolve('done'))
+
+    await bestEffort('thing', op, report)
+
+    expect(op).toHaveBeenCalledTimes(1)
+    expect(report).not.toHaveBeenCalled()
+  })
+
+  it('never rejects, and hands the failure to the injected channel', async () => {
+    const report = vi.fn()
+    const boom = new Error('port busy')
+
+    await expect(
+      bestEffort('transport.disconnect', () => Promise.reject(boom), report)
+    ).resolves.toBeUndefined()
+
+    expect(report).toHaveBeenCalledWith('transport.disconnect failed — continuing', boom)
+  })
+
+  it('catches a synchronous throw too', async () => {
+    const report = vi.fn()
+
+    await bestEffort(
+      'releaseLock',
+      () => {
+        throw new TypeError('locked')
+      },
+      report
+    )
+
+    expect(report).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to console.warn when no channel is given', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    await bestEffort('unrouted', () => Promise.reject(new Error('x')))
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    warn.mockRestore()
+  })
+})

--- a/src/transport/best-effort.ts
+++ b/src/transport/best-effort.ts
@@ -1,0 +1,17 @@
+export type BestEffortReport = (message: string, err: unknown) => void
+
+const warnToConsole: BestEffortReport = (message, err) => {
+  console.warn(message, err)
+}
+
+export const bestEffort = async (
+  label: string,
+  op: () => unknown,
+  report: BestEffortReport = warnToConsole
+): Promise<void> => {
+  try {
+    await op()
+  } catch (err) {
+    report(`${label} failed — continuing`, err)
+  }
+}

--- a/src/transport/webserial-client.ts
+++ b/src/transport/webserial-client.ts
@@ -1,4 +1,5 @@
 import { humanizeTransportError } from './humanize-transport-error'
+import { bestEffort } from './best-effort'
 
 const DEFAULT_BAUD_RATE = 115_200
 
@@ -81,14 +82,6 @@ const safeJsonParse = (line: string): unknown => {
     const preview = trimmed.length > 80 ? `${trimmed.slice(0, 80)}…` : trimmed
     console.warn(`[serial] dropped malformed frame (${reason}): ${preview}`)
     return null
-  }
-}
-
-const bestEffort = async (label: string, op: () => unknown): Promise<void> => {
-  try {
-    await op()
-  } catch (err) {
-    console.warn(`[serial] ${label} failed — continuing`, err)
   }
 }
 
@@ -192,7 +185,7 @@ export class SerialClient {
     this.drainQueueWithError('disconnected')
     const readLoopPromise = this.readLoop
     const own = this.active
-    if (own) void bestEffort('reader.cancel', () => own.reader.cancel())
+    if (own) void bestEffort('[serial] reader.cancel', () => own.reader.cancel())
     void (readLoopPromise ?? Promise.resolve()).finally(() => {
       this.setStatus('disconnected')
     })
@@ -227,7 +220,7 @@ export class SerialClient {
       }
     ).setSignals
     if (typeof setSignals !== 'function') return
-    await bestEffort('setSignals', () =>
+    await bestEffort('[serial] setSignals', () =>
       setSignals.call(port, { dataTerminalReady: false, requestToSend: false })
     )
   }
@@ -277,7 +270,7 @@ export class SerialClient {
     this.lastError = undefined
     this.setStatus('connected')
 
-    this.readLoop = bestEffort('readLoop', () => this.runReadLoop(own))
+    this.readLoop = bestEffort('[serial] readLoop', () => this.runReadLoop(own))
   }
 
   private async runReadLoop(own: PortHandles): Promise<void> {
@@ -306,12 +299,12 @@ export class SerialClient {
   }
 
   private async releaseHandles(own: PortHandles): Promise<void> {
-    await bestEffort('reader.cancel', () => own.reader.cancel())
-    await bestEffort('reader.releaseLock', () => {
+    await bestEffort('[serial] reader.cancel', () => own.reader.cancel())
+    await bestEffort('[serial] reader.releaseLock', () => {
       own.reader.releaseLock()
     })
-    await bestEffort('writer.abort', () => own.writer.abort())
-    await bestEffort('writer.releaseLock', () => {
+    await bestEffort('[serial] writer.abort', () => own.writer.abort())
+    await bestEffort('[serial] writer.releaseLock', () => {
       own.writer.releaseLock()
     })
   }
@@ -538,12 +531,12 @@ export class SerialClient {
     const loop = this.readLoop
     this.readLoop = null
 
-    await bestEffort('reader.cancel', () => own.reader.cancel())
+    await bestEffort('[serial] reader.cancel', () => own.reader.cancel())
     await loop
   }
 
   private async safeClose(port: SerialPort): Promise<void> {
-    await bestEffort('port.close', () => port.close())
+    await bestEffort('[serial] port.close', () => port.close())
   }
 
   private setStatus(next: SerialStatus, error?: string): void {
@@ -551,7 +544,7 @@ export class SerialClient {
     this.status = next
     if (error !== undefined) this.lastError = error
     for (const listener of this.statusListeners) {
-      void bestEffort('status listener', () => {
+      void bestEffort('[serial] status listener', () => {
         listener(next, this.lastError)
       })
     }


### PR DESCRIPTION
Closes #95.

## The bug

```ts
} finally {
  try {
    await transport.disconnect()
  } catch {
    void 0
  }
}
```

A failing `transport.disconnect()` is **precisely** what leaves the WebSerial port locked so the next connect throws "already open". It was discarded with no log line, which made "port busy on the second flash attempt" undiagnosable.

Second swallow: a pre-reset failure was logged and dropped, `preResetSucceeded` stayed `false`, `connectMode` silently flipped to `default_reset`, and the user got a generic handshake failure ~15 attempts later with no link back to the real cause. `forceRomBootloader` had its own catch doing the same thing one level down — two catches for one decision.

## How

The six extractions from the issue, in order.

**1.** `bestEffort` moves out of `webserial-client.ts` into `src/transport/best-effort.ts`. It gained an optional `report` channel defaulting to `console.warn`, because the console is the wrong place for a flash failure — `flashFirmware` already has `onLog`, which renders in the UI log panel. `webserial-client` passes `[serial] `-prefixed labels so its output is byte-identical to before.

**2.** `preparePort` returns `{ mode, fallbackReason? }`. `pulseRomBootloader` (was `forceRomBootloader`) no longer catches at all — it either completes or throws into `preparePort`'s single `try`, so one failure is decided in one place. The reason is **returned instead of dropped**.

**3–5.** `createLoader` (pure, no `try`), `handshake`, `writeImages` — one `try` each.

**6.** `withTransport(transport, report, run)` — `try { return await run() } finally { await bestEffort('Serial port release', …) }`.

`flashFirmware` is now 8 lines: prepare, load, create loader, then `withTransport` wrapping handshake, write and a best-effort soft reset.

The threaded `fallbackReason` is the user-visible win. The handshake error used to say only "handshake failed (timed out)". It now says *"The pre-reset into the ROM bootloader never ran (this port cannot toggle DTR/RTS), so this fell back to the slower default reset — fix that first."*

## Acceptance

- [x] no `try` inside a `try`, `catch` or `finally` in `src/lib/firmware/` — flash.ts went from 8 `try` blocks (two nested in `finally`) to 4, one per function
- [x] no empty catch in production code — within this issue's scope; see below
- [x] a failing `transport.disconnect()` produces a log line
- [x] `flashFirmware` under 30 lines — 8

Also took the four empty catches in the fake-port doubles the issue flagged (`webserial-client.test.ts`), via a shared `closeOnce` helper that nulls the controller instead of double-closing it and catching the throw.

## Test plan

`best-effort.test.ts` — 4 cases: succeeds silently, never rejects and routes the failure to the injected channel, catches a synchronous throw, falls back to `console.warn` when unrouted.

`flash.test.ts` — `esptool-js` mocked, 5 new cases:

- the port is always released
- **a failed release is reported, with the underlying message** — fails on `main`, where the empty catch produced nothing
- a failed release is reported **without masking** the `FlashError` that caused it
- a handshake failure on a port that cannot toggle DTR/RTS names the pre-reset cause
- a failing soft reset does not fail the flash and still says "unplug/replug"

plus 2 for `handshakeFailureMessage`.

292 tests / 51 files green. `typecheck`, `lint`, `format:check`, `build` all pass. Not exercised against a real CH340 — no board available.

## Residual

`releases.ts:101` and `:133` hold two sequential (not nested) `try` blocks in `fetchReleases`. That clears this issue's acceptance criterion but not the broader "one `try` per function" rule; left out to keep a critical fix narrow. The empty catches across `src/stores/**/storage.ts` are #96's territory, not this one's.