### PR TITLE
design(tuner): scale v2 — previews honour big, Type picker writes the size class (core 6.2.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^6.1.0",
+        "@canshift/core": "^6.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-6.1.0.tgz",
-      "integrity": "sha512-vqc28ywd0m3dtXVjx1/hVqbP09VgEzdqksMDB9D9yV7QkU2dlv5kGHex+m9PCCdhGdoUBmQ9Pk+w0MzNua8eRg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-6.2.0.tgz",
+      "integrity": "sha512-NljMRHuSkaUFEBv/ThWs+Qd/aghc918nBAYnIqUI9Uuh4LvJTAF0ablQ2aGm5SkPRSssZBIJwq5tujUsO3IJPw==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^6.1.0",
+    "@canshift/core": "^6.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/components/editor/property-panel/gauge-fields.tsx
+++ b/src/components/editor/property-panel/gauge-fields.tsx
@@ -7,6 +7,16 @@ import {
 } from '../../../utils/size-tokens'
 import { ConfigFieldsProps, Field, GAUGE_STYLES, Row, numberInputStyle } from './shared'
 
+const BIG_CHOICES = [
+  { label: 'Auto', big: 0, title: 'Derive from the widget box' },
+  { label: 'XL', big: 96, title: 'Hero 96 — device 48' },
+  { label: 'L', big: 88, title: 'Hero 88 — device 44' },
+  { label: 'M', big: 64, title: 'Primary 64 — device 32' },
+  { label: 'S', big: 48, title: 'Mid 48 — device 24' },
+  { label: 'XS', big: 34, title: 'Secondary 34 — device 17' },
+] as const
+
+
 export const GaugeFields = ({ widget, onChange, signalDef }: ConfigFieldsProps) => {
   const cfg = widget.config.type === 'gauge' ? widget.config : null
   if (!cfg) return null
@@ -52,6 +62,42 @@ export const GaugeFields = ({ widget, onChange, signalDef }: ConfigFieldsProps) 
               {label}
             </button>
           ))}
+        </div>
+      </Field>
+
+      <Field label="Type">
+        <div style={{ display: 'flex', gap: 4 }}>
+          {BIG_CHOICES.map((choice) => {
+            const isActive = (cfg.big ?? 0) === choice.big
+            return (
+              <button
+                key={choice.label}
+                onClick={() => {
+                  onChange({
+                    config:
+                      choice.big === 0
+                        ? (({ big: _, ...rest }) => rest)(cfg)
+                        : { ...cfg, big: choice.big },
+                  })
+                }}
+                title={choice.title}
+                style={{
+                  flex: 1,
+                  padding: '3px 0',
+                  background: isActive
+                    ? 'color-mix(in srgb, #448844 14%, transparent)'
+                    : 'hsl(var(--brand-neutral-100))',
+                  border: `1px solid ${isActive ? '#448844' : 'hsl(var(--brand-neutral-300))'}`,
+                  color: isActive ? '#66AA66' : 'hsl(var(--brand-neutral-600))',
+                  cursor: 'pointer',
+                  fontSize: 10,
+                  fontWeight: isActive ? 700 : 400,
+                }}
+              >
+                {choice.label}
+              </button>
+            )
+          })}
         </div>
       </Field>
 

--- a/src/components/editor/property-panel/gauge-fields.tsx
+++ b/src/components/editor/property-panel/gauge-fields.tsx
@@ -16,7 +16,6 @@ const BIG_CHOICES = [
   { label: 'XS', big: 34, title: 'Secondary 34 — device 17' },
 ] as const
 
-
 export const GaugeFields = ({ widget, onChange, signalDef }: ConfigFieldsProps) => {
   const cfg = widget.config.type === 'gauge' ? widget.config : null
   if (!cfg) return null

--- a/src/components/editor/widget-previews/GaugeArc.tsx
+++ b/src/components/editor/widget-previews/GaugeArc.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react'
-import { GAUGE_ARC, GAUGE_TRACK_COLORS, STALE_PLACEHOLDER } from '@canshift/core'
+import { GAUGE_ARC, GAUGE_TRACK_COLORS, STALE_PLACEHOLDER, deviceValueFontPx } from '@canshift/core'
 import { BLINK_ANIM, thresholdPct } from '../widgetPreview.styles'
 import { effectiveValue, gaugeArcD } from './gauge-math'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
@@ -47,7 +47,8 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
   const revFlash = cfg.revFlash === true
   const showRevFlash = revFlash && revLimiting
 
-  const valueFontSize = Math.max(11, Math.min(r * 0.55, h * 0.3, 42))
+  const autoValueSize = Math.max(11, Math.min(r * 0.55, h * 0.3, 42))
+  const valueFontSize = cfg.big !== undefined ? deviceValueFontPx(cfg.big) : autoValueSize
 
   return (
     <svg width={w} height={h} style={{ display: 'block', overflow: 'hidden' }} aria-hidden="true">

--- a/src/components/editor/widget-previews/GaugeNumeric.tsx
+++ b/src/components/editor/widget-previews/GaugeNumeric.tsx
@@ -1,9 +1,9 @@
-import {
-  deviceValueFontPx, memo } from 'react'
+import { memo } from 'react'
 import {
   SECONDARY_BAR,
   STALE_PLACEHOLDER,
   WIDGET_TOP_RULE,
+  deviceValueFontPx,
   valueUnitFontSize,
   widgetTopRulePx,
 } from '@canshift/core'

--- a/src/components/editor/widget-previews/GaugeNumeric.tsx
+++ b/src/components/editor/widget-previews/GaugeNumeric.tsx
@@ -1,4 +1,5 @@
-import { memo } from 'react'
+import {
+  deviceValueFontPx, memo } from 'react'
 import {
   SECONDARY_BAR,
   STALE_PLACEHOLDER,
@@ -45,7 +46,8 @@ export const GaugeNumericPreview = memo(function GaugeNumericPreview({
 
   const valueStr = String(valueOnly)
   const charBudget = valueStr.length + prefix.length + signalUnit.length * 0.45
-  const fontSize = Math.max(10, Math.min(availH * 0.85, (w - 16) / (charBudget * 0.68)))
+  const autoSize = Math.max(10, Math.min(availH * 0.85, (w - 16) / (charBudget * 0.68)))
+  const fontSize = cfg.big !== undefined ? deviceValueFontPx(cfg.big) : autoSize
   const rulePx = widgetTopRulePx(Math.round(fontSize))
   const ruleColor = danger
     ? WIDGET_TOP_RULE.dangerColor


### PR DESCRIPTION
Pairs with CANShift/canshift-firmware#140 and CANShift/canshift-core#90 (merged, 6.2.0) — the tuner side of the scale pivot from `PROMPT_DASH_IN_TUNER.md`.

- Gauge previews (numeric + arc) render at `deviceValueFontPx(cfg.big)` when the widget carries the canvas size class, keeping the box heuristic as the auto fallback.
- The gauge property panel gains a **Type** row (Auto / XL 96 / L 88 / M 64 / S 48 / XS 34) writing `big` — the Tuner is the author of the size class per the spec.
- Core 6.2.0: schema 1.33.0, frame 8/6 (the canvas grid follows `LAYOUT_GRID` automatically).

## Test plan
`typecheck` / `test` (332) / `lint` on 6.2.0.

Refs CANShift/canshift-firmware#127.