### PR TITLE
design(tuner): preview labels in Archivo 800, values in mono

### DIFF
--- a/src/components/editor/CruiseControlPreview.tsx
+++ b/src/components/editor/CruiseControlPreview.tsx
@@ -1,5 +1,5 @@
 import type { PagePalette } from '@canshift/core'
-import { FONT_FAMILY } from './widgetPreview.styles'
+import { MONO_FONT, UI_FONT, UI_LABEL_TRACKING, UI_LABEL_WEIGHT } from '../../lib/typography'
 
 const OUTER_PAD = 6
 const CENTER_W = 100
@@ -236,8 +236,9 @@ export const CruiseControlPreview = ({
               x={labelXY.x}
               y={labelXY.y}
               fill={palette.text}
-              fontFamily={FONT_FAMILY}
-              fontWeight={700}
+              fontFamily={UI_FONT}
+              fontWeight={UI_LABEL_WEIGHT}
+              letterSpacing={UI_LABEL_TRACKING}
               fontSize={labelFontSize}
               textAnchor="middle"
               dominantBaseline="central"
@@ -262,17 +263,16 @@ export const CruiseControlPreview = ({
           justifyContent: 'center',
           gap: 2 * scale,
           color: palette.text,
-          fontFamily: FONT_FAMILY,
         }}
       >
         <span
           style={{
-            fontFamily: FONT_FAMILY,
-            fontWeight: 500,
+            fontFamily: UI_FONT,
+            fontWeight: UI_LABEL_WEIGHT,
             fontSize: 10 * scale,
             color: '#888888',
             lineHeight: 1,
-            letterSpacing: '0.08em',
+            letterSpacing: UI_LABEL_TRACKING,
             textAlign: 'center',
           }}
         >
@@ -281,7 +281,7 @@ export const CruiseControlPreview = ({
         <span
           style={{
             color: palette.text,
-            fontFamily: FONT_FAMILY,
+            fontFamily: MONO_FONT,
             fontWeight: 800,
             fontSize: Math.round(40 * scale),
             lineHeight: 1,
@@ -295,11 +295,11 @@ export const CruiseControlPreview = ({
         <span
           style={{
             color: '#888888',
-            fontFamily: FONT_FAMILY,
-            fontWeight: 500,
+            fontFamily: UI_FONT,
+            fontWeight: UI_LABEL_WEIGHT,
             fontSize: Math.max(8, Math.round(10 * scale)),
             lineHeight: 1,
-            letterSpacing: '0.04em',
+            letterSpacing: UI_LABEL_TRACKING,
             textAlign: 'center',
           }}
         >

--- a/src/components/editor/widget-previews/GaugeArc.tsx
+++ b/src/components/editor/widget-previews/GaugeArc.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react'
 import { GAUGE_ARC, GAUGE_TRACK_COLORS, STALE_PLACEHOLDER } from '@canshift/core'
-import { BLINK_ANIM, FONT_FAMILY, paletteFillColor, thresholdPct } from '../widgetPreview.styles'
+import { BLINK_ANIM, paletteFillColor, thresholdPct } from '../widgetPreview.styles'
 import {
   FRAC_FONT_SCALE,
   effectiveValue,
@@ -9,6 +9,7 @@ import {
   splitDecimal,
 } from './gauge-math'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
+import { MONO_FONT, UI_FONT, UI_LABEL_TRACKING, UI_LABEL_WEIGHT } from '../../../lib/typography'
 
 export interface GaugeArcRendererProps extends BaseRendererProps {
   revLimiting: boolean
@@ -114,7 +115,7 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
         fill={textValueColor}
         fontSize={valueFontSize}
         fontWeight="900"
-        fontFamily={FONT_FAMILY}
+        fontFamily={MONO_FONT}
         style={{ animation: danger ? BLINK_ANIM : undefined }}
       >
         {(() => {
@@ -149,9 +150,9 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
         dominantBaseline="auto"
         fill="#888888"
         fontSize={SIGNAL_LABEL_FONT_SIZE}
-        fontFamily={FONT_FAMILY}
-        fontWeight="500"
-        letterSpacing="0.06em"
+        fontFamily={UI_FONT}
+        fontWeight={UI_LABEL_WEIGHT}
+        letterSpacing={UI_LABEL_TRACKING}
         style={{ textTransform: 'uppercase' }}
       >
         {formatSignalLabel(widget.signal).toUpperCase()}

--- a/src/components/editor/widget-previews/GaugeNumeric.tsx
+++ b/src/components/editor/widget-previews/GaugeNumeric.tsx
@@ -6,9 +6,10 @@ import {
   valueUnitFontSize,
   widgetTopRulePx,
 } from '@canshift/core'
-import { BLINK_ANIM, FONT_FAMILY } from '../widgetPreview.styles'
+import { BLINK_ANIM } from '../widgetPreview.styles'
 import { FRAC_FONT_SCALE, effectiveValue, splitDecimal } from './gauge-math'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
+import { MONO_FONT, uiLabelAtSize } from '../../../lib/typography'
 
 export interface GaugeNumericRendererProps extends BaseRendererProps {
   danger: boolean
@@ -112,8 +113,7 @@ export const GaugeNumericPreview = memo(function GaugeNumericPreview({
           position: 'absolute',
           top: 4,
           left: 4,
-          fontSize: 9,
-          fontFamily: FONT_FAMILY,
+          ...uiLabelAtSize(9),
           fontWeight: 500,
           color: '#888888',
           lineHeight: 1,
@@ -147,7 +147,7 @@ export const GaugeNumericPreview = memo(function GaugeNumericPreview({
             <span
               style={{
                 color: valueColor,
-                fontFamily: FONT_FAMILY,
+                fontFamily: MONO_FONT,
                 fontWeight: 800,
                 lineHeight: 1,
                 whiteSpace: 'nowrap',
@@ -170,7 +170,7 @@ export const GaugeNumericPreview = memo(function GaugeNumericPreview({
             style={{
               color: '#888888',
               fontSize: valueUnitFontSize(Math.round(fontSize)),
-              fontFamily: FONT_FAMILY,
+              fontFamily: MONO_FONT,
               fontWeight: 500,
               lineHeight: 1,
               whiteSpace: 'nowrap',

--- a/src/components/editor/widget-previews/Gear.tsx
+++ b/src/components/editor/widget-previews/Gear.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react'
 import { STALE_PLACEHOLDER } from '@canshift/core'
-import { FONT_FAMILY } from '../widgetPreview.styles'
 import type { BaseRendererProps } from './shared'
+import { MONO_FONT } from '../../../lib/typography'
 
 interface GearRendererProps extends BaseRendererProps {
   unbound?: boolean
@@ -45,7 +45,7 @@ export const GearPreview = memo(function GearPreview({
             color: st.primaryColor,
             fontSize,
             fontWeight: 800,
-            fontFamily: FONT_FAMILY,
+            fontFamily: MONO_FONT,
             lineHeight: 1,
             textAlign: 'center',
             width: '100%',

--- a/src/components/editor/widget-previews/Image.tsx
+++ b/src/components/editor/widget-previews/Image.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react'
-import { FONT_FAMILY } from '../widgetPreview.styles'
 import type { BaseRendererProps } from './shared'
+import { UI_FONT, UI_LABEL_TRACKING, UI_LABEL_WEIGHT } from '../../../lib/typography'
 
 const FRAME_BG = '#1A1A1A'
 const FRAME_STROKE = '#2A2A2A'
@@ -38,9 +38,9 @@ export const ImagePreview = memo(function ImagePreview({ widget, w, h }: BaseRen
         dominantBaseline="auto"
         fill={CAPTION_RGB}
         fontSize={Math.max(5, Math.min(7, w * 0.07))}
-        fontFamily={FONT_FAMILY}
-        fontWeight="500"
-        letterSpacing="0.05em"
+        fontFamily={UI_FONT}
+        fontWeight={UI_LABEL_WEIGHT}
+        letterSpacing={UI_LABEL_TRACKING}
       >
         IMAGE
       </text>

--- a/src/components/editor/widget-previews/Timer.tsx
+++ b/src/components/editor/widget-previews/Timer.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react'
-import { FONT_FAMILY } from '../widgetPreview.styles'
 import type { BaseRendererProps } from './shared'
+import { MONO_FONT, uiLabelAtSize } from '../../../lib/typography'
 
 const DEMO_MMSS = '01:23'
 const DEMO_SS_MMM = '12.847'
@@ -30,7 +30,7 @@ export const TimerPreview = memo(function TimerPreview({ widget, w, h }: BaseRen
           color: st.textColor,
           fontSize,
           fontWeight: fontSize >= 32 ? 900 : 700,
-          fontFamily: FONT_FAMILY,
+          fontFamily: MONO_FONT,
           letterSpacing: '0.06em',
           fontVariantNumeric: 'tabular-nums',
         }}
@@ -42,8 +42,7 @@ export const TimerPreview = memo(function TimerPreview({ widget, w, h }: BaseRen
           position: 'absolute',
           top: 2,
           left: 3,
-          fontSize: sigFontSize,
-          fontFamily: FONT_FAMILY,
+          ...uiLabelAtSize(sigFontSize),
           fontWeight: 500,
           color: '#888888',
           lineHeight: 1,

--- a/src/components/editor/widget-previews/Warning.tsx
+++ b/src/components/editor/widget-previews/Warning.tsx
@@ -1,7 +1,8 @@
 import { memo } from 'react'
 import { SensorIcon } from '../../icons/SensorIcons'
-import { BLINK_ANIM, FONT_FAMILY } from '../widgetPreview.styles'
+import { BLINK_ANIM } from '../widgetPreview.styles'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
+import { uiLabelAtSize } from '../../../lib/typography'
 
 export interface WarningRendererProps extends BaseRendererProps {
   noAnimate: boolean
@@ -47,8 +48,7 @@ export const WarningPreview = memo(function WarningPreview({
       {showSignalLabel && (
         <span
           style={{
-            fontSize: sigFontSize,
-            fontFamily: FONT_FAMILY,
+            ...uiLabelAtSize(sigFontSize),
             fontWeight: 500,
             color: st.criticalColor + '99',
             lineHeight: 1,

--- a/src/components/editor/widgetPreview.styles.ts
+++ b/src/components/editor/widgetPreview.styles.ts
@@ -1,7 +1,5 @@
 import { sensorOkColor, sensorWarningColor, type SensorIconName } from '@canshift/core'
 
-export const FONT_FAMILY = "'JetBrains Mono', ui-monospace, monospace"
-
 export const FONT_WEIGHT_VALUE = 900
 
 export const BLINK_ANIM = 'canshift-blink 0.7s step-end infinite'

--- a/src/lib/typography.ts
+++ b/src/lib/typography.ts
@@ -9,10 +9,18 @@ export const monoValueStyle: CSSProperties = {
   fontVariantNumeric: 'tabular-nums',
 }
 
+export const UI_LABEL_WEIGHT = 800
+export const UI_LABEL_TRACKING = '0.18em'
+
 export const uiLabelStyle: CSSProperties = {
   fontFamily: UI_FONT,
   fontSize: 10,
-  fontWeight: 800,
-  letterSpacing: '0.18em',
+  fontWeight: UI_LABEL_WEIGHT,
+  letterSpacing: UI_LABEL_TRACKING,
   textTransform: 'uppercase',
 }
+
+export const uiLabelAtSize = (fontSize: number): CSSProperties => ({
+  ...uiLabelStyle,
+  fontSize,
+})


### PR DESCRIPTION
Closes #111. First slice of the mockup-alignment work — mobile (#94) and the firmware follow.

## What

`widgetPreview.styles.ts` exported `FONT_FAMILY = "'JetBrains Mono', …"` and every string in the canvas preview used it — labels included. The mockups set labels in Archivo 800 with tracking and reserve mono for values the car produces. The correct tokens already existed in `src/lib/typography.ts`; the preview bypassed them with its local constant.

The constant is deleted. Every text in the seven preview components is now classified:

| Component | Label (Archivo 800 + tracking) | Value (mono, tabular) |
| --- | --- | --- |
| GaugeNumeric | corner signal label | value, unit |
| GaugeArc | signal label | arc value |
| Warning | signal label | — |
| Gear | — | the gear digit |
| Timer | corner signal label | the time digits |
| Image | the IMAGE caption | — |
| CruiseControl | button labels, SET caption, hint | the set speed |

`typography.ts` gains `UI_LABEL_WEIGHT` / `UI_LABEL_TRACKING` and `uiLabelAtSize(px)` so SVG `<text>` (which cannot spread a CSSProperties) and preview-scaled sizes use the same numbers as `uiLabelStyle` instead of restating them.

## Two stale pairs died on the way

`GaugeArc`'s signal label carried `fontWeight="500"` / `letterSpacing="0.06em"`, and `Image`'s caption `500` / `0.05em` — both are exactly the drift the spec calls out (labels are 800, tracked 0.09–0.2em). The compiler caught both as duplicate JSX attributes when the token pair landed, which is the gate doing its job.

## What deliberately did not change

Font **sizes**. They come from `widget-metrics.ts` in `@canshift/core`, the firmware mirrors them, and #73 just made those constants load-bearing. This PR changes family, weight and tracking only.

## Test plan

332 tests / 53 files, `typecheck`, `lint`, `format:check`, `build` all green. `grep FONT_FAMILY src` returns 0.

Not verified visually — it is 1 am and the preview deploy is the place to look. The geometry and sizing are untouched, so the risk is confined to family/weight/tracking rendering.