### PR TITLE
fix(tuner): aria-labels for the remaining glyph-only buttons

### DIFF
--- a/src/components/editor/CanvasToolbar.tsx
+++ b/src/components/editor/CanvasToolbar.tsx
@@ -85,11 +85,18 @@ export const CanvasToolbar = ({
         onClick={onZoomOut}
         disabled={zoom <= ZOOM_MIN}
         title="Zoom out"
+        aria-label="Zoom out"
         style={squareButtonStyle(zoom > ZOOM_MIN)}
       >
-        −
+        <span aria-hidden="true">−</span>
       </button>
-      <button type="button" onClick={onZoomReset} title="Reset zoom" style={zoomValueStyle}>
+      <button
+        type="button"
+        onClick={onZoomReset}
+        title="Reset zoom"
+        aria-label="Reset zoom"
+        style={zoomValueStyle}
+      >
         {Math.round(zoom * 100)} %
       </button>
       <button
@@ -98,9 +105,10 @@ export const CanvasToolbar = ({
         onClick={onZoomIn}
         disabled={zoom >= ZOOM_MAX}
         title="Zoom in"
+        aria-label="Zoom in"
         style={{ ...squareButtonStyle(zoom < ZOOM_MAX), borderLeft: groupRule }}
       >
-        +
+        <span aria-hidden="true">+</span>
       </button>
     </div>
 

--- a/src/components/editor/PageStrip.tsx
+++ b/src/components/editor/PageStrip.tsx
@@ -155,9 +155,11 @@ const PageCell = ({
             onSetDefault(page.id)
           }}
           title={isDefault ? 'Default page (shown at boot)' : 'Set as default'}
+          aria-label={isDefault ? 'Default page (shown at boot)' : 'Set as default'}
+          aria-pressed={isDefault}
           style={starButtonStyle(isDefault)}
         >
-          {isDefault ? '★' : '☆'}
+          <span aria-hidden="true">{isDefault ? '★' : '☆'}</span>
         </button>
         {canRemove && (
           <button
@@ -167,9 +169,10 @@ const PageCell = ({
               onRemove(page.id)
             }}
             title="Remove page"
+            aria-label={`Remove page ${String(index + 1)}`}
             style={removeButtonStyle}
           >
-            ×
+            <span aria-hidden="true">×</span>
           </button>
         )}
         <span style={cellCountStyle}>{page.widgets.length}w</span>


### PR DESCRIPTION
Closes #76.

## What

The `AlignToolbar` fix from the issue body is already on main (`aria-label` + `type=\"button\"` + `aria-hidden` glyph + `focus-visible` classes), and `CliOfflineState`'s disclosure already carries `aria-expanded`. This PR finishes the sweep the issue asked for — every remaining `<button>` whose only content is a glyph:

- `PageStrip` — the default-page star (★/☆) gets `aria-label` mirroring its title plus `aria-pressed`, and the remove button announces `Remove page N` instead of \"multiplication sign\".
- `CanvasToolbar` — the − / + zoom buttons get `aria-label=\"Zoom out\"/\"Zoom in\"`; the percentage button gets `aria-label=\"Reset zoom\"` so its action is announced, not just \"100 %\".
- Glyphs are wrapped in `aria-hidden` spans, matching the `AlignToolbar` pattern.

Audited and already compliant: `HeaderView`, `DeviceAlertBar`, `UndoToast`, `FeedbackButton`, `BurnButton`, `CanFrameRow`, `CommandForm`, `page-config-panel`. Everything else glyph-looking is plain text content.

## Test plan

- `npm run typecheck` / `lint` / `test` / `prettier --check` — all green