### PR TITLE
design(tuner): previews render whole values; button preview mirrors kicker, uppercase, ladder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^5.0.0",
+        "@canshift/core": "^6.0.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-5.0.0.tgz",
-      "integrity": "sha512-X2SIbsapiK7CA+6I3AnESrBXmIemQVec3/jaRC9LCsKLrCSp+fFgJtScS32q5Jo8wmHQy+aOFO6AnlEKnKqb/w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-6.0.0.tgz",
+      "integrity": "sha512-R/ZGmje89rTwROVMGhccw3N6q0tYPEIQIwicN966Z1RsZk8LgkQdeA4Z1Zi0NjXhVWkCxAUCLHhHdbWDVxoZ4w==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^5.0.0",
+    "@canshift/core": "^6.0.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/components/editor/widget-previews/Button.tsx
+++ b/src/components/editor/widget-previews/Button.tsx
@@ -9,20 +9,48 @@ export interface ButtonRendererProps extends BaseRendererProps {
 }
 
 const BUTTON_FONT_STEPS = [
-  { minTarget: 22, size: 28 },
+  { minTarget: 27, size: 28 },
   { minTarget: 15, size: 16 },
   { minTarget: 13, size: 14 },
   { minTarget: 0, size: 12 },
 ] as const
 
+const KICKER_BAND_PX = 24
+const GLYPH_WIDTH_RATIO = 0.65
+
 const snapButtonFontSize = (target: number): number =>
   BUTTON_FONT_STEPS.find((step) => target >= step.minTarget)?.size ?? 12
 
-export const computeButtonPreviewMetrics = (w: number, h: number): { fontSize: number } => {
-  const labelBudget = w - 12
-  const verticalBudget = h * 0.48
-  const target = Math.max(8, Math.min(verticalBudget, labelBudget * 0.22))
+export const computeButtonPreviewMetrics = (
+  w: number,
+  h: number,
+  hasKicker: boolean,
+  labelLen: number
+): { fontSize: number } => {
+  const labelBudget = w - 14
+  const verticalBudget = h - (hasKicker ? KICKER_BAND_PX : 12)
+  const widthCap = labelBudget / (Math.max(labelLen, 1) * GLYPH_WIDTH_RATIO)
+  const target = Math.max(8, Math.min(verticalBudget, widthCap))
   return { fontSize: snapButtonFontSize(target) }
+}
+
+const KICKER_BY_ACTION_TYPE: Record<string, string> = {
+  navigate: 'PAGE',
+  map_switch: 'MAP',
+  cruise_control: 'CRUISE',
+}
+
+const kickerFromConfig = (cfg: { mode: string }, signal: string): string => {
+  const fromSignal = formatSignalLabel(signal)
+  if (fromSignal !== '') return fromSignal.toUpperCase()
+  const anyCfg = cfg as {
+    mode: string
+    actions?: { type: string }[]
+    states?: { action: { type: string } }[]
+  }
+  const actionType =
+    anyCfg.mode === 'cycle' ? anyCfg.states?.[0]?.action.type : anyCfg.actions?.[0]?.type
+  return actionType !== undefined ? (KICKER_BY_ACTION_TYPE[actionType] ?? '') : ''
 }
 
 const KICKER_ENGAGED_COLOR = 'rgba(255,255,255,0.75)'
@@ -45,8 +73,10 @@ export const ButtonPreview = memo(function ButtonPreview({
   const displayLabel = activeState?.label ?? cfg.label
   const displayColors = activeState?.colors ?? cfg.colors
 
+  const displayText = displayLabel.toUpperCase()
+  const kicker = kickerFromConfig(cfg, widget.signal)
   const showLabel = cfg.showLabel !== false
-  const { fontSize } = computeButtonPreviewMetrics(w, h)
+  const { fontSize } = computeButtonPreviewMetrics(w, h, kicker !== '', displayText.length)
 
   const engagedColor = displayColors?.active ?? WIDGET_ACCENT_COLOR
   const idleBorder = displayColors?.normal ?? st.textColor
@@ -55,8 +85,6 @@ export const ButtonPreview = memo(function ButtonPreview({
   const borderColor = active ? engagedColor : idleBorder
   const textColor = active ? '#FFFFFF' : st.textColor
   const kickerColor = active ? KICKER_ENGAGED_COLOR : WIDGET_MUTED_COLOR
-
-  const kicker = formatSignalLabel(widget.signal)
 
   return (
     <div
@@ -89,7 +117,7 @@ export const ButtonPreview = memo(function ButtonPreview({
             lineHeight: 1,
           }}
         >
-          {kicker.toUpperCase()}
+          {kicker}
         </span>
       )}
       {showLabel && (
@@ -107,7 +135,7 @@ export const ButtonPreview = memo(function ButtonPreview({
             lineHeight: 1,
           }}
         >
-          {displayLabel}
+          {displayText}
         </span>
       )}
     </div>

--- a/src/components/editor/widget-previews/GaugeArc.tsx
+++ b/src/components/editor/widget-previews/GaugeArc.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react'
 import { GAUGE_ARC, GAUGE_TRACK_COLORS, STALE_PLACEHOLDER } from '@canshift/core'
 import { BLINK_ANIM, thresholdPct } from '../widgetPreview.styles'
-import { FRAC_FONT_SCALE, effectiveValue, gaugeArcD, splitDecimal } from './gauge-math'
+import { effectiveValue, gaugeArcD } from './gauge-math'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
 import { MONO_FONT, UI_FONT, UI_LABEL_TRACKING, UI_LABEL_WEIGHT } from '../../../lib/typography'
 
@@ -90,30 +90,7 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
         fontFamily={MONO_FONT}
         style={{ animation: danger ? BLINK_ANIM : undefined }}
       >
-        {(() => {
-          const { int, frac } = splitDecimal(valueStr)
-          if (frac !== '') {
-            return (
-              <>
-                <tspan>{int}</tspan>
-                <tspan fontSize={valueFontSize * FRAC_FONT_SCALE}>{frac}</tspan>
-              </>
-            )
-          }
-          const absInt = int.startsWith('-') ? int.slice(1) : int
-          if (absInt.length > 3) {
-            const sign = int.startsWith('-') ? '-' : ''
-            const head = absInt.slice(0, -3)
-            const tail = absInt.slice(-3)
-            return (
-              <>
-                <tspan>{sign + head}</tspan>
-                <tspan fontSize={valueFontSize * FRAC_FONT_SCALE}>{tail}</tspan>
-              </>
-            )
-          }
-          return valueStr
-        })()}
+        {valueStr}
       </text>
       <text
         x={4}

--- a/src/components/editor/widget-previews/GaugeNumeric.tsx
+++ b/src/components/editor/widget-previews/GaugeNumeric.tsx
@@ -7,7 +7,7 @@ import {
   widgetTopRulePx,
 } from '@canshift/core'
 import { BLINK_ANIM } from '../widgetPreview.styles'
-import { FRAC_FONT_SCALE, effectiveValue, splitDecimal } from './gauge-math'
+import { effectiveValue } from './gauge-math'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
 import { MONO_FONT, uiLabelAtSize } from '../../../lib/typography'
 
@@ -44,12 +44,7 @@ export const GaugeNumericPreview = memo(function GaugeNumericPreview({
   const availH = h - sigHeaderH
 
   const valueStr = String(valueOnly)
-  const intLen = valueStr.includes('.') ? valueStr.split('.')[0]!.length : valueStr.length
-  const willSplit = !cfg.prefix && intLen > 3 && !valueStr.includes('.')
-  const headChars = willSplit ? intLen - 3 : intLen
-  const tailChars = willSplit ? 3 : valueStr.includes('.') ? valueStr.length - intLen : 0
-  const unitChars = signalUnit.length
-  const charBudget = headChars + tailChars * FRAC_FONT_SCALE + unitChars * FRAC_FONT_SCALE * 0.45
+  const charBudget = valueStr.length + prefix.length + signalUnit.length * 0.45
   const fontSize = Math.max(10, Math.min(availH * 0.85, (w - 16) / (charBudget * 0.68)))
   const rulePx = widgetTopRulePx(Math.round(fontSize))
   const ruleColor = danger
@@ -138,33 +133,22 @@ export const GaugeNumericPreview = memo(function GaugeNumericPreview({
           flexShrink: 0,
         }}
       >
-        {(() => {
-          const { int, frac } = splitDecimal(valueOnly)
-          const isWideInt = !prefix && int.length > 3 && frac === ''
-          const intHead = isWideInt ? int.slice(0, -3) : int
-          const intTail = isWideInt ? int.slice(-3) : ''
-          return (
-            <span
-              style={{
-                color: valueColor,
-                fontFamily: MONO_FONT,
-                fontWeight: 800,
-                lineHeight: 1,
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'clip',
-                textAlign: 'center',
-                animation: danger ? BLINK_ANIM : undefined,
-              }}
-            >
-              <span style={{ fontSize }}>{prefix + intHead}</span>
-              {intTail !== '' && (
-                <span style={{ fontSize: fontSize * FRAC_FONT_SCALE }}>{intTail}</span>
-              )}
-              {frac !== '' && <span style={{ fontSize: fontSize * FRAC_FONT_SCALE }}>{frac}</span>}
-            </span>
-          )
-        })()}
+        <span
+          style={{
+            color: valueColor,
+            fontFamily: MONO_FONT,
+            fontWeight: 800,
+            fontSize,
+            lineHeight: 1,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'clip',
+            textAlign: 'left',
+            animation: danger ? BLINK_ANIM : undefined,
+          }}
+        >
+          {prefix + valueStr}
+        </span>
         {signalUnit !== '' && (
           <span
             style={{

--- a/src/components/editor/widget-previews/gauge-math.ts
+++ b/src/components/editor/widget-previews/gauge-math.ts
@@ -1,5 +1,5 @@
 import type { Widget } from '@canshift/core'
-import { GAUGE_ARC, VALUE_FRAC_FONT_RATIO, gaugeArcPath, ratioScale } from '@canshift/core'
+import { GAUGE_ARC, gaugeArcPath } from '@canshift/core'
 import { thresholdPct } from '../widgetPreview.styles'
 
 export const DEMO_PCT = 0.65
@@ -26,14 +26,6 @@ export const isDangerState = (widget: Widget, testValue: number | null | undefin
   }
   return false
 }
-
-export const splitDecimal = (s: string): { int: string; frac: string } => {
-  const dot = s.indexOf('.')
-  if (dot < 0) return { int: s, frac: '' }
-  return { int: s.slice(0, dot), frac: s.slice(dot) }
-}
-
-export const FRAC_FONT_SCALE = ratioScale(VALUE_FRAC_FONT_RATIO)
 
 export const gaugeArcD = (
   cx: number,


### PR DESCRIPTION
Pairs with CANShift/canshift-firmware#138 and CANShift/canshift-core#88 (slice 7): the canvas previews follow the device — values render whole at the tier size (no thousands/decimal split spans, `splitDecimal`/`FRAC_FONT_SCALE` deleted), value text left-aligned, and the button preview mirrors the firmware's action-derived kicker (`PAGE`/`MAP`/`CRUISE`), UPPERCASE state words and the length-aware 28-px ladder.

Requires core 6.0.0 — the dep bump lands in this PR once it's on npm.

## Test plan
`typecheck` / `test` (332) / `lint` against the 6.0.0-sibling schema.

Refs CANShift/canshift-firmware#127.