### PR TITLE
fix(tuner): stop the error paths from swallowing, wedging and retrying forever

### DIFF
--- a/src/components/ecu/XmlImportZone.tsx
+++ b/src/components/ecu/XmlImportZone.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties, DragEvent, ChangeEvent } from 'react'
 import { useRef, useState } from 'react'
 import { formatBytes } from '../../lib/format'
 import { MONO_FONT } from '../../lib/typography'
+import { errorMessage } from '../../lib/error-message'
 
 export interface XmlImportZoneProps {
   loadedFileName: string | null
@@ -32,9 +33,14 @@ export const XmlImportZone = ({
       )
       return
     }
-    void file.text().then((text) => {
-      onFileLoad(file.name, text)
-    })
+    void file
+      .text()
+      .then((text) => {
+        onFileLoad(file.name, text)
+      })
+      .catch((err: unknown) => {
+        onError(`Could not read "${file.name}" — ${errorMessage(err)}`)
+      })
   }
 
   const onDragOver = (e: DragEvent<HTMLDivElement>) => {

--- a/src/hooks/useVersionHandshake.ts
+++ b/src/hooks/useVersionHandshake.ts
@@ -3,6 +3,7 @@ import { useDeviceStore } from '../stores/device.store'
 import { useLogStore } from '../stores/log.store'
 import { usbService } from '../transport'
 import { transportErrorText } from '../transport/humanize-transport-error'
+import { errorMessage } from '../lib/error-message'
 
 export const useVersionHandshake = (): void => {
   const connected = useDeviceStore((s) => s.connected)
@@ -17,34 +18,41 @@ export const useVersionHandshake = (): void => {
   useEffect(() => {
     if (!connected || simulationMode || transport !== 'usb') return
     let cancelled = false
-    void usbService.queryVersion().then((result) => {
-      if (cancelled) return
-      if (result.kind === 'error') {
-        log('warn', `Version handshake failed: ${transportErrorText(result.error)}`)
+    void usbService
+      .queryVersion()
+      .then((result) => {
+        if (cancelled) return
+        if (result.kind === 'error') {
+          log('warn', `Version handshake failed: ${transportErrorText(result.error)}`)
+          setFirmwareCompat({ kind: 'unknown' })
+          return
+        }
+        const { version, protocol, isDay, boardId } = result.identity
+        setFirmwareVersion(version)
+        setBoardId(boardId ?? null)
+        setIsDayMode(isDay)
+        const reportedMajor = Number(version.split('.')[0] ?? 0)
+        if (reportedMajor !== __EXPECTED_FIRMWARE_MAJOR__) {
+          log(
+            'error',
+            `Firmware major mismatch — tuner expects ${String(__EXPECTED_FIRMWARE_MAJOR__)}.x, device reports ${version}. Burn disabled.`
+          )
+          setFirmwareCompat({
+            kind: 'mismatch',
+            expected: __EXPECTED_FIRMWARE_MAJOR__,
+            got: reportedMajor,
+            version,
+          })
+          return
+        }
+        setFirmwareCompat({ kind: 'compatible', protocol })
+        log('success', `Connected to firmware v${version} (proto ${String(protocol)})`)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        log('warn', `Version handshake failed: ${errorMessage(err)}`)
         setFirmwareCompat({ kind: 'unknown' })
-        return
-      }
-      const { version, protocol, isDay, boardId } = result.identity
-      setFirmwareVersion(version)
-      setBoardId(boardId ?? null)
-      setIsDayMode(isDay)
-      const reportedMajor = Number(version.split('.')[0] ?? 0)
-      if (reportedMajor !== __EXPECTED_FIRMWARE_MAJOR__) {
-        log(
-          'error',
-          `Firmware major mismatch — tuner expects ${String(__EXPECTED_FIRMWARE_MAJOR__)}.x, device reports ${version}. Burn disabled.`
-        )
-        setFirmwareCompat({
-          kind: 'mismatch',
-          expected: __EXPECTED_FIRMWARE_MAJOR__,
-          got: reportedMajor,
-          version,
-        })
-        return
-      }
-      setFirmwareCompat({ kind: 'compatible', protocol })
-      log('success', `Connected to firmware v${version} (proto ${String(protocol)})`)
-    })
+      })
     return () => {
       cancelled = true
     }

--- a/src/routes/CliRoute.tsx
+++ b/src/routes/CliRoute.tsx
@@ -9,6 +9,7 @@ import { CliOfflineState } from '../components/cli/CliOfflineState'
 import { RouteHeader } from '../components/shell/RouteHeader'
 import { MONO_FONT } from '../lib/typography'
 import { transportErrorText } from '../transport/humanize-transport-error'
+import { errorMessage } from '../lib/error-message'
 
 const HISTORY_CAP = 50
 const ENTRIES_CAP = 200
@@ -48,18 +49,25 @@ const CliRoute = () => {
       historyCursorRef.current = -1
       push({ kind: 'request', label: opcodeLabel, payload: fields })
       setBusy(true)
-      void usbService.sendRaw(cmd, fields).then((result) => {
-        if (result.kind === 'ok') {
-          push({ kind: 'ok', label: opcodeLabel, payload: result.data })
-        } else {
-          push({
-            kind: 'error',
-            label: `${opcodeLabel} — ${transportErrorText(result.error)}`,
-            payload: result.data,
-          })
-        }
-        setBusy(false)
-      })
+      void usbService
+        .sendRaw(cmd, fields)
+        .then((result) => {
+          if (result.kind === 'ok') {
+            push({ kind: 'ok', label: opcodeLabel, payload: result.data })
+          } else {
+            push({
+              kind: 'error',
+              label: `${opcodeLabel} — ${transportErrorText(result.error)}`,
+              payload: result.data,
+            })
+          }
+        })
+        .catch((err: unknown) => {
+          push({ kind: 'error', label: `${opcodeLabel} — ${errorMessage(err)}`, payload: null })
+        })
+        .finally(() => {
+          setBusy(false)
+        })
     },
     [push]
   )

--- a/src/routes/EcuRoute.tsx
+++ b/src/routes/EcuRoute.tsx
@@ -99,30 +99,33 @@ const EcuRoute = () => {
 
   const onSelectItem = async (item: CatalogueItem) => {
     setImportError(null)
+    let xml: string
     try {
       const res = await fetch(item.path)
       if (!res.ok) throw new Error(`HTTP ${String(res.status)}`)
-      const xml = await res.text()
-      const result = parseCanXml(xml)
-      if (result.signals.length === 0) {
-        const reason = result.warnings[0] ?? 'no signals found'
-        setImportError(`Catalogue load failed — ${reason}`)
-        log('error', `Catalogue entry "${item.label}" failed: ${reason}`)
-        return
-      }
-      setSource({
-        kind: 'catalogue',
-        itemId: item.id,
-        label: item.label,
-        vendor: item.vendor,
-        signals: result.signals,
-        warnings: result.warnings,
-      })
+      xml = await res.text()
     } catch (err) {
       const message = errorMessage(err)
       setImportError(`Catalogue load failed — ${message}`)
       log('error', `Catalogue entry "${item.label}" fetch failed: ${message}`)
+      return
     }
+
+    const result = parseCanXml(xml)
+    if (result.signals.length === 0) {
+      const reason = result.warnings[0] ?? 'no signals found'
+      setImportError(`Catalogue load failed — ${reason}`)
+      log('error', `Catalogue entry "${item.label}" failed: ${reason}`)
+      return
+    }
+    setSource({
+      kind: 'catalogue',
+      itemId: item.id,
+      label: item.label,
+      vendor: item.vendor,
+      signals: result.signals,
+      warnings: result.warnings,
+    })
   }
 
   const onImportLoad = (fileName: string, xml: string) => {

--- a/src/transport/__tests__/webserial-client.test.ts
+++ b/src/transport/__tests__/webserial-client.test.ts
@@ -90,7 +90,7 @@ const installNavigatorSerial = (getPortsResult: SerialPort[] = []): void => {
 }
 
 const flush = async (): Promise<void> => {
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 20; i++) {
     await Promise.resolve()
   }
 }
@@ -462,6 +462,63 @@ describe('SerialClient — reconnect retry', () => {
     expect(openMock).toHaveBeenCalledTimes(4)
 
     client.disconnect()
+  })
+})
+
+describe('SerialClient — reconnect gives up', () => {
+  it('stops after 6 attempts and settles on disconnected instead of retrying forever', async () => {
+    vi.useFakeTimers()
+    const fake = makeFakePort()
+    const client = new SerialClient()
+    await client.connect(fake.port)
+    const openMock = vi.mocked(fake.port.open)
+    openMock.mockRejectedValue(new Error('failed to open'))
+
+    fake.closeReader()
+    await flush()
+    expect(client.getStatus()).toBe('reconnecting')
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+
+    expect(client.getStatus()).toBe('disconnected')
+    const attempts = openMock.mock.calls.length - 1
+    expect(attempts).toBe(6)
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    expect(openMock.mock.calls.length - 1).toBe(6)
+
+    client.disconnect()
+  })
+})
+
+describe('SerialClient — subscriber isolation', () => {
+  it('a throwing subscriber does not tear down the connection', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const fake = makeFakePort()
+    const client = new SerialClient({ disableReconnect: true })
+    const good = vi.fn()
+
+    client.subscribe('tele', () => {
+      throw new Error('render blew up')
+    })
+    client.subscribe('can', good)
+
+    await client.connect(fake.port)
+    fake.pushBytes('{"tele":1,"v":{"rpm":1}}\n')
+    await flush()
+
+    expect(client.getStatus()).toBe('connected')
+
+    fake.pushBytes('{"can":1,"id":1,"len":0,"d":[]}\n')
+    await flush()
+
+    expect(good).toHaveBeenCalledTimes(1)
+    expect(
+      warn.mock.calls.filter(([msg]) => typeof msg === 'string' && msg.includes('tele subscriber'))
+    ).toHaveLength(1)
+
+    client.disconnect()
+    warn.mockRestore()
   })
 })
 

--- a/src/transport/webserial-client.ts
+++ b/src/transport/webserial-client.ts
@@ -13,6 +13,7 @@ const BYTES_PER_KB = 1024
 const RECONNECT_INITIAL_MS = 500
 const RECONNECT_MAX_MS = 30_000
 const RECONNECT_FACTOR = 2
+const RECONNECT_MAX_ATTEMPTS = 6
 
 const STALE_ACK_FLUSH_MS = 1_000
 
@@ -111,6 +112,7 @@ export class SerialClient {
   private activityListeners: ActivityListener[] = []
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectDelay = RECONNECT_INITIAL_MS
+  private reconnectAttempts = 0
   private staleAckDiscards = 0
   private staleAckFlushTimer: ReturnType<typeof setTimeout> | null = null
   private successUptimeStartedAt: number | null = null
@@ -160,6 +162,7 @@ export class SerialClient {
     this.intentionalDisconnect = false
     this.cancelReconnect()
     this.reconnectDelay = RECONNECT_INITIAL_MS
+    this.reconnectAttempts = 0
     this.successUptimeStartedAt = null
 
     if (this.active) {
@@ -268,6 +271,7 @@ export class SerialClient {
     this.rxResyncing = false
     this.clearStaleAckFlush()
     this.successUptimeStartedAt = Date.now()
+    this.reconnectAttempts = 0
     this.lastError = undefined
     this.setStatus('connected')
 
@@ -287,12 +291,18 @@ export class SerialClient {
     } catch (err) {
       this.lastError = errorMessage(err, 'read_error')
     } finally {
+      await this.finishReadLoop(own)
+    }
+  }
+
+  private async finishReadLoop(own: PortHandles): Promise<void> {
+    await bestEffort('[serial] final drain', () => {
       const tail = this.decoder.decode()
       if (tail) this.rxBuffer += tail
       this.drainFrames()
-      await this.releaseHandles(own)
-      if (!this.isSuperseded(own)) this.handleClose(own)
-    }
+    })
+    await this.releaseHandles(own)
+    if (!this.isSuperseded(own)) this.handleClose(own)
   }
 
   private isSuperseded(own: PortHandles): boolean {
@@ -371,7 +381,9 @@ export class SerialClient {
 
     for (const sub of this.subscriptions) {
       if (sub.discriminator in parsed) {
-        sub.handler(parsed)
+        void bestEffort(`[serial] ${sub.discriminator} subscriber`, () => {
+          sub.handler(parsed)
+        })
         return
       }
     }
@@ -429,7 +441,9 @@ export class SerialClient {
       this.drainPendingSends()
       return
     }
-    void this.dispatchSend(next.cmd, next.fields, next.opts).then(next.resolve)
+    void bestEffort('[serial] queued send', () =>
+      this.dispatchSend(next.cmd, next.fields, next.opts).then(next.resolve)
+    )
   }
 
   private drainQueueWithError(reason: string): void {
@@ -507,10 +521,15 @@ export class SerialClient {
     if (!this.autoReconnect || this.intentionalDisconnect) return
     if (this.reconnectTimer) return
     if (!port) return
+    if (this.reconnectAttempts >= RECONNECT_MAX_ATTEMPTS) {
+      this.setStatus('disconnected', 'auto_reconnect_failed')
+      return
+    }
 
     this.setStatus('reconnecting', this.lastError)
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null
+      this.reconnectAttempts += 1
       this.reconnectDelay = Math.min(this.reconnectDelay * RECONNECT_FACTOR, RECONNECT_MAX_MS)
       void this.openPort(port).catch(() => {
         this.scheduleReconnect(port)


### PR DESCRIPTION
Closes #100. Second and final half — the "Other error-path defects" section. The title items shipped in #104.

## What

**A throwing subscriber tore down the serial connection.** `onFrame` called `sub.handler(parsed)` bare, inside `drainFrames()`, inside `runReadLoop`'s `try`. Any throw from a React subscriber — a render bug, a bad store update — was caught by the read loop's own `catch`, recorded as `lastError`, and **ended the loop**. A UI bug presented as a dropped cable. Handlers are now isolated through `bestEffort`, so one bad subscriber cannot take the link with it, and it is logged rather than silently reinterpreted.

**The `finally` could leak the port.** A throw from `drainFrames()` skipped both `releaseHandles` **and** `handleClose`, leaking the reader and writer locks — the exact class `b0736f6` fixed one layer down. The five things it did are now `finishReadLoop(own)`, with the final drain wrapped so a failure there cannot stop the release from running.

**The reconnect loop had no attempt cap.** `openPort().catch(() => scheduleReconnect(port))` recursed forever: a dash left unplugged retried until the tab closed, holding `reconnecting` and never letting the UI offer anything else. Capped at `RECONNECT_MAX_ATTEMPTS = 6`, after which it settles on `disconnected` with `auto_reconnect_failed` — a message that already existed in the table with nothing setting it. The counter resets on a successful open and on an explicit `connect()`.

**Three floating promises, no `.catch`,** while every sibling call site had one — omissions, not convention:

- `CliRoute` — a rejection stranded `setBusy(true)` and wedged the console form permanently. `setBusy(false)` moved into `.finally()`, so it runs on every outcome.
- `useVersionHandshake` — a rejection left `firmwareCompat` unset forever, so the burn gate never resolved either way. Now falls to `{ kind: 'unknown' }`, the same state an error result produces.
- `XmlImportZone` — a `File.text()` failure was completely silent; the user saw nothing happen. Now routed to the existing `onError`.

`drainPendingSends`'s `void …then(next.resolve)` also gets a `catch`.

**`EcuRoute` reported a parser bug as a network failure.** One `try` spanned `fetch`, `res.text()`, `parseCanXml()` and `setSource()`, so a `parseCanXml` crash surfaced as "Catalogue load failed", masking a real defect. The `try` now covers only `fetch` / `text()`; a parser crash reaches the `ErrorBoundary` that already exists and logs component stacks.

## One test-harness change

`flush()` drained a fixed 5 microtask turns. `finishReadLoop` adds one turn to the teardown chain, which broke two reconnect tests that were implicitly asserting the exact turn count rather than the resulting state. Raised to 20 — the harness should drain the queue, not count it.

## Test plan

- **reconnect gives up** — with `open` permanently rejecting, exactly 6 attempts run, the client settles on `disconnected`, and ten more minutes of timers produce no further attempts
- **subscriber isolation** — a `tele` subscriber that throws leaves the status `connected`, a later `can` frame still reaches its subscriber, and the failure is logged once

323 tests / 52 files green — up from 321. `typecheck`, `lint`, `format:check`, `build` all pass. `grep "void .*\.then("` over `src/` outside tests returns nothing without a `.catch`. Not exercised against a board.

## Acceptance on #100

- [x] no raw transport code renders to a user — #104
- [x] one `errorMessage` helper; no inline `instanceof Error` ternary in `src/` — #104
- [x] no floating promise without a `.catch`