### PR TITLE
seo(tuner): meta description, per-route titles, robots.txt and a reachable sitemap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .vercel/
 .vite/
 src/styles/tokens.generated.css
+public/sitemap.xml

--- a/index.html
+++ b/index.html
@@ -9,12 +9,47 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#201E1D" />
+    <meta
+      name="description"
+      content="Configure your CANShift dash, live. Edit pages, bind CAN signals, tune OBD-II polling and flash firmware — all in your browser."
+    />
+    <link rel="canonical" href="https://tuner.canshift.app/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="CANShift" />
     <meta property="og:title" content="CANShift Tuner" />
+    <meta
+      property="og:description"
+      content="Configure your CANShift dash, live. Edit pages, bind CAN signals, tune OBD-II polling and flash firmware — all in your browser."
+    />
+    <meta property="og:url" content="https://tuner.canshift.app/" />
     <meta property="og:image" content="https://tuner.canshift.app/og-image-1200x630.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="CANShift Tuner — browser configurator for CANShift dashes"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
     <title>CANShift Tuner</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "CANShift Tuner",
+        "description": "Browser configurator for CANShift dashes — edit pages and widgets, bind CAN signals, tune OBD-II polling and flash firmware over WebSerial.",
+        "url": "https://tuner.canshift.app/",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Chromium-based browsers",
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>
+    <noscript>
+      CANShift Tuner is a browser configurator for CANShift dashes and needs JavaScript to run. Read
+      more at <a href="https://docs.canshift.tmbk.ch">docs.canshift.tmbk.ch</a>.
+    </noscript>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "predev": "npm run tokens:gen",
     "dev": "vite",
-    "prebuild": "npm run tokens:gen",
+    "prebuild": "npm run tokens:gen && npm run sitemap:gen",
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
@@ -18,6 +18,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "tokens:gen": "tsx scripts/generate-tokens.css.ts",
+    "sitemap:gen": "tsx scripts/generate-sitemap.ts",
     "prepare": "husky",
     "lint:pre-commit": "lint-staged"
   },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://tuner.canshift.app/sitemap.xml

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { ROUTE_PATHS } from '../src/constants/routes'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const OUTPUT_PATH = resolve(SCRIPT_DIR, '..', 'public', 'sitemap.xml')
+const BASE_URL = 'https://tuner.canshift.app'
+
+const urlEntry = (path: string): string =>
+  `  <url>\n    <loc>${BASE_URL}${path === '/' ? '/' : path}</loc>\n  </url>`
+
+const sitemap = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+  ...ROUTE_PATHS.map(urlEntry),
+  '</urlset>',
+  '',
+].join('\n')
+
+writeFileSync(OUTPUT_PATH, sitemap)
+console.log(`sitemap: ${String(ROUTE_PATHS.length)} routes -> ${OUTPUT_PATH}`)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { useBurnShortcut } from './hooks/useBurnShortcut'
 import { bootstrapProjects } from './stores/project/project.store'
 import { useWidgetOverflowWarnings } from './hooks/useWidgetOverflowWarnings'
 import { useUnsavedChangesGuard } from './hooks/useUnsavedChangesGuard'
+import { useDocumentMeta } from './hooks/useDocumentMeta'
 import { DeviceConfigConflictDialog } from './components/shell/DeviceConfigConflictDialog'
 import { ROUTE_PATHS, type RoutePath } from './constants/routes'
 
@@ -107,6 +108,7 @@ const App = () => {
   useBurnShortcut()
   useWidgetOverflowWarnings()
   useUnsavedChangesGuard()
+  useDocumentMeta()
 
   const hasDashboardConfig = useDashboardStore((s) => s.config !== null)
   useEffect(() => {

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,16 +1,65 @@
-export const ROUTE_PATHS = [
-  '/',
-  '/dashboard',
-  '/can',
-  '/ecu',
-  '/obd2',
-  '/themes',
-  '/live',
-  '/logs',
-  '/cli',
-  '/board',
-  '/firmware',
-  '/about',
-] as const
+export interface RouteMeta {
+  title: string
+  description: string
+}
 
-export type RoutePath = (typeof ROUTE_PATHS)[number]
+export const ROUTE_META = {
+  '/': {
+    title: 'CANShift Tuner',
+    description:
+      'Configure your CANShift dash, live. Edit pages, bind CAN signals, tune OBD-II polling and flash firmware — all in your browser.',
+  },
+  '/dashboard': {
+    title: 'Pages & widgets — CANShift Tuner',
+    description:
+      'Arrange pages and widgets on the dash canvas — gauges, warnings, gear and shift lights — with a live device-accurate preview.',
+  },
+  '/can': {
+    title: 'CAN bus — CANShift Tuner',
+    description:
+      'Scan the CAN bus live — frame rates, byte histograms and signal binding straight from the wire.',
+  },
+  '/ecu': {
+    title: 'ECU profile — CANShift Tuner',
+    description:
+      'Load an ECU broadcast profile from the catalogue or import its XML, and preview the decoded signals.',
+  },
+  '/obd2': {
+    title: 'OBD-II — CANShift Tuner',
+    description:
+      'Tune OBD-II PID polling and read diagnostic trouble codes from the connected device.',
+  },
+  '/themes': {
+    title: 'Themes — CANShift Tuner',
+    description: 'Pick a colour theme for the dash and preview its palette before burning it.',
+  },
+  '/live': {
+    title: 'Live data — CANShift Tuner',
+    description: 'Watch decoded signal values stream from the device in real time.',
+  },
+  '/logs': {
+    title: 'Logs — CANShift Tuner',
+    description: 'Browse device log output and recorded sessions.',
+  },
+  '/cli': {
+    title: 'CLI — CANShift Tuner',
+    description: 'Send raw firmware opcodes to the device over USB.',
+  },
+  '/board': {
+    title: 'Board config — CANShift Tuner',
+    description:
+      'Select a supported board or describe custom hardware — display, touch, pins and CAN transceiver.',
+  },
+  '/firmware': {
+    title: 'Firmware — CANShift Tuner',
+    description: 'Download CANShift firmware releases and flash them to the board over WebSerial.',
+  },
+  '/about': {
+    title: 'About — CANShift Tuner',
+    description: 'Version details, device diagnostics and feedback.',
+  },
+} as const satisfies Record<string, RouteMeta>
+
+export type RoutePath = keyof typeof ROUTE_META
+
+export const ROUTE_PATHS = Object.keys(ROUTE_META) as readonly RoutePath[]

--- a/src/hooks/useDocumentMeta.ts
+++ b/src/hooks/useDocumentMeta.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import { ROUTE_META, type RoutePath } from '../constants/routes'
+
+const isKnownPath = (pathname: string): pathname is RoutePath => pathname in ROUTE_META
+
+export const useDocumentMeta = (): void => {
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    const meta = isKnownPath(pathname) ? ROUTE_META[pathname] : ROUTE_META['/']
+    document.title = meta.title
+    document.querySelector('meta[name="description"]')?.setAttribute('content', meta.description)
+  }, [pathname])
+}

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   "outputDirectory": "dist",
   "rewrites": [
     {
-      "source": "/((?!api/).*)",
+      "source": "/((?!api/|robots\\.txt|sitemap\\.xml).*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
Closes #72

## What

- **Static head** (`index.html`): meta description, full `og:` set (`type`, `site_name`, `description`, `url`, image dimensions + alt), `twitter:card=summary_large_image`, canonical link, a `<noscript>` block pointing at the docs, and a `SoftwareApplication` JSON-LD block
- **Per-route titles + descriptions**: `ROUTE_META` is now the single source in `constants/routes.ts` — `ROUTE_PATHS` is derived from its keys, so a new route can't miss its metadata. A `useDocumentMeta` hook (wired once in `App`, keyed on `useLocation`) sets `document.title` and swaps the description per route
- **`public/robots.txt`** — allow all, points at the sitemap
- **`public/sitemap.xml`** — generated from `ROUTE_PATHS` by `scripts/generate-sitemap.ts`, run from `prebuild`; the generated file is gitignored
- **Vercel rewrite** now excludes `robots.txt` and `sitemap.xml` from the SPA catch-all so the static files actually win

## Verification

After deploy:
- `curl -I https://tuner.canshift.app/robots.txt` → `text/plain`
- `curl -I https://tuner.canshift.app/sitemap.xml` → `application/xml`
- Route changes update the tab title

## Test plan

- `typecheck`, `lint`, `test` (332 passing), `build` via CI — `dist/` verified locally to contain both static files