### PR TITLE
fix(tuner): align toolbar announces its actions, not arrow glyphs

### DIFF
--- a/src/components/cli/CliOfflineState.tsx
+++ b/src/components/cli/CliOfflineState.tsx
@@ -40,7 +40,9 @@ export const CliOfflineState = () => {
           aria-expanded={opcodesOpen}
         >
           <span>Known opcodes ({String(KNOWN_OPCODES.length)})</span>
-          <span style={chevronStyle(opcodesOpen)}>▸</span>
+          <span style={chevronStyle(opcodesOpen)} aria-hidden="true">
+            ▸
+          </span>
         </button>
         {opcodesOpen && (
           <table style={tableStyle}>

--- a/src/components/editor/AlignToolbar.tsx
+++ b/src/components/editor/AlignToolbar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type CSSProperties, type MouseEvent } from 'react'
+import { useCallback, type CSSProperties } from 'react'
 import { useDashboardStore } from '../../stores/dashboard.store'
 import type { AlignDirection } from '../../stores/dashboard.store'
 import { MONO_FONT } from '../../lib/typography'
@@ -7,13 +7,16 @@ const BUTTON_STYLE: CSSProperties = {
   padding: '2px 7px',
   fontSize: 10,
   background: 'hsl(var(--brand-neutral-100))',
-  border: '1px solid hsl(var(--brand-neutral-300))',
-  color: 'hsl(var(--brand-neutral-600))',
   cursor: 'pointer',
   letterSpacing: '0.03em',
   fontFamily: MONO_FONT,
   lineHeight: 1.2,
 }
+
+const BUTTON_CLASS =
+  'border border-[hsl(var(--brand-neutral-300))] text-[hsl(var(--brand-neutral-600))] ' +
+  'hover:border-[hsl(var(--brand-neutral-400))] hover:text-[hsl(var(--brand-neutral-700))] ' +
+  'focus-visible:border-[hsl(var(--brand-neutral-400))] focus-visible:text-[hsl(var(--brand-neutral-700))]'
 
 const LABEL_STYLE: CSSProperties = {
   fontSize: 9,
@@ -30,15 +33,6 @@ const DIVIDER_STYLE: CSSProperties = {
   margin: '0 2px',
 }
 
-const handleMouseEnter = (e: MouseEvent<HTMLButtonElement>) => {
-  e.currentTarget.style.borderColor = 'hsl(var(--brand-neutral-400))'
-  e.currentTarget.style.color = 'hsl(var(--brand-neutral-700))'
-}
-const handleMouseLeave = (e: MouseEvent<HTMLButtonElement>) => {
-  e.currentTarget.style.borderColor = 'hsl(var(--brand-neutral-300))'
-  e.currentTarget.style.color = 'hsl(var(--brand-neutral-600))'
-}
-
 interface ToolbarButtonProps {
   glyph: string
   title: string
@@ -48,13 +42,14 @@ interface ToolbarButtonProps {
 const ToolbarButton = ({ glyph, title, onClick }: ToolbarButtonProps) => {
   return (
     <button
+      type="button"
+      className={BUTTON_CLASS}
       style={BUTTON_STYLE}
       title={title}
+      aria-label={title}
       onClick={onClick}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
     >
-      {glyph}
+      <span aria-hidden="true">{glyph}</span>
     </button>
   )
 }

--- a/src/components/editor/property-panel/button/action-row.tsx
+++ b/src/components/editor/property-panel/button/action-row.tsx
@@ -51,6 +51,7 @@ export const ActionRow = ({ action, pageIds, onUpdate, onRemove }: ActionRowProp
           {action.category} — {typeLabel}
         </span>
         <button
+          type="button"
           onClick={onRemove}
           style={{
             background: 'none',
@@ -61,6 +62,7 @@ export const ActionRow = ({ action, pageIds, onUpdate, onRemove }: ActionRowProp
             display: 'flex',
           }}
           title="Remove action"
+          aria-label="Remove action"
         >
           <IconTrash size={11} color="#553333" />
         </button>

--- a/src/components/editor/property-panel/button/cycle-state-row.tsx
+++ b/src/components/editor/property-panel/button/cycle-state-row.tsx
@@ -80,8 +80,10 @@ export const CycleStateRow = ({
           Initial
         </label>
         <button
+          type="button"
           onClick={onRemove}
           disabled={!canRemove}
+          aria-label="Remove state"
           style={{
             background: 'none',
             border: 'none',


### PR DESCRIPTION
Closes #76

## What

- `ToolbarButton` gets `aria-label={title}`, `type="button"`, and the glyph wrapped in `aria-hidden` — screen readers now announce "Align left edges" instead of "leftwards arrow"
- The `onMouseEnter`/`onMouseLeave` style mutation is replaced by `hover:`/`focus-visible:` Tailwind classes (border/colour moved out of the inline style so the variants can win), which also gives keyboard focus a visible affordance
- Sweep of the other glyph-only buttons: the two `IconTrash` removers (`action-row`, `cycle-state-row`) get `aria-label` + `type="button"`; `CliOfflineState`'s chevron span is marked decorative (`aria-expanded` was already in place)

`widget-editor-panel`'s delete button already carries visible text — untouched.

## Test plan

- `typecheck`, `lint`, `test` (332 passing), `build` via CI
- Manual: tab through the editor toolbar — focused buttons show the hover treatment