### PR TITLE
refactor(tuner): welcome screen to tailwind

### DIFF
--- a/eslint-inline-style-baseline.mjs
+++ b/eslint-inline-style-baseline.mjs
@@ -85,7 +85,6 @@ export const INLINE_STYLE_BASELINE = [
   'src/components/shell/Sidebar.tsx',
   'src/components/shell/SidebarView.tsx',
   'src/components/shell/ThemeToggleButton.tsx',
-  'src/components/shell/WelcomeScreen.tsx',
   'src/components/themes/ThemeCard.tsx',
   'src/components/themes/ThemeControls.tsx',
   'src/components/themes/ThemeStatusCard.tsx',

--- a/src/components/shell/WelcomeScreen.tsx
+++ b/src/components/shell/WelcomeScreen.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@/components/ui/spinner'
-import type { CSSProperties, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { BrandLockup } from '@/components/brand/BrandLockup'
 
@@ -40,14 +40,16 @@ export const WelcomeScreen = ({
   footerLinks,
 }: WelcomeScreenProps) => {
   return (
-    <div style={containerStyle}>
-      <div style={contentStyle}>
-        <header style={heroStyle}>
-          <div style={lockupStyle}>
+    <div className="flex flex-1 items-center justify-center overflow-y-auto bg-background px-8 py-12">
+      <div className="flex w-full max-w-[540px] flex-col gap-7">
+        <header className="flex flex-col items-center gap-3 text-center">
+          <div className="flex justify-center text-text">
             <BrandLockup height={78} withBaseline label="CANShift Tuner" />
           </div>
-          <h1 style={titleStyle}>Configure your dash, live.</h1>
-          <p style={taglineStyle}>
+          <h1 className="m-0 text-[30px] font-bold leading-[1.15] tracking-[-0.02em] text-text">
+            Configure your dash, live.
+          </h1>
+          <p className="m-0 max-w-[440px] text-sm leading-[1.6] text-text-dim">
             Edit pages, bind CAN signals, tune OBD-II polling — all in your browser, with the dash
             connected over USB. No install, nothing to deploy.
           </p>
@@ -57,29 +59,31 @@ export const WelcomeScreen = ({
           <UnsupportedBrowserCard />
         ) : (
           <>
-            <ol style={stepsStyle}>
+            <ol className="m-0 flex list-none flex-col gap-3.5 p-0">
               {STEPS.map((step, idx) => (
-                <li key={step.title} style={stepStyle}>
-                  <div style={stepNumberStyle}>{idx + 1}</div>
+                <li
+                  key={step.title}
+                  className="flex items-start gap-3.5 border border-border bg-surface px-4 py-3.5"
+                >
+                  <div className="mt-0.5 flex size-7 shrink-0 items-center justify-center bg-brand-accent/15 text-[13px] font-bold text-brand-accent">
+                    {idx + 1}
+                  </div>
                   <div>
-                    <div style={stepTitleStyle}>{step.title}</div>
-                    <div style={stepBodyStyle}>{step.body}</div>
+                    <div className="mb-0.5 text-sm leading-[1.5] font-semibold text-text">
+                      {step.title}
+                    </div>
+                    <div className="text-[13px] leading-[1.5] text-text-dim">{step.body}</div>
                   </div>
                 </li>
               ))}
             </ol>
 
-            <div style={ctaRowStyle}>
+            <div className="mt-1 flex flex-wrap items-center justify-center gap-3">
               <Button
                 type="button"
                 disabled={busy}
                 onClick={onConnect}
-                className="h-auto gap-0"
-                style={{
-                  ...connectButtonStyle,
-                  cursor: busy ? 'wait' : 'pointer',
-                  opacity: busy ? 0.7 : 1,
-                }}
+                className="h-auto gap-0 px-7 py-3.5 text-[13px] leading-5 font-semibold uppercase tracking-[0.06em] disabled:opacity-70"
               >
                 {busy ? (
                   <>
@@ -95,204 +99,49 @@ export const WelcomeScreen = ({
                   variant="outline"
                   disabled={busy}
                   onClick={onExploreSimulation}
-                  className="h-auto gap-0"
-                  style={{
-                    ...exploreButtonStyle,
-                    cursor: busy ? 'wait' : 'pointer',
-                    opacity: busy ? 0.6 : 1,
-                  }}
+                  className="h-auto gap-0 bg-transparent px-[22px] py-[13px] text-xs leading-5 font-medium tracking-[0.04em] text-text-dim disabled:opacity-60"
                 >
                   Explore with sample data
                 </Button>
               )}
             </div>
 
-            {lastError ? <div style={errorPillStyle}>{lastError}</div> : null}
+            {lastError ? (
+              <div className="border border-destructive bg-bg-inset px-3.5 py-2.5 text-center text-[13px] text-destructive">
+                {lastError}
+              </div>
+            ) : null}
           </>
         )}
 
-        {footerLinks ? <footer style={footerStyle}>{footerLinks}</footer> : null}
+        {footerLinks ? (
+          <footer className="mt-2 flex items-center justify-center gap-2 border-t border-border pt-2">
+            {footerLinks}
+          </footer>
+        ) : null}
       </div>
     </div>
   )
 }
 
 const UnsupportedBrowserCard = () => (
-  <div style={unsupportedCardStyle} role="alert">
-    <div
-      style={{
-        fontWeight: 600,
-        color: 'hsl(var(--text))',
-        marginBottom: 6,
-      }}
-    >
-      WebSerial isn't available in this browser
+  <div
+    className="border border-border bg-bg-inset px-5 py-[18px] text-left text-[13px] text-text-dim"
+    role="alert"
+  >
+    <div className="mb-1.5 font-semibold text-text">
+      WebSerial isn&apos;t available in this browser
     </div>
-    <div style={{ fontSize: 13, marginBottom: 12 }}>
+    <div className="mb-3 text-[13px]">
       CANShift Tuner needs the WebSerial API to talk to the dash over USB. Open this page in one of
       the supported browsers — or copy the URL and paste it into the new one:
     </div>
-    <ul style={{ listStyle: 'none', padding: 0, margin: 0, fontSize: 13 }}>
+    <ul className="m-0 list-none p-0 text-[13px]">
       {SUPPORTED_BROWSERS.map((b) => (
-        <li key={b} style={{ padding: '2px 0' }}>
+        <li key={b} className="py-0.5">
           · {b}
         </li>
       ))}
     </ul>
   </div>
 )
-
-const containerStyle: CSSProperties = {
-  flex: 1,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  background: 'hsl(var(--bg))',
-  padding: '48px 32px',
-  overflowY: 'auto',
-}
-
-const contentStyle: CSSProperties = {
-  width: '100%',
-  maxWidth: 540,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 28,
-}
-
-const heroStyle: CSSProperties = {
-  textAlign: 'center',
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  gap: 12,
-}
-
-const lockupStyle: CSSProperties = {
-  display: 'flex',
-  justifyContent: 'center',
-  color: 'hsl(var(--text))',
-}
-
-const titleStyle: CSSProperties = {
-  fontSize: 30,
-  fontWeight: 700,
-  color: 'hsl(var(--text))',
-  letterSpacing: '-0.02em',
-  margin: 0,
-  lineHeight: 1.15,
-}
-
-const taglineStyle: CSSProperties = {
-  fontSize: 14,
-  color: 'hsl(var(--text-dim))',
-  lineHeight: 1.6,
-  margin: 0,
-  maxWidth: 440,
-}
-
-const stepsStyle: CSSProperties = {
-  listStyle: 'none',
-  padding: 0,
-  margin: 0,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 14,
-}
-
-const stepStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'flex-start',
-  gap: 14,
-  padding: '14px 16px',
-  background: 'hsl(var(--surface))',
-  border: '1px solid hsl(var(--border))',
-}
-
-const stepNumberStyle: CSSProperties = {
-  width: 28,
-  height: 28,
-  flexShrink: 0,
-  background: 'hsl(var(--brand-accent) / 0.15)',
-  color: 'hsl(var(--brand-accent))',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  fontWeight: 700,
-  fontSize: 13,
-  marginTop: 2,
-}
-
-const stepTitleStyle: CSSProperties = {
-  fontWeight: 600,
-  color: 'hsl(var(--text))',
-  fontSize: 14,
-  marginBottom: 2,
-}
-
-const stepBodyStyle: CSSProperties = {
-  fontSize: 13,
-  color: 'hsl(var(--text-dim))',
-  lineHeight: 1.5,
-}
-
-const ctaRowStyle: CSSProperties = {
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  gap: 12,
-  flexWrap: 'wrap',
-  marginTop: 4,
-}
-
-const connectButtonStyle: CSSProperties = {
-  background: 'hsl(var(--brand-accent))',
-  color: 'hsl(var(--brand-ground))',
-  border: 'none',
-  padding: '14px 28px',
-  fontSize: 13,
-  fontWeight: 600,
-  letterSpacing: '0.06em',
-  textTransform: 'uppercase',
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-}
-
-const exploreButtonStyle: CSSProperties = {
-  background: 'transparent',
-  color: 'hsl(var(--text-dim))',
-  border: '1px solid hsl(var(--border))',
-  padding: '13px 22px',
-  fontSize: 12,
-  fontWeight: 500,
-  letterSpacing: '0.04em',
-}
-
-const errorPillStyle: CSSProperties = {
-  background: 'hsl(var(--bg-inset))',
-  border: '1px solid hsl(var(--destructive))',
-  color: 'hsl(var(--destructive))',
-  padding: '10px 14px',
-  fontSize: 13,
-  textAlign: 'center',
-}
-
-const unsupportedCardStyle: CSSProperties = {
-  background: 'hsl(var(--bg-inset))',
-  border: '1px solid hsl(var(--border))',
-  padding: '18px 20px',
-  color: 'hsl(var(--text-dim))',
-  textAlign: 'left',
-  fontSize: 13,
-}
-
-const footerStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  gap: 8,
-  paddingTop: 8,
-  borderTop: '1px solid hsl(var(--border))',
-  marginTop: 8,
-}


### PR DESCRIPTION
First per-surface conversion under #75. `WelcomeScreen` was the biggest offender at 18 `CSSProperties` objects; it now has zero and drops out of the ESLint baseline (102 → 101).

195 lines deleted, 43 added.

## What this fixes beyond the style objects

Both buttons were `<Button>` with the component's own variant styling overridden inline — `connectButtonStyle` hand-re-declared `bg-brand-accent` / `text-brand-ground`, which is exactly `variant="default"`, and `exploreButtonStyle` re-declared `variant="outline"`. That is the "bespoke buttons whose focus ring differs from `Button`'s" case in the issue. They now use the variants and only carry the size/typography deltas, so they inherit `Button`'s hover and `focus-visible` treatment for free.

## A gotcha worth knowing for the remaining surfaces

A naive `fontSize: 13` → `text-[13px]` mapping **silently changes vertical rhythm**, and this is going to bite every surface PR.

`src/index.css` sets `body { line-height: 1.5 }` as a unitless ratio, so an inline `fontSize` inherited a computed line-height proportional to it. Tailwind's `text-*` utilities ship their *own* paired line-height (`text-xs` is 12px/**16px**, `text-sm` is 14px/**20px**), and arbitrary values like `text-[13px]` set no line-height at all and fall back to the inherited ratio.

First pass came out 0.864% different — the whole content column had drifted 2px because the container centres vertically and the block had shrunk. Measuring rather than eyeballing found three elements:

| Element | Before | Naive mapping | Fix |
| --- | --- | --- | --- |
| Explore button | 12px/20px (from `Button`'s `text-sm`) | `text-xs` → 12px/16px | `+ leading-5` |
| Connect button | 13px/20px (same) | `text-[13px]` → 13px/19.5px | `+ leading-5` |
| Step title | 14px/21px (body ratio) | `text-sm` → 14px/20px | `+ leading-[1.5]` |

Note the buttons: their *original* line-height came from `Button`'s own `text-sm`, not from the inline style — the inline `fontSize` changed the size but left Tailwind's line-height in place. Easy to miss.

**Takeaway for the next surfaces: pair every `text-*` with an explicit `leading-*`, and verify with a pixel diff rather than by eye.**

## Visual verification

Both rendered states, full-page at 1440×900, production build:

| State | Diff |
| --- | --- |
| default | **0 px — pixel-identical** |
| unsupported browser | **0 px — pixel-identical** |

No console errors in either.

Worth recording how these were captured, because it is not obvious: `useSimulationBootstrap` auto-enters simulation mode whenever `import.meta.env.DEV` is set, so `WelcomeRoute` immediately redirects to `/dashboard` and **the welcome screen is unreachable on the dev server**. It has to be verified against `vite preview` on a production build. The unsupported-browser branch is reached by deleting `Navigator.prototype.serial` in an init script — note `isWebSerialAvailable` uses `'serial' in navigator`, so redefining the property as `undefined` is not enough, it has to be deleted.

## Not verified by screenshot

The `busy` and `lastError` states are not reachable without a device or a failed connection. Their mappings are one element each and listed here for review: `opacity: 0.7` / `0.6` became `disabled:opacity-70` / `disabled:opacity-60` (overriding `Button`'s `disabled:opacity-50` via tailwind-merge), and the error pill is a straight class translation. One deliberate drop: both buttons carried `cursor: busy ? 'wait' : 'pointer'`, which never had any effect — `Button`'s base sets `disabled:pointer-events-none`, and the buttons are `disabled={busy}`, so the cursor was dead code in exactly the state it was written for.

## Test plan

- `npm run typecheck`, `lint`, `format:check`, `test` (53 files, 332 tests), `build` — all green
- Baseline down to 101 entries, consistency asserted (no stale entries)
- Pixel diff on both rendered states against `main`, same production build pipeline, as above
