### PR TITLE
design(tuner): button preview mirrors the engaged-accent grammar

### DIFF
--- a/src/components/editor/widget-previews/Button.tsx
+++ b/src/components/editor/widget-previews/Button.tsx
@@ -1,11 +1,23 @@
 import { memo } from 'react'
+import { WIDGET_ACCENT_COLOR, WIDGET_MUTED_COLOR } from '@canshift/core'
 import { SensorIcon } from '../../icons/SensorIcons'
-import type { BaseRendererProps } from './shared'
+import { type BaseRendererProps, formatSignalLabel } from './shared'
+import { UI_FONT, UI_LABEL_TRACKING, UI_LABEL_WEIGHT } from '../../../lib/typography'
 
 export interface ButtonRendererProps extends BaseRendererProps {
   active: boolean
   cycleStateIndex?: number | undefined
 }
+
+const BUTTON_FONT_STEPS = [
+  { minTarget: 22, size: 28 },
+  { minTarget: 15, size: 16 },
+  { minTarget: 13, size: 14 },
+  { minTarget: 0, size: 12 },
+] as const
+
+const snapButtonFontSize = (target: number): number =>
+  BUTTON_FONT_STEPS.find((step) => target >= step.minTarget)?.size ?? 12
 
 export const computeButtonPreviewMetrics = (
   w: number,
@@ -15,9 +27,11 @@ export const computeButtonPreviewMetrics = (
   const iconSize = showIcon ? Math.max(18, Math.min(h * 0.75, h - 14, w * 0.7, 56)) : 0
   const labelBudget = w - 12
   const verticalBudget = showIcon ? Math.min(h * 0.2, iconSize * 0.4) : h * 0.48
-  const fontSize = Math.max(8, Math.min(verticalBudget, labelBudget * 0.22))
-  return { iconSize, fontSize }
+  const target = Math.max(8, Math.min(verticalBudget, labelBudget * 0.22))
+  return { iconSize, fontSize: snapButtonFontSize(target) }
 }
+
+const KICKER_ENGAGED_COLOR = 'rgba(255,255,255,0.75)'
 
 export const ButtonPreview = memo(function ButtonPreview({
   widget,
@@ -42,12 +56,15 @@ export const ButtonPreview = memo(function ButtonPreview({
   const showLabel = cfg.showLabel !== false
   const { iconSize, fontSize } = computeButtonPreviewMetrics(w, h, showIcon)
 
-  const normalColor = displayColors?.normal ?? st.primaryColor
-  const activeColor = displayColors?.active ?? st.primaryColor
-  const stateColor = active ? activeColor : normalColor
-  const bgColor = active ? activeColor + '55' : normalColor + '18'
-  const borderColor = active ? activeColor : st.secondaryColor
-  const textColor = active ? stateColor : st.textColor
+  const engagedColor = displayColors?.active ?? WIDGET_ACCENT_COLOR
+  const idleBorder = displayColors?.normal ?? st.textColor
+
+  const bgColor = active ? engagedColor : 'transparent'
+  const borderColor = active ? engagedColor : idleBorder
+  const textColor = active ? '#FFFFFF' : st.textColor
+  const kickerColor = active ? KICKER_ENGAGED_COLOR : WIDGET_MUTED_COLOR
+
+  const kicker = formatSignalLabel(widget.signal)
 
   return (
     <div
@@ -56,18 +73,33 @@ export const ButtonPreview = memo(function ButtonPreview({
         height: h,
         display: 'flex',
         flexDirection: 'column',
-        alignItems: 'center',
+        alignItems: 'flex-start',
         justifyContent: 'center',
         gap: 2,
-        padding: '4px 6px',
+        padding: '4px 7px',
         boxSizing: 'border-box',
         background: bgColor,
-        border: `1px solid ${borderColor}`,
+        border: `2px solid ${borderColor}`,
         borderRadius: 0,
         overflow: 'visible',
         transition: 'background 0.1s, border-color 0.1s',
       }}
     >
+      {showLabel && kicker !== '' && (
+        <span
+          style={{
+            color: kickerColor,
+            fontSize: 10,
+            fontFamily: UI_FONT,
+            fontWeight: UI_LABEL_WEIGHT,
+            letterSpacing: UI_LABEL_TRACKING,
+            textTransform: 'uppercase',
+            lineHeight: 1,
+          }}
+        >
+          {kicker.toUpperCase()}
+        </span>
+      )}
       {showIcon && displayIconName !== null && (
         <div style={{ flexShrink: 0, display: 'flex' }}>
           <SensorIcon name={displayIconName} size={iconSize} color={textColor + 'CC'} />
@@ -78,14 +110,14 @@ export const ButtonPreview = memo(function ButtonPreview({
           style={{
             color: textColor,
             fontSize,
-            fontWeight: 500,
+            fontFamily: UI_FONT,
+            fontWeight: 800,
             whiteSpace: 'normal',
             wordBreak: 'break-word',
             overflow: 'visible',
-            letterSpacing: '0.04em',
             minWidth: 0,
-            textAlign: 'center',
-            lineHeight: 1.1,
+            textAlign: 'left',
+            lineHeight: 1,
           }}
         >
           {displayLabel}


### PR DESCRIPTION
Pairs with CANShift/canshift-firmware#132 (slice 4 of firmware#127). The canvas button preview now renders what the firmware renders:

- Engaged = filled `WIDGET_ACCENT_COLOR` (#FF4747, border + ground), white state word, kicker at 75% white — idle = transparent ground, 2 px ink outline, muted kicker. Configured button colors still override, like on the device.
- 10 px Archivo kicker (signal label, 0.18 em tracking) above the state word, everything flush left.
- Font sizes snap to the firmware ladder (12/14/16/**28**) instead of a continuous scale — the state word is Archivo 800.

## Test plan
`typecheck` / `test` (332) / `lint` / `prettier` green.

Refs CANShift/canshift-firmware#127.