### PR TITLE
ci(tuner): deploy from GitHub Actions instead of the Vercel Git integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,105 @@
+name: deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Which Vercel environment to deploy
+        required: true
+        default: preview
+        type: choice
+        options:
+          - preview
+          - production
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  NODE_VERSION: '24'
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    env:
+      TARGET: ${{ inputs.target || (github.ref == 'refs/heads/main' && 'production') || 'preview' }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Vercel CLI
+        run: npm i -g vercel@latest
+
+      - name: Pull Vercel project settings
+        run: vercel pull --yes --environment=${{ env.TARGET }} --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build
+        run: vercel build ${{ env.TARGET == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy prebuilt output
+        id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt ${{ env.TARGET == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Deployed to $url"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Comment the preview URL
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.deploy.outputs.url }}'
+            const marker = '<!-- vercel-preview -->'
+            const body = `${marker}\n**Preview:** ${url}`
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const existing = comments.find((c) => c.body?.startsWith(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+              return
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            })
+
+      - name: Summary
+        run: |
+          {
+            echo "### Deployed (${{ env.TARGET }})"
+            echo ""
+            echo "${{ steps.deploy.outputs.url }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,15 @@
 {
+  "git": {
+    "deploymentEnabled": false
+  },
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }],
+  "rewrites": [
+    {
+      "source": "/((?!api/).*)",
+      "destination": "/index.html"
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",
@@ -10,16 +18,36 @@
           "key": "Content-Security-Policy",
           "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api.github.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://tmbk.ch; worker-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
         },
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "Referrer-Policy", "value": "no-referrer" },
-        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
-        { "key": "Permissions-Policy", "value": "serial=(self)" }
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "no-referrer"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "serial=(self)"
+        }
       ]
     },
     {
       "source": "/assets/(.*)",
-      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Mirrors what canshift-docs just switched to (CANShift/canshift-docs#114, #118).

## Urgent context

**The Vercel Git integration for this project has already been disconnected**, so `main` currently has no publisher at all — nothing deploys tuner.canshift.app until this merges. That is the reason this is not sitting behind a runbook like the docs one did.

## What

`vercel pull` → `vercel build` → `vercel deploy --prebuilt`, on:

- `push: main` → production
- `pull_request` → preview, URL posted as a PR comment (updated in place)
- `workflow_dispatch` → either, manually

`TARGET` is derived once — dispatch input, else `production` on `main`, else `preview` — so the `--prod` flag, the pulled environment and the summary cannot disagree.

`cancel-in-progress` is true for pull requests only; superseding a preview is fine, cancelling a half-finished production deploy is not.

The three secrets already exist here (`VERCEL_TOKEN` added tonight, `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` since 2026-08-02).

## Two differences from the docs workflow

- **No `GITHUB_TOKEN`, and no token-source reporting step.** Those exist in docs because its changelog fetches GitHub releases *at build time*. This build makes no network calls: the only `fetch` in `vite.config.ts` is inside `configureServer`, so it runs in the dev server and never during `vite build`. Passing a token this build cannot use would be cargo cult.
- **`vercel.json` gains `git.deploymentEnabled: false`.** Belt-and-braces: the dashboard disconnect is the live state, but this records the intent in the repo, so reconnecting by accident does not silently produce a second publisher racing this workflow on the production alias.

## Test plan

`typecheck`, `lint`, `test` (52 files), `build` and `format:check` all clean locally. The workflow itself is exercised by this PR — the `pull_request` path runs from the PR head, so a green `deploy` check here means preview deployment and the comment step both work before anything touches production.

The first production deploy is the merge commit. Worth watching, and reversible: reconnecting the Git integration restores the previous publisher, and Vercel's own rollback is unaffected — this changes only who runs `npm run build`, not where the site is hosted.