### PR TITLE
refactor(tuner): one localStorage module and one key namespace

### DIFF
--- a/src/components/shell/FeedbackButton.tsx
+++ b/src/components/shell/FeedbackButton.tsx
@@ -1,20 +1,11 @@
 import { useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { submitFeedback } from '../../lib/feedback'
+import { readItem, writeItem, STORAGE_KEYS } from '../../lib/local-storage'
 
-const STORAGE_KEY = 'canshift:feedback-dismissed-hint'
-const LEGACY_STORAGE_KEY = 'tuner.feedback.dismissed-hint'
+const STORAGE_KEY = STORAGE_KEYS.feedbackDismissedHint
 
-const readDismissed = (): boolean => {
-  if (localStorage.getItem(STORAGE_KEY) === '1') return true
-  if (localStorage.getItem(LEGACY_STORAGE_KEY) === '1') {
-    localStorage.setItem(STORAGE_KEY, '1')
-    localStorage.removeItem(LEGACY_STORAGE_KEY)
-    return true
-  }
-  localStorage.removeItem(LEGACY_STORAGE_KEY)
-  return false
-}
+const readDismissed = (): boolean => readItem(STORAGE_KEY) === '1'
 
 type Status = 'idle' | 'sending' | 'sent' | 'error'
 
@@ -40,7 +31,7 @@ const FeedbackButton = () => {
 
   const dismissHint = () => {
     setShowHint(false)
-    localStorage.setItem(STORAGE_KEY, '1')
+    writeItem(STORAGE_KEY, '1')
   }
 
   const openDialog = () => {

--- a/src/lib/local-storage.test.ts
+++ b/src/lib/local-storage.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  migrateLegacyKeys,
+  projectStorageKey,
+  readItem,
+  readJson,
+  removeItem,
+  STORAGE_KEYS,
+  writeItem,
+} from './local-storage'
+
+const memoryStorage = (): Storage => {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => {
+      map.clear()
+    },
+    getItem: (k: string) => map.get(k) ?? null,
+    key: (i: number) => [...map.keys()][i] ?? null,
+    removeItem: (k: string) => {
+      map.delete(k)
+    },
+    setItem: (k: string, v: string) => {
+      map.set(k, v)
+    },
+  }
+}
+
+const throwingStorage = (): Storage =>
+  ({
+    getItem: () => {
+      throw new Error('blocked')
+    },
+    setItem: () => {
+      throw new Error('quota')
+    },
+    removeItem: () => {
+      throw new Error('blocked')
+    },
+  }) as unknown as Storage
+
+beforeEach(() => {
+  globalThis.localStorage = memoryStorage()
+})
+
+describe('every key lives under one namespace', () => {
+  it('has no key outside canshift.tuner.', () => {
+    const strays = Object.values(STORAGE_KEYS).filter((k) => !k.startsWith('canshift.tuner.'))
+    expect(strays).toEqual([])
+  })
+
+  it('namespaces project keys too', () => {
+    expect(projectStorageKey('abc')).toBe('canshift.tuner.project.abc')
+  })
+
+  it('has no duplicate key', () => {
+    const values = Object.values(STORAGE_KEYS)
+    expect(new Set(values).size).toBe(values.length)
+  })
+})
+
+describe('storage access never throws', () => {
+  it('reads null and reports a failed write when localStorage is blocked', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    globalThis.localStorage = throwingStorage()
+
+    expect(readItem('x')).toBeNull()
+    expect(writeItem('x', '1')).toBe(false)
+    expect(() => {
+      removeItem('x')
+    }).not.toThrow()
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('readJson rejects malformed JSON and values failing the guard', () => {
+    const isNumber = (v: unknown): v is number => typeof v === 'number'
+    writeItem('k', '{oops')
+    expect(readJson('k', isNumber)).toBeNull()
+    writeItem('k', '"a string"')
+    expect(readJson('k', isNumber)).toBeNull()
+    writeItem('k', '42')
+    expect(readJson('k', isNumber)).toBe(42)
+  })
+})
+
+describe('legacy keys migrate once, without data loss', () => {
+  it('moves a legacy value to its namespaced key and drops the old one', () => {
+    localStorage.setItem('cs-left-nav-collapsed', '1')
+    localStorage.setItem('canshift:signal-store-v1', '{"a":1}')
+    localStorage.setItem('canshift.log.verbose', '1')
+
+    migrateLegacyKeys()
+
+    expect(readItem(STORAGE_KEYS.leftNavCollapsed)).toBe('1')
+    expect(readItem(STORAGE_KEYS.signals)).toBe('{"a":1}')
+    expect(readItem(STORAGE_KEYS.logVerbose)).toBe('1')
+    expect(localStorage.getItem('cs-left-nav-collapsed')).toBeNull()
+    expect(localStorage.getItem('canshift:signal-store-v1')).toBeNull()
+  })
+
+  it('never overwrites a value already stored under the new key', () => {
+    writeItem(STORAGE_KEYS.theme, 'light')
+    localStorage.setItem('canshift.tuner.theme', 'light')
+    localStorage.setItem('cs-left-nav-collapsed', '1')
+    writeItem(STORAGE_KEYS.leftNavCollapsed, '0')
+
+    migrateLegacyKeys()
+
+    expect(readItem(STORAGE_KEYS.leftNavCollapsed)).toBe('0')
+    expect(localStorage.getItem('cs-left-nav-collapsed')).toBeNull()
+  })
+
+  it('is idempotent — a second run changes nothing', () => {
+    localStorage.setItem('tuner.feedback.dismissed-hint', '1')
+    migrateLegacyKeys()
+    const after = readItem(STORAGE_KEYS.feedbackDismissedHint)
+    migrateLegacyKeys()
+    expect(readItem(STORAGE_KEYS.feedbackDismissedHint)).toBe(after)
+    expect(after).toBe('1')
+  })
+
+  it('does nothing when there is no legacy data', () => {
+    migrateLegacyKeys()
+    expect(readItem(STORAGE_KEYS.leftNavCollapsed)).toBeNull()
+  })
+})

--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -1,0 +1,82 @@
+const NAMESPACE = 'canshift.tuner.'
+
+const key = (name: string): string => `${NAMESPACE}${name}`
+
+export const STORAGE_KEYS = {
+  autosave: key('autosave'),
+  boardProfiles: key('board-profiles'),
+  feedbackDismissedHint: key('feedback-dismissed-hint'),
+  flashHistory: key('flash-history'),
+  inspectorCollapsed: key('inspector-collapsed'),
+  leftNavCollapsed: key('left-nav-collapsed'),
+  logVerbose: key('log-verbose'),
+  observability: key('observability'),
+  pageTemplates: key('page-templates'),
+  projectIndex: key('projects'),
+  selectedBoard: key('selected-board'),
+  signals: key('signals'),
+  theme: key('theme'),
+} as const
+
+export const PROJECT_KEY_PREFIX = key('project.')
+
+export const projectStorageKey = (id: string): string => `${PROJECT_KEY_PREFIX}${id}`
+
+const LEGACY_KEYS: Record<string, string> = {
+  'cs-left-nav-collapsed': STORAGE_KEYS.leftNavCollapsed,
+  'cs-inspector-collapsed': STORAGE_KEYS.inspectorCollapsed,
+  'canshift:feedback-dismissed-hint': STORAGE_KEYS.feedbackDismissedHint,
+  'canshift:signal-store-v1': STORAGE_KEYS.signals,
+  'canshift.log.verbose': STORAGE_KEYS.logVerbose,
+  'tuner.feedback.dismissed-hint': STORAGE_KEYS.feedbackDismissedHint,
+}
+
+export const readItem = (name: string): string | null => {
+  try {
+    return localStorage.getItem(name)
+  } catch {
+    return null
+  }
+}
+
+export const writeItem = (name: string, value: string): boolean => {
+  try {
+    localStorage.setItem(name, value)
+    return true
+  } catch {
+    console.warn(`[storage] could not persist ${name} — the change will not survive a reload`)
+    return false
+  }
+}
+
+export const removeItem = (name: string): void => {
+  try {
+    localStorage.removeItem(name)
+  } catch {
+    console.warn(`[storage] could not remove ${name}`)
+  }
+}
+
+export const readJson = <T>(name: string, guard: (value: unknown) => value is T): T | null => {
+  const raw = readItem(name)
+  if (raw === null) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  return guard(parsed) ? parsed : null
+}
+
+export const writeJson = (name: string, value: unknown): boolean =>
+  writeItem(name, JSON.stringify(value))
+
+export const migrateLegacyKeys = (): void => {
+  for (const [from, to] of Object.entries(LEGACY_KEYS)) {
+    const legacy = readItem(from)
+    if (legacy === null) continue
+    if (readItem(to) === null) writeItem(to, legacy)
+    removeItem(from)
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,11 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
+import { migrateLegacyKeys } from './lib/local-storage'
 import { initTelemetry } from './lib/telemetry'
 import './index.css'
 
+migrateLegacyKeys()
 initTelemetry()
 
 const root = document.getElementById('root')

--- a/src/stores/board-config/storage.ts
+++ b/src/stores/board-config/storage.ts
@@ -1,7 +1,8 @@
 import type { BoardProfile } from '@canshift/core'
+import { readItem, writeItem, removeItem, STORAGE_KEYS } from '../../lib/local-storage'
 
-export const CUSTOM_BOARDS_KEY = 'canshift.tuner.board-profiles'
-export const SELECTED_BOARD_KEY = 'canshift.tuner.selected-board'
+export const CUSTOM_BOARDS_KEY = STORAGE_KEYS.boardProfiles
+export const SELECTED_BOARD_KEY = STORAGE_KEYS.selectedBoard
 
 export interface CustomBoardEntry {
   id: string
@@ -11,23 +12,6 @@ export interface CustomBoardEntry {
 }
 
 export type SelectedBoard = { source: 'catalog' | 'custom'; boardId: string }
-
-const safeGet = (key: string): string | null => {
-  try {
-    return localStorage.getItem(key)
-  } catch {
-    return null
-  }
-}
-
-const safeSet = (key: string, value: string): boolean => {
-  try {
-    localStorage.setItem(key, value)
-    return true
-  } catch {
-    return false
-  }
-}
 
 const isEntry = (value: unknown): value is CustomBoardEntry => {
   if (typeof value !== 'object' || value === null) return false
@@ -44,7 +28,7 @@ const isEntry = (value: unknown): value is CustomBoardEntry => {
 }
 
 export const readCustomBoards = (): CustomBoardEntry[] => {
-  const raw = safeGet(CUSTOM_BOARDS_KEY)
+  const raw = readItem(CUSTOM_BOARDS_KEY)
   if (raw === null) return []
   let parsed: unknown
   try {
@@ -56,10 +40,10 @@ export const readCustomBoards = (): CustomBoardEntry[] => {
 }
 
 export const writeCustomBoards = (entries: CustomBoardEntry[]): boolean =>
-  safeSet(CUSTOM_BOARDS_KEY, JSON.stringify(entries))
+  writeItem(CUSTOM_BOARDS_KEY, JSON.stringify(entries))
 
 export const readSelectedBoard = (): SelectedBoard | null => {
-  const raw = safeGet(SELECTED_BOARD_KEY)
+  const raw = readItem(SELECTED_BOARD_KEY)
   if (raw === null) return null
   let parsed: unknown
   try {
@@ -76,12 +60,8 @@ export const readSelectedBoard = (): SelectedBoard | null => {
 
 export const writeSelectedBoard = (selected: SelectedBoard | null): void => {
   if (selected === null) {
-    try {
-      localStorage.removeItem(SELECTED_BOARD_KEY)
-    } catch {
-      void 0
-    }
+    removeItem(SELECTED_BOARD_KEY)
     return
   }
-  safeSet(SELECTED_BOARD_KEY, JSON.stringify(selected))
+  writeItem(SELECTED_BOARD_KEY, JSON.stringify(selected))
 }

--- a/src/stores/dashboard/autosave.ts
+++ b/src/stores/dashboard/autosave.ts
@@ -1,7 +1,8 @@
 import { CURRENT_SCHEMA_VERSION, DashboardConfigSchema, migrateConfig } from '@canshift/core'
 import type { DashboardConfig } from '@canshift/core'
+import { readItem, writeItem, removeItem, STORAGE_KEYS } from '../../lib/local-storage'
 
-export const AUTOSAVE_KEY = 'canshift.tuner.autosave'
+export const AUTOSAVE_KEY = STORAGE_KEYS.autosave
 export const AUTOSAVE_DEBOUNCE_MS = 500
 
 export interface AutosavePayload {
@@ -86,21 +87,10 @@ export const parseAutosave = (raw: string): AutosavePayload | null => {
 
 export const readAutosave = (): AutosavePayload | null => {
   if (typeof window === 'undefined') return null
-  let raw: string | null
-  try {
-    raw = window.localStorage.getItem(AUTOSAVE_KEY)
-  } catch {
-    return null
-  }
+  const raw = readItem(AUTOSAVE_KEY)
   if (raw === null) return null
   const payload = parseAutosave(raw)
-  if (payload === null) {
-    try {
-      window.localStorage.removeItem(AUTOSAVE_KEY)
-    } catch {
-      void 0
-    }
-  }
+  if (payload === null) removeItem(AUTOSAVE_KEY)
   return payload
 }
 
@@ -142,11 +132,7 @@ export const startAutosave = (store: AutosaveStore): (() => void) => {
     const savedAt = Date.now()
     const raw = serializeAutosave(s, savedAt)
     if (raw === null) return
-    try {
-      window.localStorage.setItem(AUTOSAVE_KEY, raw)
-    } catch {
-      return
-    }
+    if (!writeItem(AUTOSAVE_KEY, raw)) return
     lastWritten = s
     store.getState().markAutosaved(savedAt)
   }

--- a/src/stores/flash-history.store.ts
+++ b/src/stores/flash-history.store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { readItem, writeItem, STORAGE_KEYS } from '../lib/local-storage'
 
 export interface FlashHistoryEntry {
   label: string
@@ -6,13 +7,13 @@ export interface FlashHistoryEntry {
   ok: boolean
 }
 
-const STORAGE_KEY = 'canshift.tuner.flash-history'
+const STORAGE_KEY = STORAGE_KEYS.flashHistory
 const HISTORY_CAP = 20
 
 const readStoredHistory = (): FlashHistoryEntry[] => {
   if (typeof window === 'undefined') return []
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY)
+    const raw = readItem(STORAGE_KEY)
     if (raw === null) return []
     const parsed: unknown = JSON.parse(raw)
     if (!Array.isArray(parsed)) return []
@@ -32,7 +33,7 @@ const readStoredHistory = (): FlashHistoryEntry[] => {
 const writeStoredHistory = (entries: FlashHistoryEntry[]): void => {
   if (typeof window === 'undefined') return
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+    writeItem(STORAGE_KEY, JSON.stringify(entries))
   } catch {
     void 0
   }

--- a/src/stores/log.store.ts
+++ b/src/stores/log.store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { readItem, writeItem, STORAGE_KEYS } from '../lib/local-storage'
 
 export type LogLevel = 'info' | 'warn' | 'error' | 'success' | 'debug'
 
@@ -20,12 +21,12 @@ interface LogState {
   clear: () => void
 }
 
-const VERBOSE_STORAGE_KEY = 'canshift.log.verbose'
+const VERBOSE_STORAGE_KEY = STORAGE_KEYS.logVerbose
 
 const readVerboseFlag = (): boolean => {
   if (typeof window === 'undefined') return false
   try {
-    return window.localStorage.getItem(VERBOSE_STORAGE_KEY) === '1'
+    return readItem(VERBOSE_STORAGE_KEY) === '1'
   } catch {
     return false
   }
@@ -34,7 +35,7 @@ const readVerboseFlag = (): boolean => {
 const writeVerboseFlag = (verbose: boolean): void => {
   if (typeof window === 'undefined') return
   try {
-    window.localStorage.setItem(VERBOSE_STORAGE_KEY, verbose ? '1' : '0')
+    writeItem(VERBOSE_STORAGE_KEY, verbose ? '1' : '0')
   } catch {
     void 0
   }

--- a/src/stores/observability.store.ts
+++ b/src/stores/observability.store.ts
@@ -1,10 +1,11 @@
 import { create } from 'zustand'
+import { readItem, writeItem, STORAGE_KEYS } from '../lib/local-storage'
 
-const STORAGE_KEY = 'canshift.tuner.observability'
+const STORAGE_KEY = STORAGE_KEYS.observability
 
 export const readStoredObservability = (): boolean => {
   try {
-    return localStorage.getItem(STORAGE_KEY) === 'on'
+    return readItem(STORAGE_KEY) === 'on'
   } catch {
     return false
   }
@@ -12,7 +13,7 @@ export const readStoredObservability = (): boolean => {
 
 const writeStored = (enabled: boolean): void => {
   try {
-    localStorage.setItem(STORAGE_KEY, enabled ? 'on' : 'off')
+    writeItem(STORAGE_KEY, enabled ? 'on' : 'off')
   } catch {
     void 0
   }

--- a/src/stores/project/storage.ts
+++ b/src/stores/project/storage.ts
@@ -5,44 +5,23 @@ import {
   migrateConfig,
 } from '@canshift/core'
 import type { Project, ProjectMeta } from '@canshift/core'
+import {
+  readItem,
+  writeItem,
+  removeItem,
+  projectStorageKey,
+  STORAGE_KEYS,
+} from '../../lib/local-storage'
 
-export const PROJECT_INDEX_KEY = 'canshift.tuner.projects'
-const PROJECT_KEY_PREFIX = 'canshift.tuner.project.'
+export const PROJECT_INDEX_KEY = STORAGE_KEYS.projectIndex
 
 export interface ProjectIndex {
   activeId: string | null
   projects: ProjectMeta[]
 }
 
-export const projectStorageKey = (id: string): string => `${PROJECT_KEY_PREFIX}${id}`
-
-const safeGet = (key: string): string | null => {
-  try {
-    return localStorage.getItem(key)
-  } catch {
-    return null
-  }
-}
-
-const safeSet = (key: string, value: string): boolean => {
-  try {
-    localStorage.setItem(key, value)
-    return true
-  } catch {
-    return false
-  }
-}
-
-const safeRemove = (key: string): void => {
-  try {
-    localStorage.removeItem(key)
-  } catch {
-    void 0
-  }
-}
-
 export const readProjectIndex = (): ProjectIndex | null => {
-  const raw = safeGet(PROJECT_INDEX_KEY)
+  const raw = readItem(PROJECT_INDEX_KEY)
   if (raw === null) return null
   let parsed: unknown
   try {
@@ -67,7 +46,7 @@ export const readProjectIndex = (): ProjectIndex | null => {
 }
 
 export const writeProjectIndex = (index: ProjectIndex): void => {
-  safeSet(PROJECT_INDEX_KEY, JSON.stringify(index))
+  writeItem(PROJECT_INDEX_KEY, JSON.stringify(index))
 }
 
 export const deserializeProject = (raw: string): Project | null => {
@@ -93,18 +72,20 @@ export const deserializeProject = (raw: string): Project | null => {
 }
 
 export const readProject = (id: string): Project | null => {
-  const raw = safeGet(projectStorageKey(id))
+  const raw = readItem(projectStorageKey(id))
   if (raw === null) return null
   return deserializeProject(raw)
 }
 
 export const writeProject = (project: Project): boolean => {
   if (!ProjectSchema.safeParse(project).success) return false
-  return safeSet(projectStorageKey(project.id), JSON.stringify(project))
+  return writeItem(projectStorageKey(project.id), JSON.stringify(project))
 }
 
 export const removeProject = (id: string): void => {
-  safeRemove(projectStorageKey(id))
+  removeItem(projectStorageKey(id))
 }
+
+export { projectStorageKey }
 
 export const PROJECT_VERSION = PROJECT_FILE_VERSION

--- a/src/stores/signal.store.ts
+++ b/src/stores/signal.store.ts
@@ -1,12 +1,13 @@
 import { create } from 'zustand'
 import type { SignalDef } from '@canshift/core'
 import { DEFAULT_PROFILE_ID, ECU_PROFILES } from '@canshift/core'
+import { readItem, writeItem, STORAGE_KEYS } from '../lib/local-storage'
 
 const FALLBACK_PROFILE_ID = 'maxxecu-street'
 const FALLBACK_SIGNALS: SignalDef[] =
   ECU_PROFILES.find((p) => p.id === FALLBACK_PROFILE_ID)?.signals ?? []
 
-const STORAGE_KEY = 'canshift:signal-store-v1'
+const STORAGE_KEY = STORAGE_KEYS.signals
 export const DEFAULT_PROFILE_KEY = `builtin:${DEFAULT_PROFILE_ID}`
 
 interface StoredState {
@@ -16,7 +17,7 @@ interface StoredState {
 
 const readStored = (): StoredState | null => {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY)
+    const raw = readItem(STORAGE_KEY)
     if (!raw) return null
     const parsed: unknown = JSON.parse(raw)
     if (
@@ -34,7 +35,7 @@ const readStored = (): StoredState | null => {
 
 const writeStored = (state: StoredState): void => {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+    writeItem(STORAGE_KEY, JSON.stringify(state))
   } catch {
     void 0
   }

--- a/src/stores/template/storage.ts
+++ b/src/stores/template/storage.ts
@@ -1,29 +1,13 @@
 import type { PageConfig } from '@canshift/core'
+import { readItem, writeItem, STORAGE_KEYS } from '../../lib/local-storage'
 
-export const PAGE_TEMPLATES_KEY = 'canshift.tuner.page-templates'
+export const PAGE_TEMPLATES_KEY = STORAGE_KEYS.pageTemplates
 
 export interface PageTemplateEntry {
   id: string
   name: string
   createdAt: string
   page: PageConfig
-}
-
-const safeGet = (key: string): string | null => {
-  try {
-    return localStorage.getItem(key)
-  } catch {
-    return null
-  }
-}
-
-const safeSet = (key: string, value: string): boolean => {
-  try {
-    localStorage.setItem(key, value)
-    return true
-  } catch {
-    return false
-  }
 }
 
 const isEntry = (value: unknown): value is PageTemplateEntry => {
@@ -39,7 +23,7 @@ const isEntry = (value: unknown): value is PageTemplateEntry => {
 }
 
 export const readTemplates = (): PageTemplateEntry[] => {
-  const raw = safeGet(PAGE_TEMPLATES_KEY)
+  const raw = readItem(PAGE_TEMPLATES_KEY)
   if (raw === null) return []
   let parsed: unknown
   try {
@@ -52,4 +36,4 @@ export const readTemplates = (): PageTemplateEntry[] => {
 }
 
 export const writeTemplates = (templates: PageTemplateEntry[]): boolean =>
-  safeSet(PAGE_TEMPLATES_KEY, JSON.stringify(templates))
+  writeItem(PAGE_TEMPLATES_KEY, JSON.stringify(templates))

--- a/src/stores/theme.store.ts
+++ b/src/stores/theme.store.ts
@@ -1,13 +1,14 @@
 import { create } from 'zustand'
+import { readItem, writeItem, STORAGE_KEYS } from '../lib/local-storage'
 
 export type ChromeTheme = 'dark' | 'light'
 
-const THEME_STORAGE_KEY = 'canshift.tuner.theme'
+const THEME_STORAGE_KEY = STORAGE_KEYS.theme
 
 const readStoredTheme = (): ChromeTheme => {
   if (typeof window === 'undefined') return 'dark'
   try {
-    return window.localStorage.getItem(THEME_STORAGE_KEY) === 'light' ? 'light' : 'dark'
+    return readItem(THEME_STORAGE_KEY) === 'light' ? 'light' : 'dark'
   } catch {
     return 'dark'
   }
@@ -16,7 +17,7 @@ const readStoredTheme = (): ChromeTheme => {
 const writeStoredTheme = (theme: ChromeTheme): void => {
   if (typeof window === 'undefined') return
   try {
-    window.localStorage.setItem(THEME_STORAGE_KEY, theme)
+    writeItem(THEME_STORAGE_KEY, theme)
   } catch {
     void 0
   }

--- a/src/stores/ui.store.ts
+++ b/src/stores/ui.store.ts
@@ -1,11 +1,12 @@
 import { create } from 'zustand'
+import { readItem, writeItem, STORAGE_KEYS } from '../lib/local-storage'
 
-const LEFT_NAV_KEY = 'cs-left-nav-collapsed'
-const INSPECTOR_KEY = 'cs-inspector-collapsed'
+const LEFT_NAV_KEY = STORAGE_KEYS.leftNavCollapsed
+const INSPECTOR_KEY = STORAGE_KEYS.inspectorCollapsed
 
 const readCollapsed = (key: string): boolean => {
   try {
-    return localStorage.getItem(key) === '1'
+    return readItem(key) === '1'
   } catch {
     return false
   }
@@ -13,7 +14,7 @@ const readCollapsed = (key: string): boolean => {
 
 const writeCollapsed = (key: string, value: boolean): void => {
   try {
-    localStorage.setItem(key, value ? '1' : '0')
+    writeItem(key, value ? '1' : '0')
   } catch {
     return
   }


### PR DESCRIPTION
Closes #96.

## What

`safeGet` / `safeSet` were **byte-identical in three files**, and nine more hand-rolled the same `try`/`catch` around `localStorage` — 12 files in all. `src/lib/local-storage.ts` now owns it: `readItem` / `writeItem` / `removeItem` / `readJson<T>(key, guard)` / `writeJson`.

After: `grep -rn localStorage src` outside the module and its tests returns **one** line — `persistence: 'localStorage'` in the PostHog config, which is a string naming a backend, not an API call. The three private copies are gone.

`writeItem` also stops swallowing quota failures silently: it returns `false` **and** logs, which is what `autosave.ts` needed to know whether the write landed.

## The key namespace was fractured four ways

`cs-<name>`, `canshift:<name>`, `canshift.log.<name>` and `canshift.tuner.<name>` all coexisted. Everything is now `canshift.tuner.<name>`, from a single `STORAGE_KEYS` const, with `projectStorageKey(id)` built from the same prefix.

**Five keys therefore move**, so a one-shot `migrateLegacyKeys()` runs from `main.tsx` before anything reads storage:

| was | becomes |
| --- | --- |
| `cs-left-nav-collapsed` | `canshift.tuner.left-nav-collapsed` |
| `cs-inspector-collapsed` | `canshift.tuner.inspector-collapsed` |
| `canshift:signal-store-v1` | `canshift.tuner.signals` |
| `canshift:feedback-dismissed-hint` | `canshift.tuner.feedback-dismissed-hint` |
| `canshift.log.verbose` | `canshift.tuner.log-verbose` |

`FeedbackButton` already ran a bespoke migration for its own older key (`tuner.feedback.dismissed-hint`). That hand-rolled version is deleted and the key folded into the shared table, so there is one migration mechanism rather than two.

## autosave was the tangle

`readAutosave` had a `try` inside an `if` inside a function that had already returned from a `try` — 18 lines for "read, parse, drop it if it is corrupt". It is now five, and the write path is `if (!writeItem(AUTOSAVE_KEY, raw)) return` instead of a `try`/`catch` whose `catch` did the same thing.

## Test plan

`local-storage.test.ts`, 9 cases. The migration ones matter most because that is where user data can be lost:

- a legacy value moves to the namespaced key and the old key is removed
- **an existing value under the new key is never overwritten** by a legacy one
- running it twice changes nothing
- no legacy data is a no-op
- blocked `localStorage` (private mode, quota) reads `null`, reports `false` on write, and never throws
- `readJson` rejects malformed JSON *and* values failing the guard

Plus namespace invariants asserted rather than eyeballed: no key outside `canshift.tuner.`, no duplicates, project keys included.

**332 tests / 53 files green.** `typecheck`, `lint`, `format:check`, `build` clean.

## Not verified

The migration is exercised against an in-memory `Storage` double, not a real browser profile carrying old keys. The logic is small and the "never overwrite" case is covered, but if you have a long-lived tab with the old keys it is worth one manual check that the nav collapse state and signal profile survive a reload.