### PR TITLE
chore(tuner): bump @canshift/core to 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^4.0.0",
+        "@canshift/core": "^4.1.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-4.0.0.tgz",
-      "integrity": "sha512-77BZLr+1AtpwkA+BPEQPu4r72wXe5saXG0zQ/llzoPekpF3ewDee/LbuEQHQUel5VNchy4GjOxA6O95lTVwwdQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-OzKi6gyRHVsSq8U+hRaslIz7AEOUgQMbq+vE/NvpHINf3eZWOdIibhLpfTeJSVS6P/cwlUuKcmFpyqbbvf6zVg==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^4.0.0",
+    "@canshift/core": "^4.1.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",


### PR DESCRIPTION
Picks up the stale placeholder change (`--` → `- -`, dash spec: grey and `- -`) so the canvas previews render stale exactly like the firmware. No tuner code change — the previews read `STALE_PLACEHOLDER` from core.

## Test plan
`typecheck` / `test` (332) / `build` green on 4.1.0.

Refs CANShift/canshift-firmware#127.