### PR TITLE
fix(tuner): humanise transport codes at the UI boundary and unify error messages

### DIFF
--- a/src/components/can-bus/CanScanToolbar.tsx
+++ b/src/components/can-bus/CanScanToolbar.tsx
@@ -4,6 +4,7 @@ import type { CanScannerStatus } from '../../hooks/useCanScanner'
 import type { LearnWindow } from '../../stores/can-scan/accumulator'
 import { MONO_FONT } from '../../lib/typography'
 import { SortBar, type SortKey } from './SortBar'
+import { transportErrorText } from '../../transport/humanize-transport-error'
 
 export interface CanScanToolbarProps {
   status: CanScannerStatus
@@ -106,7 +107,7 @@ export const CanScanToolbar = ({
           <Metric label="STATUS" value={prettyStatus(status)} accent={status === 'running'} />
         </div>
       </header>
-      {error && <div style={errorStyle}>Scan error: {error}</div>}
+      {error && <div style={errorStyle}>Scan error: {transportErrorText(error)}</div>}
     </>
   )
 }

--- a/src/components/cli/CommandForm.tsx
+++ b/src/components/cli/CommandForm.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '../ui/button'
 import { KNOWN_OPCODES } from '../../transport'
 import { MONO_FONT } from '../../lib/typography'
+import { errorMessage } from '../../lib/error-message'
 
 export interface CommandFormProps {
   disabled: boolean
@@ -45,7 +46,7 @@ export const CommandForm = ({
     try {
       fields = JSON.parse(trimmed)
     } catch (err) {
-      setParseError(`JSON parse error — ${err instanceof Error ? err.message : 'invalid'}`)
+      setParseError(`JSON parse error — ${errorMessage(err, 'invalid')}`)
       return
     }
     if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {

--- a/src/components/ecu/EcuCatalogueList.tsx
+++ b/src/components/ecu/EcuCatalogueList.tsx
@@ -4,6 +4,7 @@ import { formatBytes } from '../../lib/format'
 import { Input } from '../ui/input'
 import { TogglePill } from '../ui/toggle-pill'
 import { MONO_FONT } from '../../lib/typography'
+import { errorMessage } from '../../lib/error-message'
 
 export interface CatalogueItem {
   id: string
@@ -58,7 +59,7 @@ export const EcuCatalogueList = ({ activeKey, selectedId, onSelect }: EcuCatalog
         if (cancelled) return
         setState({
           kind: 'error',
-          message: err instanceof Error ? err.message : 'fetch_failed',
+          message: errorMessage(err, 'fetch_failed'),
         })
       })
     return () => {

--- a/src/components/editor/ScreenSettingsPanel.tsx
+++ b/src/components/editor/ScreenSettingsPanel.tsx
@@ -5,6 +5,7 @@ import { useLogStore } from '../../stores/log.store'
 import { useDeviceState } from '../../hooks/useDeviceState'
 import { usePreviewTheme } from '../../hooks/useDashboardConfig'
 import { usbService } from '../../transport'
+import { transportErrorText } from '../../transport/humanize-transport-error'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -55,7 +56,7 @@ const ScreenSettingsPanel = ({ scale }: ScreenSettingsPanelProps) => {
     if (result.success) {
       log('success', `Screen settings pushed — brightness ${String(brightness)}%`)
     } else {
-      log('error', `Screen settings push failed: ${result.error ?? 'unknown error'}`)
+      log('error', `Screen settings push failed: ${transportErrorText(result.error)}`)
     }
   }
 
@@ -94,7 +95,7 @@ const ScreenSettingsPanel = ({ scale }: ScreenSettingsPanelProps) => {
       setIsDayMode(day)
       log('success', `Theme set to ${target}`)
     } else {
-      log('error', `Theme set failed: ${result.error ?? 'unknown error'}`)
+      log('error', `Theme set failed: ${transportErrorText(result.error)}`)
     }
   }
 
@@ -111,7 +112,7 @@ const ScreenSettingsPanel = ({ scale }: ScreenSettingsPanelProps) => {
     if (result.success) {
       log('info', 'Touch calibration started — follow the crosshairs on the device')
     } else {
-      log('error', `Calibration failed: ${result.error ?? 'unknown error'}`)
+      log('error', `Calibration failed: ${transportErrorText(result.error)}`)
     }
   }
 

--- a/src/components/firmware/FlashActions.tsx
+++ b/src/components/firmware/FlashActions.tsx
@@ -10,6 +10,7 @@ import { useLogStore } from '../../stores/log.store'
 import { downloadFirmwareAsset } from '../../lib/firmware/download'
 import { formatBytes } from '../../lib/format'
 import { MONO_FONT } from '../../lib/typography'
+import { errorMessage } from '../../lib/error-message'
 
 export interface FlashActionsProps {
   selection: FirmwareSelection
@@ -91,7 +92,7 @@ export const FlashActions = ({
         )
       })
       .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err)
+        const message = errorMessage(err)
         setDownloadError(message)
         log('error', `Download failed for ${asset.name}: ${message}`)
       })

--- a/src/components/obd2/DtcPanel.tsx
+++ b/src/components/obd2/DtcPanel.tsx
@@ -5,6 +5,7 @@ import { useDtcStore } from '../../stores/dtc.store'
 import { useDeviceStore } from '../../stores/device.store'
 import { MONO_FONT } from '../../lib/typography'
 import { DtcClearConfirmDialog } from './DtcClearConfirmDialog'
+import { transportErrorText } from '../../transport/humanize-transport-error'
 
 interface DtcBodyProps {
   ready: boolean
@@ -51,7 +52,7 @@ export const DtcPanel = () => {
       <div style={headerStyle}>TROUBLE CODES</div>
       <div style={bodyStyle}>
         <DtcBody ready={ready} reading={status === 'reading'} hasRead={hasRead} codes={codes} />
-        {error && <div style={errorStyle}>Failed — {error}</div>}
+        {error && <div style={errorStyle}>Failed — {transportErrorText(error)}</div>}
       </div>
       <div style={footerStyle}>
         <button

--- a/src/components/project/ProjectSwitcher.tsx
+++ b/src/components/project/ProjectSwitcher.tsx
@@ -88,7 +88,8 @@ export const ProjectSwitcher = () => {
     let raw: string
     try {
       raw = await readProjectFileText(file)
-    } catch {
+    } catch (err) {
+      console.warn('[project] import read failed', err)
       log('error', 'Could not read the selected file.')
       return
     }

--- a/src/components/shell/RebootButton.tsx
+++ b/src/components/shell/RebootButton.tsx
@@ -3,6 +3,8 @@ import { Button } from '@/components/ui/button'
 import { useDeviceStore } from '../../stores/device.store'
 import { useLogStore } from '../../stores/log.store'
 import { usbService } from '../../transport'
+import { errorMessage } from '../../lib/error-message'
+import { transportErrorText } from '../../transport/humanize-transport-error'
 
 export interface RebootButtonProps {
   label?: string
@@ -25,11 +27,11 @@ export const RebootButton = ({ label = 'Reboot' }: RebootButtonProps) => {
         if (result.success) {
           log('success', 'Reboot command sent — dash is restarting')
         } else {
-          log('error', `Reboot failed: ${result.error ?? 'unknown_error'}`)
+          log('error', `Reboot failed: ${transportErrorText(result.error)}`)
         }
       })
       .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err)
+        const message = errorMessage(err)
         log('error', `Reboot failed: ${message}`)
       })
       .finally(() => {

--- a/src/hooks/useBurnDashboard.ts
+++ b/src/hooks/useBurnDashboard.ts
@@ -9,6 +9,7 @@ import { usbService } from '../transport'
 import { humanizeTransportError } from '../transport/humanize-transport-error'
 import { verifyBurnedConfig, type VerifyResult } from './verifyBurnedConfig'
 import { captureFlowEvent } from '../lib/posthog'
+import { errorMessage } from '../lib/error-message'
 
 interface UseBurnDashboard {
   canBurn: boolean
@@ -61,8 +62,9 @@ export const useBurnDashboard = (): UseBurnDashboard => {
       const result = await usbService.pushConfig(config)
       if (!result.success) {
         const code = result.error ?? 'unknown_error'
-        log('error', `Burn failed: ${code}`)
-        setLastBurnResult({ kind: 'error', message: humanizeTransportError(code) })
+        const message = humanizeTransportError(code)
+        log('error', `Burn failed: ${message}`)
+        setLastBurnResult({ kind: 'error', message })
         captureFlowEvent('burn_completed', { outcome: 'push_failed', reason: code })
         return
       }
@@ -81,7 +83,7 @@ export const useBurnDashboard = (): UseBurnDashboard => {
         captureFlowEvent('burn_completed', { outcome: 'verify_failed', reason: verify.kind })
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      const message = errorMessage(err)
       log('error', `Burn failed: ${message}`)
       setLastBurnResult({ kind: 'error', message: humanizeTransportError(message) })
       captureFlowEvent('burn_completed', { outcome: 'exception' })

--- a/src/hooks/useDeviceConfigBootstrap.ts
+++ b/src/hooks/useDeviceConfigBootstrap.ts
@@ -3,6 +3,8 @@ import { useDeviceStore } from '../stores/device.store'
 import { useDashboardStore } from '../stores/dashboard.store'
 import { useLogStore } from '../stores/log.store'
 import { deviceIpc } from '../transport'
+import { errorMessage } from '../lib/error-message'
+import { transportErrorText } from '../transport/humanize-transport-error'
 
 export const useDeviceConfigBootstrap = (): void => {
   const connected = useDeviceStore((s) => s.connected)
@@ -36,14 +38,17 @@ export const useDeviceConfigBootstrap = (): void => {
           const outcome = loadFromDeviceOrDemo(null)
           if (outcome === 'demo') log('info', 'Device has no config — loaded demo')
         } else {
-          log('error', `Device config is unreadable or invalid: ${result.error}`)
+          log(
+            'error',
+            `Device config is unreadable or invalid: ${transportErrorText(result.error)}`
+          )
           const outcome = loadFromDeviceOrDemo(null)
           if (outcome === 'demo') log('info', 'Loaded demo config instead')
         }
       })
       .catch((err: unknown) => {
         if (cancelled) return
-        const message = err instanceof Error ? err.message : String(err)
+        const message = errorMessage(err)
         log('error', `Failed to read device config: ${message}`)
       })
     return () => {

--- a/src/hooks/useFirmwareManifest.ts
+++ b/src/hooks/useFirmwareManifest.ts
@@ -3,6 +3,7 @@ import type { ReleaseInfo } from '@canshift/core'
 import { findManifestAsset } from '../lib/firmware/releases'
 import { firmwareAssetProxyUrl } from '../lib/firmware/download'
 import { parseManifest, type BoardManifest } from '../lib/firmware/manifest'
+import { errorMessage } from '../lib/error-message'
 
 const MANIFEST_FETCH_TIMEOUT_MS = 10_000
 
@@ -71,7 +72,7 @@ export const useFirmwareManifest = (release: ReleaseInfo | null): ManifestState 
           tag,
           state: {
             kind: 'error',
-            message: err instanceof Error ? err.message : 'Manifest fetch failed.',
+            message: errorMessage(err, 'Manifest fetch failed.'),
           },
         })
       })

--- a/src/hooks/useHeartbeat.ts
+++ b/src/hooks/useHeartbeat.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useDeviceStore } from '../stores/device.store'
 import { useLogStore } from '../stores/log.store'
 import { usbService } from '../transport'
+import { transportErrorText } from '../transport/humanize-transport-error'
 
 const HEARTBEAT_INTERVAL_MS = 5_000
 const HEARTBEAT_MISS_THRESHOLD = 3
@@ -46,7 +47,10 @@ export const useHeartbeat = (): void => {
           sinceMs: firstMissedAt,
         })
         if (!unresponsiveLogged) {
-          log('error', `Firmware unresponsive — ${String(missed)} pings missed (${result.error})`)
+          log(
+            'error',
+            `Firmware unresponsive — ${String(missed)} pings missed (${transportErrorText(result.error)})`
+          )
           unresponsiveLogged = true
         }
       }

--- a/src/hooks/useProvisionBoardProfile.ts
+++ b/src/hooks/useProvisionBoardProfile.ts
@@ -4,6 +4,8 @@ import { useDeviceStore } from '../stores/device.store'
 import { useLogStore } from '../stores/log.store'
 import { boardProfileBlob, type BoardProfileWriteResult } from '../lib/firmware/board-provision'
 import { useResolvedBoardProfile, type ResolvedBoardProfile } from './useResolvedBoardProfile'
+import { errorMessage } from '../lib/error-message'
+import { transportErrorText } from '../transport/humanize-transport-error'
 
 export type ProvisionState =
   | { kind: 'idle' }
@@ -53,11 +55,11 @@ export const useProvisionBoardProfile = (): UseProvisionBoardProfile => {
           log('error', 'Firmware rejected the board profile (invalid_board_profile)')
           return
         }
-        setState({ kind: 'error', message: result.error })
-        log('error', `Board profile write failed: ${result.error}`)
+        setState({ kind: 'error', message: transportErrorText(result.error) })
+        log('error', `Board profile write failed: ${transportErrorText(result.error)}`)
       })
       .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err)
+        const message = errorMessage(err)
         setState({ kind: 'error', message })
         log('error', `Board profile write failed: ${message}`)
       })

--- a/src/hooks/useVersionHandshake.ts
+++ b/src/hooks/useVersionHandshake.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useDeviceStore } from '../stores/device.store'
 import { useLogStore } from '../stores/log.store'
 import { usbService } from '../transport'
+import { transportErrorText } from '../transport/humanize-transport-error'
 
 export const useVersionHandshake = (): void => {
   const connected = useDeviceStore((s) => s.connected)
@@ -19,7 +20,7 @@ export const useVersionHandshake = (): void => {
     void usbService.queryVersion().then((result) => {
       if (cancelled) return
       if (result.kind === 'error') {
-        log('warn', `Version handshake failed: ${result.error}`)
+        log('warn', `Version handshake failed: ${transportErrorText(result.error)}`)
         setFirmwareCompat({ kind: 'unknown' })
         return
       }

--- a/src/lib/error-message.test.ts
+++ b/src/lib/error-message.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { errorMessage } from './error-message'
+
+describe('errorMessage', () => {
+  it('takes the message off an Error', () => {
+    expect(errorMessage(new Error('port busy'))).toBe('port busy')
+  })
+
+  it('passes a thrown string through', () => {
+    expect(errorMessage('ack_timeout')).toBe('ack_timeout')
+  })
+
+  it('falls back rather than stringifying an object into [object Object]', () => {
+    expect(errorMessage({ code: 7 })).toBe('unknown_error')
+    expect(errorMessage(null)).toBe('unknown_error')
+    expect(errorMessage(undefined)).toBe('unknown_error')
+  })
+
+  it('falls back on an Error with an empty message', () => {
+    expect(errorMessage(new Error(''), 'open_failed')).toBe('open_failed')
+  })
+
+  it('uses the caller fallback when one is given', () => {
+    expect(errorMessage(42, 'connect_failed')).toBe('connect_failed')
+  })
+})

--- a/src/lib/error-message.ts
+++ b/src/lib/error-message.ts
@@ -1,0 +1,7 @@
+const DEFAULT_FALLBACK = 'unknown_error'
+
+export const errorMessage = (err: unknown, fallback: string = DEFAULT_FALLBACK): string => {
+  if (err instanceof Error && err.message.length > 0) return err.message
+  if (typeof err === 'string' && err.length > 0) return err
+  return fallback
+}

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -1,3 +1,5 @@
+import { errorMessage } from './error-message'
+
 const CONTACT_ENDPOINT = 'https://tmbk.ch/api/contact/canshift'
 const REPORTER_NAME = 'CANShift Tuner'
 const FALLBACK_EMAIL = 'noreply@canshift.ch'
@@ -43,7 +45,7 @@ export const submitFeedback = async (input: FeedbackInput): Promise<FeedbackResu
     }
     return { ok: true }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Network unreachable'
+    const message = errorMessage(error, 'Network unreachable')
     return { ok: false, error: message }
   } finally {
     clearTimeout(timer)

--- a/src/lib/firmware/flash.ts
+++ b/src/lib/firmware/flash.ts
@@ -1,5 +1,6 @@
 import { chipFamiliesMatch } from './board-resolution'
 import { bestEffort, type BestEffortReport } from '../../transport/best-effort'
+import { errorMessage } from '../error-message'
 
 const FLASH_BAUD = 460_800
 const PRE_RESET_BAUD = 115_200
@@ -14,8 +15,6 @@ const PRE_RESET_SETTLE_MS = 600
 const ROM_BOOTLOADER_CONNECT_ATTEMPTS = 15
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
-
-const errorText = (err: unknown): string => (err instanceof Error ? err.message : String(err))
 
 interface SignalCapablePort {
   setSignals?: (signals: { dataTerminalReady?: boolean; requestToSend?: boolean }) => Promise<void>
@@ -104,7 +103,7 @@ export const handshakeFailureMessage = (detail: string, fallbackReason?: string)
 const reportTo =
   (onLog: FlashLog): BestEffortReport =>
   (message, err) => {
-    onLog(`${message}: ${errorText(err)}`)
+    onLog(`${message}: ${errorMessage(err)}`)
   }
 
 const pulseRomBootloader = async (port: SerialPort, onLog: FlashLog): Promise<PortPreparation> => {
@@ -133,7 +132,7 @@ const preparePort = async (port: SerialPort, onLog: FlashLog): Promise<PortPrepa
     prepared = await pulseRomBootloader(port, onLog)
   } catch (err) {
     report('Pre-reset', err)
-    prepared = { mode: 'default_reset', fallbackReason: errorText(err) }
+    prepared = { mode: 'default_reset', fallbackReason: errorMessage(err) }
   }
   await bestEffort('Pre-reset port close', () => port.close(), report)
   return prepared
@@ -177,7 +176,10 @@ const handshake = async (
   try {
     await loader.main(preparation.mode)
   } catch (err) {
-    throw new FlashError(handshakeFailureMessage(errorText(err), preparation.fallbackReason), err)
+    throw new FlashError(
+      handshakeFailureMessage(errorMessage(err), preparation.fallbackReason),
+      err
+    )
   }
 
   const detectedChip = loader.chip.CHIP_NAME
@@ -207,10 +209,7 @@ const writeImages = async (
       },
     })
   } catch (err) {
-    throw new FlashError(
-      err instanceof Error ? `Flash write failed: ${err.message}` : 'Flash write failed.',
-      err
-    )
+    throw new FlashError(`Flash write failed: ${errorMessage(err)}`, err)
   }
 }
 
@@ -247,7 +246,7 @@ export const flashFirmware = async ({
       'Reset',
       () => loader.softReset(false),
       (_message, err) => {
-        onLog(`Reset failed (${errorText(err)}) — unplug/replug to restart the dash.`)
+        onLog(`Reset failed (${errorMessage(err)}) — unplug/replug to restart the dash.`)
       }
     )
   })

--- a/src/routes/CliRoute.tsx
+++ b/src/routes/CliRoute.tsx
@@ -8,6 +8,7 @@ import type { CliEntry } from '../components/cli/CliOutput'
 import { CliOfflineState } from '../components/cli/CliOfflineState'
 import { RouteHeader } from '../components/shell/RouteHeader'
 import { MONO_FONT } from '../lib/typography'
+import { transportErrorText } from '../transport/humanize-transport-error'
 
 const HISTORY_CAP = 50
 const ENTRIES_CAP = 200
@@ -51,7 +52,11 @@ const CliRoute = () => {
         if (result.kind === 'ok') {
           push({ kind: 'ok', label: opcodeLabel, payload: result.data })
         } else {
-          push({ kind: 'error', label: `${opcodeLabel} — ${result.error}`, payload: result.data })
+          push({
+            kind: 'error',
+            label: `${opcodeLabel} — ${transportErrorText(result.error)}`,
+            payload: result.data,
+          })
         }
         setBusy(false)
       })

--- a/src/routes/EcuRoute.tsx
+++ b/src/routes/EcuRoute.tsx
@@ -12,6 +12,7 @@ import { SignalPreviewTable } from '../components/ecu/SignalPreviewTable'
 import { ApplyConfirmDialog } from '../components/ecu/ApplyConfirmDialog'
 import { MONO_FONT } from '../lib/typography'
 import { prettyProfileKey } from '../utils/profile-key'
+import { errorMessage } from '../lib/error-message'
 
 type Source =
   | { kind: 'none' }
@@ -118,7 +119,7 @@ const EcuRoute = () => {
         warnings: result.warnings,
       })
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'unknown_error'
+      const message = errorMessage(err)
       setImportError(`Catalogue load failed — ${message}`)
       log('error', `Catalogue entry "${item.label}" fetch failed: ${message}`)
     }

--- a/src/routes/ThemesRoute.tsx
+++ b/src/routes/ThemesRoute.tsx
@@ -11,6 +11,7 @@ import { ThemeTokensRail } from '../components/themes/ThemeTokensRail'
 import { ThemeStatusCard } from '../components/themes/ThemeStatusCard'
 import { ThemeControls } from '../components/themes/ThemeControls'
 import { MONO_FONT } from '../lib/typography'
+import { transportErrorText } from '../transport/humanize-transport-error'
 
 const LIGHT_BG_LUMINANCE = 0.5
 
@@ -65,7 +66,7 @@ const ThemesRoute = () => {
         `Theme toggled to ${next === true ? 'Day' : next === false ? 'Night' : 'unknown'}`
       )
     } else {
-      log('error', `Theme toggle failed: ${result.error ?? 'unknown_error'}`)
+      log('error', `Theme toggle failed: ${transportErrorText(result.error)}`)
     }
     setBusy(false)
   }
@@ -77,7 +78,7 @@ const ThemesRoute = () => {
       setIsDayMode(true)
       log('success', 'Theme forced to Day')
     } else {
-      log('error', `Set Day failed: ${result.error ?? 'unknown_error'}`)
+      log('error', `Set Day failed: ${transportErrorText(result.error)}`)
     }
     setBusy(false)
   }
@@ -89,7 +90,7 @@ const ThemesRoute = () => {
       setIsDayMode(false)
       log('success', 'Theme forced to Night')
     } else {
-      log('error', `Set Night failed: ${result.error ?? 'unknown_error'}`)
+      log('error', `Set Night failed: ${transportErrorText(result.error)}`)
     }
     setBusy(false)
   }

--- a/src/stores/can-scan/can-scan.store.ts
+++ b/src/stores/can-scan/can-scan.store.ts
@@ -5,6 +5,7 @@ import { useLogStore } from '../log.store'
 import { createScanAccumulator, emptySnapshot } from './accumulator'
 import { captureFlowEvent } from '../../lib/posthog'
 import type { CanScanSnapshot } from './accumulator'
+import { transportErrorText } from '../../transport/humanize-transport-error'
 
 const SNAPSHOT_INTERVAL_MS = 250
 
@@ -68,7 +69,7 @@ export const useCanScanStore = create<CanScanState>()((set, get) => {
         return
       }
       if (!result.success) {
-        const err = result.error ?? 'unknown_error'
+        const err = transportErrorText(result.error)
         set({ status: 'error', error: err })
         log('error', `CAN scan start failed: ${err}`)
         return
@@ -96,7 +97,7 @@ export const useCanScanStore = create<CanScanState>()((set, get) => {
       }
       const result = await canScannerIpc.stop()
       if (!result.success) {
-        log('warn', `CAN scan stop failed: ${result.error ?? 'unknown_error'}`)
+        log('warn', `CAN scan stop failed: ${transportErrorText(result.error)}`)
       }
       set({ status: 'idle', snapshot: accumulator.snapshot(performance.now()) })
       log('info', `CAN scan stopped — ${String(accumulator.totalFrames())} frames captured`)

--- a/src/stores/connection.store.ts
+++ b/src/stores/connection.store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { getSerialClient, type SerialStatus } from '../transport/webserial-client'
 import { useDeviceStore } from './device.store'
+import { errorMessage } from '../lib/error-message'
 
 const USB_LABEL = 'webserial'
 
@@ -51,7 +52,7 @@ export const useConnectionStore = create<ConnectionState>()((set, get) => {
         await client.connect(port)
         set({ port: client.getPort() })
       } catch (err) {
-        const msg = err instanceof Error ? err.message : 'connect_failed'
+        const msg = errorMessage(err, 'connect_failed')
         set({ lastError: toReportableError(msg) })
       }
     },
@@ -69,7 +70,7 @@ export const useConnectionStore = create<ConnectionState>()((set, get) => {
         if (!first) return
         await get().connect(first)
       } catch (err) {
-        const msg = err instanceof Error ? err.message : 'auto_reconnect_failed'
+        const msg = errorMessage(err, 'auto_reconnect_failed')
         set({ lastError: msg })
       }
     },

--- a/src/stores/device-config.store.ts
+++ b/src/stores/device-config.store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { DEFAULT_DEVICE_CONFIG, type DeviceConfig } from '@canshift/core'
 import { deviceConfigIpc } from '../transport'
+import { errorMessage } from '../lib/error-message'
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
 
@@ -55,7 +56,7 @@ export const useDeviceConfigStore = create<DeviceConfigState>()((set, get) => ({
       }
       set({ saveStatus: 'error', saveError: result.error ?? 'Save failed' })
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Save failed'
+      const msg = errorMessage(err, 'Save failed')
       set({ saveStatus: 'error', saveError: msg })
     }
   },

--- a/src/stores/input-bindings.store.ts
+++ b/src/stores/input-bindings.store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import type { InputBinding } from '@canshift/core'
 import { inputBindingsIpc } from '../transport'
+import { errorMessage } from '../lib/error-message'
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
 
@@ -67,7 +68,7 @@ export const useInputBindingsStore = create<InputBindingsState>()((set, get) => 
       }
       set({ saveStatus: 'error', saveError: result.error ?? 'Save failed' })
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Save failed'
+      const msg = errorMessage(err, 'Save failed')
       set({ saveStatus: 'error', saveError: msg })
     }
   },

--- a/src/transport/__tests__/humanize-transport-error.test.ts
+++ b/src/transport/__tests__/humanize-transport-error.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { humanizeTransportError, TRANSPORT_ERROR_MESSAGES } from '../humanize-transport-error'
+import {
+  humanizeTransportError,
+  transportErrorText,
+  TRANSPORT_ERROR_MESSAGES,
+} from '../humanize-transport-error'
 
 const KNOWN_CODES = [
   'no_port_selected',
@@ -17,6 +21,10 @@ const KNOWN_CODES = [
   'send_failed',
   'device_error',
   'unknown_error',
+  'read_failed',
+  'clear_failed',
+  'fetch_failed',
+  'invalid_board_profile',
 ]
 
 describe('humanizeTransportError', () => {
@@ -43,5 +51,18 @@ describe('humanizeTransportError', () => {
 
   it('passes unknown strings through unchanged', () => {
     expect(humanizeTransportError('something exotic happened')).toBe('something exotic happened')
+  })
+})
+
+describe('transportErrorText', () => {
+  it('treats a missing, null or empty code as unknown_error rather than rendering blank', () => {
+    const unknown = TRANSPORT_ERROR_MESSAGES.unknown_error
+    expect(transportErrorText(undefined)).toBe(unknown)
+    expect(transportErrorText(null)).toBe(unknown)
+    expect(transportErrorText('')).toBe(unknown)
+  })
+
+  it.each(KNOWN_CODES)('never renders %s raw to a user', (code) => {
+    expect(transportErrorText(code)).not.toBe(code)
   })
 })

--- a/src/transport/device-ipc.ts
+++ b/src/transport/device-ipc.ts
@@ -5,13 +5,14 @@ import { CMD_GET_CONFIG } from './opcodes'
 import type { DeviceConfigResult } from './types'
 import { isRecord } from './types'
 import { getSerialClient } from './webserial-client'
+import { errorMessage } from '../lib/error-message'
 
 const migrateAndParse = (raw: Record<string, unknown>): DeviceConfigResult => {
   let migrated: ReturnType<typeof migrateConfig>
   try {
     migrated = migrateConfig(raw, CURRENT_SCHEMA_VERSION)
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = errorMessage(err)
     return { kind: 'error', error: `config_migration_failed: ${message}` }
   }
   const parsed = DashboardConfigSchema.safeParse(migrated.config)

--- a/src/transport/humanize-transport-error.ts
+++ b/src/transport/humanize-transport-error.ts
@@ -17,6 +17,11 @@ export const TRANSPORT_ERROR_MESSAGES: Record<string, string> = {
   send_failed: 'Sending to the dash failed — check the cable and retry.',
   device_error: 'The dash reported an error — open the Logs page for details.',
   unknown_error: 'Something went wrong on the dash — open the Logs page for details.',
+  read_failed: 'Could not read the trouble codes from the dash — check the cable and retry.',
+  clear_failed: 'The dash refused to clear the trouble codes — check the cable and retry.',
+  fetch_failed: 'Could not fetch that from the dash — check the cable and retry.',
+  invalid_board_profile:
+    'The firmware rejected this board profile — re-check the board definition and re-provision.',
 }
 
 export const humanizeTransportError = (code: string): string => {
@@ -34,3 +39,8 @@ export const humanizeTransportError = (code: string): string => {
   }
   return code
 }
+
+export const transportErrorText = (code: string | undefined | null): string =>
+  humanizeTransportError(
+    code === undefined || code === null || code.length === 0 ? 'unknown_error' : code
+  )

--- a/src/transport/webserial-client.ts
+++ b/src/transport/webserial-client.ts
@@ -1,5 +1,6 @@
 import { humanizeTransportError } from './humanize-transport-error'
 import { bestEffort } from './best-effort'
+import { errorMessage } from '../lib/error-message'
 
 const DEFAULT_BAUD_RATE = 115_200
 
@@ -78,7 +79,7 @@ const safeJsonParse = (line: string): unknown => {
   try {
     return JSON.parse(trimmed) as unknown
   } catch (err) {
-    const reason = err instanceof Error ? err.message : 'unknown'
+    const reason = errorMessage(err, 'unknown')
     const preview = trimmed.length > 80 ? `${trimmed.slice(0, 80)}…` : trimmed
     console.warn(`[serial] dropped malformed frame (${reason}): ${preview}`)
     return null
@@ -242,7 +243,7 @@ export class SerialClient {
       await port.open({ baudRate: this.baudRate })
       await this.deassertResetSignals(port)
     } catch (err) {
-      const raw = err instanceof Error ? err.message : 'open_failed'
+      const raw = errorMessage(err, 'open_failed')
       const msg = humanizeTransportError(raw)
       this.lastError = msg
       this.setStatus('disconnected', msg)
@@ -284,7 +285,7 @@ export class SerialClient {
         }
       }
     } catch (err) {
-      this.lastError = err instanceof Error ? err.message : 'read_error'
+      this.lastError = errorMessage(err, 'read_error')
     } finally {
       const tail = this.decoder.decode()
       if (tail) this.rxBuffer += tail
@@ -412,7 +413,7 @@ export class SerialClient {
         .catch((err: unknown) => {
           clearTimeout(timer)
           this.pendingAck = null
-          const msg = err instanceof Error ? err.message : 'send_failed'
+          const msg = errorMessage(err, 'send_failed')
           resolve({ ok: false, error: msg })
           this.drainPendingSends()
         })


### PR DESCRIPTION
Part of #100 — covers the two items in the title. The "Other error-path defects" section gets its own PR.

## What

`humanizeTransportError` existed, was good, and was applied at 5 sites while being skipped at ~15. Raw wire codes rendered verbatim: `Failed — ack_timeout` straight into the DOM in `DtcPanel`, `Scan error: queue_full` in `CanScanToolbar`, and `Theme toggle failed: unknown_error` into the user-visible Logs page from nine more files.

Separately, 21 hand-written `err instanceof Error ? …` ternaries across 16 files invented 12 different fallback strings — `String(err)`, `'unknown'`, `'unknown_error'`, `'Save failed'`, `'open_failed'`, `'read_error'`, `'send_failed'`, `'connect_failed'`, `'fetch_failed'`, `'Network unreachable'`, `'invalid'`, `'Manifest fetch failed.'`. That is why one failure read three different ways across three surfaces.

## How

**`src/lib/error-message.ts`** — one `errorMessage(err, fallback?)`. All 21 ternaries now call it; `grep -c "instanceof Error ?" src` is **0**. It also fixes a latent bug the ternaries shared: `String(err)` on a thrown object renders `[object Object]` to the user, where the helper falls through to the fallback. An `Error` with an empty message does the same.

**`transportErrorText(code)`** joins `humanizeTransportError` in `humanize-transport-error.ts` and is applied at every surface where a code reaches a person — `DtcPanel`, `CanScanToolbar`, `RebootButton`, `ScreenSettingsPanel` (×3), `ThemesRoute` (×3), `CliRoute`, `can-scan.store` (×2), `useProvisionBoardProfile` (×2), `useHeartbeat`, `useVersionHandshake`, `useDeviceConfigBootstrap`. It absorbs the `?? 'unknown_error'` fallback, which is what stops it being re-invented per site.

The `src/transport/*` IPC modules keep normalising to raw codes — that is the transport contract, and the codes stay intact in store state for tests and telemetry. Only the render/log boundary humanises.

**Four codes had no entry**, so passing them through the humaniser would still have rendered them raw: `read_failed`, `clear_failed` (both reach `DtcPanel`), `fetch_failed`, and `invalid_board_profile`.

**Two smaller ones from the issue:**

- `useBurnDashboard` humanised the panel message but logged the raw code. Now both read the same, and the raw code stays in the PostHog `reason` field where it belongs.
- `ProjectSwitcher` showed a correct generic message but discarded the cause entirely. The cause is now logged locally — generic to the user, specific to the console.

## Test plan

`error-message.test.ts` — 5 cases, including the `[object Object]` and empty-message paths the ternaries got wrong.

The existing `__tests__/humanize-transport-error.test.ts` gains the four new codes to its `KNOWN_CODES` list (its exact-key-set assertion is what caught them) plus a `transportErrorText` block: `undefined` / `null` / `''` all resolve to the `unknown_error` message rather than rendering blank, and no known code is ever returned raw.

321 tests / 52 files green — up from 292. `typecheck`, `lint`, `format:check`, `build` all pass. Not exercised against a board.

## Acceptance progress on #100

- [x] no raw transport code renders to a user
- [x] one `errorMessage` helper; no inline `instanceof Error` ternary in `src/`
- [ ] no floating promise without a `.catch` — next PR, with the reconnect cap, the `finally` hardening and the `EcuRoute` try narrowing