### PR TITLE
design(tuner): refresh the repo mark

### DIFF
--- a/.github/icons/tuner-avatar-460.svg
+++ b/.github/icons/tuner-avatar-460.svg
@@ -2,7 +2,7 @@
   <rect width="460" height="460" fill="#151313"></rect>
   <svg x="110.4" y="126.9" width="239.2" height="206.2" viewBox="0 0 116 100">
   <g transform="translate(10,0) skewX(-11)" fill="none">
-    <path d="M30 26 H94 V78 H30 Z" stroke="#F3F2F2" stroke-width="7" stroke-dasharray="11 9"></path>
+    <path d="M30 26 H94 V78 H30 Z" stroke="#F3F2F2" stroke-width="7" stroke-dasharray="18 12"></path>
     <path d="M30 26 h0 M94 26 h0 M30 78 h0" stroke="#F3F2F2" stroke-width="18" stroke-linecap="square"></path>
     <path d="M94 78 h0" stroke="#FF4747" stroke-width="18" stroke-linecap="square"></path>
   </g>

--- a/.github/icons/tuner-currentcolor.svg
+++ b/.github/icons/tuner-currentcolor.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 116 100" width="116" height="100" fill="none">
   <g transform="translate(10,0) skewX(-11)" fill="none">
-    <path d="M30 26 H94 V78 H30 Z" stroke="currentColor" stroke-width="7" stroke-dasharray="11 9"></path>
+    <path d="M30 26 H94 V78 H30 Z" stroke="currentColor" stroke-width="7" stroke-dasharray="18 12"></path>
     <path d="M30 26 h0 M94 26 h0 M30 78 h0" stroke="currentColor" stroke-width="18" stroke-linecap="square"></path>
     <path d="M94 78 h0" stroke="#EC3013" stroke-width="18" stroke-linecap="square"></path>
   </g>

--- a/.github/icons/tuner-dark.svg
+++ b/.github/icons/tuner-dark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 116 100" width="116" height="100" fill="none">
   <g transform="translate(10,0) skewX(-11)" fill="none">
-    <path d="M30 26 H94 V78 H30 Z" stroke="#F3F2F2" stroke-width="7" stroke-dasharray="11 9"></path>
+    <path d="M30 26 H94 V78 H30 Z" stroke="#F3F2F2" stroke-width="7" stroke-dasharray="18 12"></path>
     <path d="M30 26 h0 M94 26 h0 M30 78 h0" stroke="#F3F2F2" stroke-width="18" stroke-linecap="square"></path>
     <path d="M94 78 h0" stroke="#FF4747" stroke-width="18" stroke-linecap="square"></path>
   </g>

--- a/.github/icons/tuner-onaccent.svg
+++ b/.github/icons/tuner-onaccent.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 116 100" width="116" height="100" fill="none">
-  <g transform="translate(10,0) skewX(-11)" fill="none"><path d="M30 26 H94 V78 H30 Z" stroke="#FFFFFF" stroke-width="7" stroke-dasharray="11 9"></path><path d="M30 26 h0 M94 26 h0 M30 78 h0" stroke="#FFFFFF" stroke-width="18" stroke-linecap="square"></path><path d="M94 78 h0" stroke="#FFFFFF" stroke-width="18" stroke-linecap="square"></path></g>
+  <g transform="translate(10,0) skewX(-11)" fill="none"><path d="M30 26 H94 V78 H30 Z" stroke="#FFFFFF" stroke-width="7" stroke-dasharray="18 12"></path><path d="M30 26 h0 M94 26 h0 M30 78 h0" stroke="#FFFFFF" stroke-width="18" stroke-linecap="square"></path><path d="M94 78 h0" stroke="#FFFFFF" stroke-width="18" stroke-linecap="square"></path></g>
 </svg>

--- a/.github/icons/tuner.svg
+++ b/.github/icons/tuner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 116 100" width="116" height="100" fill="none">
   <g transform="translate(10,0) skewX(-11)" fill="none">
-    <path d="M30 26 H94 V78 H30 Z" stroke="#201E1D" stroke-width="7" stroke-dasharray="11 9"></path>
+    <path d="M30 26 H94 V78 H30 Z" stroke="#201E1D" stroke-width="7" stroke-dasharray="18 12"></path>
     <path d="M30 26 h0 M94 26 h0 M30 78 h0" stroke="#201E1D" stroke-width="18" stroke-linecap="square"></path>
     <path d="M94 78 h0" stroke="#EC3013" stroke-width="18" stroke-linecap="square"></path>
   </g>


### PR DESCRIPTION
New icon handoff from `design_handoff_canshift_docs/canshift-repo-icons`. Five of the seven tuner files changed; `tuner-small.svg` and `tuner-small-dark.svg` are unchanged.

## Scope is smaller than it looks, deliberately

Three things I checked and then did **not** change, because checking said not to:

- **`public/favicon.svg` was already correct.** It already carried the small tuner mark — selected widget bounds, three ink handles, the grabbed one in accent — theme-aware. My first pass rewrote it from the handoff and produced a one-line **indentation-only** diff, so I reverted it. A no-op diff on a design asset is worse than no diff.
- **`favicon-16.png` and `favicon-32.png` are unchanged.** They render from `tuner-small.svg`, which this handoff does not touch. I regenerated both with `rsvg-convert` at their existing 16×14 and 32×28 (they preserve the 116×100 ratio rather than being square) and git reported no change — which is the correct outcome, and worth having confirmed rather than assumed.
- **`apple-touch-icon.png` left alone.** It is opaque 180×180 — an app icon, and the handoff is explicit: *"App icons are not built from these marks: the store icon, adaptive icon and splash all carry the CS monogram. The repo marks stop at favicons and avatars."* Swapping the tuner mark in would break that rule. If it currently shows the wrong thing, that is an app-icon-handoff question, not this one.

So this PR is exactly the five `.github/icons/` files that changed.

## Also not touched

`.github/icons/tuner-appicon-1024.svg` and `tuner-maskable-1024.svg` are not in this handoff and, by the rule above, should not derive from this mark at all. Left as-is rather than guessed at — same call as in the docs PR.

## Test plan

`build` clean, `format:check` clean. Nothing in `src/` references `.github/icons/`, so there is no code path to break; the risk here is visual, and the geometry is the designer's, unmodified.

**mobile needs nothing** — its seven files were already byte-identical to the handoff.