### PR TITLE
feat(tuner): semantic button kicker — preview priority + property-panel input (core 6.1.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^6.0.0",
+        "@canshift/core": "^6.1.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-6.0.0.tgz",
-      "integrity": "sha512-R/ZGmje89rTwROVMGhccw3N6q0tYPEIQIwicN966Z1RsZk8LgkQdeA4Z1Zi0NjXhVWkCxAUCLHhHdbWDVxoZ4w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-vqc28ywd0m3dtXVjx1/hVqbP09VgEzdqksMDB9D9yV7QkU2dlv5kGHex+m9PCCdhGdoUBmQ9Pk+w0MzNua8eRg==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^6.0.0",
+    "@canshift/core": "^6.1.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/components/editor/property-panel/button-fields.tsx
+++ b/src/components/editor/property-panel/button-fields.tsx
@@ -124,6 +124,20 @@ export const ButtonFields = ({ widget, onChange }: ConfigFieldsProps) => {
         />
       </Field>
 
+      <Field label="Kicker">
+        <input
+          style={inputStyle}
+          value={cfg.kicker ?? ''}
+          placeholder="auto"
+          onChange={(e) => {
+            const value = e.target.value
+            onChange({
+              config: value ? { ...cfg, kicker: value } : (({ kicker: _, ...rest }) => rest)(cfg),
+            })
+          }}
+        />
+      </Field>
+
       <Field label="Show">
         <div
           style={{ display: 'flex', gap: 12, fontSize: 12, color: 'hsl(var(--brand-neutral-600))' }}

--- a/src/components/editor/widget-previews/Button.tsx
+++ b/src/components/editor/widget-previews/Button.tsx
@@ -41,13 +41,15 @@ const KICKER_BY_ACTION_TYPE: Record<string, string> = {
 }
 
 const kickerFromConfig = (cfg: { mode: string }, signal: string): string => {
-  const fromSignal = formatSignalLabel(signal)
-  if (fromSignal !== '') return fromSignal.toUpperCase()
   const anyCfg = cfg as {
     mode: string
+    kicker?: string
     actions?: { type: string }[]
     states?: { action: { type: string } }[]
   }
+  if (anyCfg.kicker !== undefined && anyCfg.kicker !== '') return anyCfg.kicker.toUpperCase()
+  const fromSignal = formatSignalLabel(signal)
+  if (fromSignal !== '') return fromSignal.toUpperCase()
   const actionType =
     anyCfg.mode === 'cycle' ? anyCfg.states?.[0]?.action.type : anyCfg.actions?.[0]?.type
   return actionType !== undefined ? (KICKER_BY_ACTION_TYPE[actionType] ?? '') : ''


### PR DESCRIPTION
Pairs with CANShift/canshift-core#89 and firmware#139 (slice 8). The preview honours the config `kicker` first (then signal label, then action-derived), and the button property panel gains a Kicker input (empty = auto). Core bumped to 6.1.0 (schema 1.32.0).

## Test plan
`typecheck` / `test` (332) / `lint` on core 6.1.0.

Refs CANShift/canshift-firmware#127.