### PR TITLE
design(tuner)!: spec-strict gauge preview — drop zones/gradient/palette, core 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^3.0.0",
+        "@canshift/core": "^4.0.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-aOuCKYZZ01sftY5a0hefRpYhZarAv+RBpPdaPPPI5+mEhdQs9qe/dIcmks61R8XrIN2RKUjWm3o3b0jc6hJKZA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-4.0.0.tgz",
+      "integrity": "sha512-77BZLr+1AtpwkA+BPEQPu4r72wXe5saXG0zQ/llzoPekpF3ewDee/LbuEQHQUel5VNchy4GjOxA6O95lTVwwdQ==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^3.0.0",
+    "@canshift/core": "^4.0.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/components/editor/widget-previews/GaugeArc.tsx
+++ b/src/components/editor/widget-previews/GaugeArc.tsx
@@ -1,13 +1,7 @@
 import { memo } from 'react'
 import { GAUGE_ARC, GAUGE_TRACK_COLORS, STALE_PLACEHOLDER } from '@canshift/core'
-import { BLINK_ANIM, paletteFillColor, thresholdPct } from '../widgetPreview.styles'
-import {
-  FRAC_FONT_SCALE,
-  effectiveValue,
-  gaugeArcD,
-  interpolateGreenOrangeRed,
-  splitDecimal,
-} from './gauge-math'
+import { BLINK_ANIM, thresholdPct } from '../widgetPreview.styles'
+import { FRAC_FONT_SCALE, effectiveValue, gaugeArcD, splitDecimal } from './gauge-math'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
 import { MONO_FONT, UI_FONT, UI_LABEL_TRACKING, UI_LABEL_WEIGHT } from '../../../lib/typography'
 
@@ -39,30 +33,8 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
 
   const valueStr = unbound ? STALE_PLACEHOLDER : bound.raw.toFixed(cfg.decimalPlaces)
 
-  const zonesMode = cfg.arcFillStyle === 'zones'
-  const gradientMode = cfg.arcFillStyle === 'gradient'
-  const palette = zonesMode ? paletteFillColor(cfg.iconName, valuePct, dangerPct) : undefined
-  const inPaletteMode = palette !== undefined
   const inDanger = valuePct >= dangerPct
-
   const inkColor = inDanger ? st.criticalColor : st.textColor
-
-  const textValueColor = inPaletteMode
-    ? palette
-    : zonesMode
-      ? inDanger
-        ? st.criticalColor
-        : st.primaryColor
-      : inkColor
-
-  const arcValueColor = inPaletteMode
-    ? palette
-    : gradientMode || zonesMode
-      ? interpolateGreenOrangeRed(valuePct)
-      : inkColor
-
-  const trackColor =
-    inPaletteMode || gradientMode ? GAUGE_TRACK_COLORS.gradient : GAUGE_TRACK_COLORS.plain
 
   const cx = w / 2
   const cy = h * 0.5
@@ -95,14 +67,14 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
       <path
         d={gaugeArcD(cx, cy, r, 0, 1)}
         fill="none"
-        stroke={trackColor}
+        stroke={GAUGE_TRACK_COLORS.plain}
         strokeWidth={strokeW}
         strokeLinecap="butt"
       />
       <path
         d={gaugeArcD(cx, cy, r, 0, valuePct)}
         fill="none"
-        stroke={arcValueColor}
+        stroke={inkColor}
         strokeWidth={strokeW}
         strokeLinecap="butt"
         style={{ animation: danger ? BLINK_ANIM : undefined }}
@@ -112,7 +84,7 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
         y={cy + valueYOffset}
         textAnchor="middle"
         dominantBaseline="middle"
-        fill={textValueColor}
+        fill={inkColor}
         fontSize={valueFontSize}
         fontWeight="900"
         fontFamily={MONO_FONT}

--- a/src/components/editor/widget-previews/gauge-math.ts
+++ b/src/components/editor/widget-previews/gauge-math.ts
@@ -1,13 +1,6 @@
 import type { Widget } from '@canshift/core'
-import {
-  GAUGE_ARC,
-  VALUE_FRAC_FONT_RATIO,
-  gaugeArcPath,
-  gaugeGradientColorAt,
-} from '@canshift/core'
+import { GAUGE_ARC, VALUE_FRAC_FONT_RATIO, gaugeArcPath, ratioScale } from '@canshift/core'
 import { thresholdPct } from '../widgetPreview.styles'
-
-export const interpolateGreenOrangeRed = (pct: number): string => gaugeGradientColorAt(pct)
 
 export const DEMO_PCT = 0.65
 
@@ -40,7 +33,7 @@ export const splitDecimal = (s: string): { int: string; frac: string } => {
   return { int: s.slice(0, dot), frac: s.slice(dot) }
 }
 
-export const FRAC_FONT_SCALE = VALUE_FRAC_FONT_RATIO
+export const FRAC_FONT_SCALE = ratioScale(VALUE_FRAC_FONT_RATIO)
 
 export const gaugeArcD = (
   cx: number,

--- a/src/components/editor/widgetPreview.styles.ts
+++ b/src/components/editor/widgetPreview.styles.ts
@@ -1,26 +1,9 @@
-import { sensorOkColor, sensorWarningColor, type SensorIconName } from '@canshift/core'
-
 export const FONT_WEIGHT_VALUE = 900
 
 export const BLINK_ANIM = 'canshift-blink 0.7s step-end infinite'
 
 export const BLINK_KEYFRAMES_CSS =
   '@keyframes canshift-blink { 0%,49%{opacity:1} 50%,100%{opacity:0} }'
-
-export const ZONE_NORMAL = '#00CC44'
-export const ZONE_DANGER = '#FF4444'
-
-export const paletteFillColor = (
-  iconName: SensorIconName | undefined,
-  valuePct: number,
-  dangerPct: number
-): string | undefined => {
-  const ok = sensorOkColor(iconName)
-  if (!ok) return undefined
-  const warning = sensorWarningColor(iconName)
-  if (warning === undefined) return ok
-  return valuePct >= dangerPct ? warning : ok
-}
 
 export const thresholdPct = (level: number, min: number, max: number): number => {
   const range = max - min || 1


### PR DESCRIPTION
Closes the loop on the spec-strict fills decision (firmware#127 slice 2) — pairs with CANShift/canshift-firmware#129 (merged) and CANShift/canshift-core#82 (merged, v4.0.0 on npm).

## What changed

- **`@canshift/core` → 4.0.0** (schema 1.30.0). Opening a legacy config migrates it — `arcFillStyle` is stripped by the 1.29.0 → 1.30.0 migration.
- **GaugeArc preview**: zones/gradient/palette branches removed — fill and value are ink, switching to `criticalColor` past the danger threshold, exactly like the firmware gauge now renders. Track is always `#222222`.
- `paletteFillColor`, the `ZONE_*` constants (dead exports) and the `interpolateGreenOrangeRed` wrapper deleted.
- `FRAC_FONT_SCALE` now goes through `ratioScale()` — core main had turned `VALUE_FRAC_FONT_RATIO` into a ratio object; the break was latent until this dep bump.

There was no editor form for the fill style — the preview was the only tuner surface.

## Test plan

- `typecheck` / `test` (332) / `lint` / `format:check` / `build`: all green on core 4.0.0.

Refs CANShift/canshift-firmware#127.