### PR TITLE
feat(tuner): accept manifest schema 2 artifact checksums, fall back to them when GitHub has no digest

### DIFF
--- a/src/components/firmware/FlashActions.tsx
+++ b/src/components/firmware/FlashActions.tsx
@@ -17,6 +17,7 @@ export interface FlashActionsProps {
   pickedRelease: ReleaseInfo | null
   mergedAsset: ReleaseAsset | null
   expectedChip?: string
+  mergedSha256?: string | null
 }
 
 const SELECTION_LABELS: Record<FirmwareSelection['kind'], (s: FirmwareSelection) => string> = {
@@ -78,6 +79,7 @@ export const FlashActions = ({
   pickedRelease,
   mergedAsset,
   expectedChip,
+  mergedSha256,
 }: FlashActionsProps) => {
   const setReleaseFirmware = useFirmwareSelectionStore((s) => s.setReleaseFirmware)
   const log = useLogStore((s) => s.push)
@@ -109,10 +111,14 @@ export const FlashActions = ({
     setDownloadError(null)
     log('info', `Downloading ${asset.name} (${formatBytes(asset.sizeBytes)})`)
     try {
-      const firmware = await downloadFirmwareAsset(asset, (loaded, total) => {
-        setLoadedBytes(loaded)
-        setProgress(total > 0 ? loaded / total : 0)
-      })
+      const firmware = await downloadFirmwareAsset(
+        asset,
+        (loaded, total) => {
+          setLoadedBytes(loaded)
+          setProgress(total > 0 ? loaded / total : 0)
+        },
+        mergedSha256
+      )
       setReleaseFirmware(release, firmware)
       log(
         'success',

--- a/src/hooks/useFirmwareManifest.test.ts
+++ b/src/hooks/useFirmwareManifest.test.ts
@@ -12,7 +12,11 @@ const manifest: BoardManifest = {
       chip: 'esp32',
       display: 'ILI9341 320x240',
       touch: 'XPT2046',
-      artifacts: { merged: 'm.bin', firmware: 'f.bin', spiffs: 's.bin' },
+      artifacts: {
+        merged: { file: 'm.bin', sha256: null },
+        firmware: { file: 'f.bin', sha256: null },
+        spiffs: { file: 's.bin', sha256: null },
+      },
     },
   ],
 }

--- a/src/lib/firmware/board-resolution.test.ts
+++ b/src/lib/firmware/board-resolution.test.ts
@@ -12,14 +12,22 @@ const manifest = (): BoardManifest => ({
       chip: 'esp32',
       display: 'ILI9341 320x240',
       touch: 'XPT2046',
-      artifacts: { merged: 'a-merged.bin', firmware: 'a-firmware.bin', spiffs: 'a-spiffs.bin' },
+      artifacts: {
+        merged: { file: 'a-merged.bin', sha256: null },
+        firmware: { file: 'a-firmware.bin', sha256: null },
+        spiffs: { file: 'a-spiffs.bin', sha256: null },
+      },
     },
     {
       id: 'generic_ili9341_gt911',
       chip: 'esp32',
       display: 'ILI9341 320x240',
       touch: 'GT911',
-      artifacts: { merged: 'b-merged.bin', firmware: 'b-firmware.bin', spiffs: 'b-spiffs.bin' },
+      artifacts: {
+        merged: { file: 'b-merged.bin', sha256: null },
+        firmware: { file: 'b-firmware.bin', sha256: null },
+        spiffs: { file: 'b-spiffs.bin', sha256: null },
+      },
     },
   ],
 })

--- a/src/lib/firmware/download.ts
+++ b/src/lib/firmware/download.ts
@@ -25,18 +25,24 @@ export const firmwareAssetProxyUrl = (downloadUrl: string): string => {
   return `${PROXY_PATH}?${params.toString()}`
 }
 
-const expectedDigestHex = (asset: ReleaseAsset): string => {
+const normaliseDigest = (raw: string): string =>
+  (raw.startsWith(DIGEST_PREFIX) ? raw.slice(DIGEST_PREFIX.length) : raw).toLowerCase()
+
+const expectedDigestHex = (asset: ReleaseAsset, manifestSha256?: string | null): string => {
   const raw = asset.digest
-  if (typeof raw !== 'string' || raw.length === 0) {
-    throw new Error(
-      `No checksum published for ${asset.name} — refusing to flash an image that cannot be verified.`
-    )
+  if (typeof raw === 'string' && raw.length > 0) {
+    const hex = normaliseDigest(raw)
+    if (!SHA256_HEX_RE.test(hex)) {
+      throw new Error(`Unusable checksum published for ${asset.name}: ${raw}`)
+    }
+    return hex
   }
-  const hex = (raw.startsWith(DIGEST_PREFIX) ? raw.slice(DIGEST_PREFIX.length) : raw).toLowerCase()
-  if (!SHA256_HEX_RE.test(hex)) {
-    throw new Error(`Unusable checksum published for ${asset.name}: ${raw}`)
+  if (typeof manifestSha256 === 'string' && SHA256_HEX_RE.test(manifestSha256.toLowerCase())) {
+    return manifestSha256.toLowerCase()
   }
-  return hex
+  throw new Error(
+    `No checksum published for ${asset.name} — refusing to flash an image that cannot be verified.`
+  )
 }
 
 const oversized = (received: number): LocalFirmwareError =>
@@ -47,7 +53,8 @@ const oversized = (received: number): LocalFirmwareError =>
 
 export const downloadFirmwareAsset = async (
   asset: ReleaseAsset,
-  onProgress?: DownloadProgress
+  onProgress?: DownloadProgress,
+  manifestSha256?: string | null
 ): Promise<LocalFirmware> => {
   if (asset.sizeBytes > FIRMWARE_MAX_BYTES) {
     throw new LocalFirmwareError(
@@ -56,7 +63,7 @@ export const downloadFirmwareAsset = async (
     )
   }
 
-  const expected = expectedDigestHex(asset)
+  const expected = expectedDigestHex(asset, manifestSha256)
   const proxyUrl = firmwareAssetProxyUrl(asset.downloadUrl)
 
   const controller = new AbortController()

--- a/src/lib/firmware/manifest.test.ts
+++ b/src/lib/firmware/manifest.test.ts
@@ -1,6 +1,27 @@
 import { describe, expect, it } from 'vitest'
 import { boardLabel, findBoard, parseManifest } from './manifest'
 
+const SHA = 'a'.repeat(64)
+
+const SCHEMA_2_MANIFEST = JSON.stringify({
+  schema: 2,
+  version: '2.0.0',
+  tag: 'v2.0.0',
+  boards: [
+    {
+      id: 'crowpanel_28',
+      chip: 'esp32',
+      display: 'ILI9341 320x240',
+      touch: 'XPT2046',
+      artifacts: {
+        merged: { file: 'canshift-crowpanel_28-v2.0.0-merged.bin', sha256: SHA },
+        firmware: { file: 'canshift-crowpanel_28-v2.0.0-firmware.bin', sha256: SHA },
+        spiffs: { file: 'canshift-crowpanel_28-v2.0.0-spiffs.bin', sha256: SHA },
+      },
+    },
+  ],
+})
+
 const MANIFEST = JSON.stringify({
   schema: 1,
   version: '1.4.0',
@@ -37,9 +58,60 @@ describe('parseManifest', () => {
     expect(manifest).not.toBeNull()
     if (!manifest) return
     expect(manifest.boards).toHaveLength(2)
-    expect(findBoard(manifest, 'crowpanel_28')?.artifacts.merged).toBe(
-      'canshift-crowpanel_28-v1.4.0-merged.bin'
-    )
+    expect(findBoard(manifest, 'crowpanel_28')?.artifacts.merged).toEqual({
+      file: 'canshift-crowpanel_28-v1.4.0-merged.bin',
+      sha256: null,
+    })
+  })
+
+  it('reads the schema-2 object form and keeps the checksum', () => {
+    const manifest = parseManifest(SCHEMA_2_MANIFEST)
+    expect(manifest).not.toBeNull()
+    if (!manifest) return
+    expect(findBoard(manifest, 'crowpanel_28')?.artifacts.merged).toEqual({
+      file: 'canshift-crowpanel_28-v2.0.0-merged.bin',
+      sha256: SHA,
+    })
+    expect(findBoard(manifest, 'crowpanel_28')?.artifacts.spiffs.sha256).toBe(SHA)
+  })
+
+  it('uppercases are normalised and a malformed checksum degrades to null', () => {
+    const raw = JSON.stringify({
+      schema: 2,
+      version: '2.0.0',
+      tag: 'v2.0.0',
+      boards: [
+        {
+          id: 'b',
+          chip: 'esp32',
+          display: 'd',
+          touch: 't',
+          artifacts: {
+            merged: { file: 'm.bin', sha256: SHA.toUpperCase() },
+            firmware: { file: 'f.bin', sha256: 'not-a-digest' },
+            spiffs: { file: 's.bin' },
+          },
+        },
+      ],
+    })
+    const board = findBoard(parseManifest(raw)!, 'b')
+    expect(board?.artifacts.merged.sha256).toBe(SHA)
+    expect(board?.artifacts.firmware.sha256).toBeNull()
+    expect(board?.artifacts.spiffs.sha256).toBeNull()
+  })
+
+  it('rejects an artifact entry with no filename in either shape', () => {
+    const withArtifacts = (artifacts: unknown) =>
+      JSON.stringify({
+        schema: 2,
+        version: '1',
+        tag: 'v1',
+        boards: [{ id: 'b', chip: 'c', display: 'd', touch: 't', artifacts }],
+      })
+    expect(parseManifest(withArtifacts({ merged: '', firmware: 'f', spiffs: 's' }))).toBeNull()
+    expect(
+      parseManifest(withArtifacts({ merged: { sha256: SHA }, firmware: 'f', spiffs: 's' }))
+    ).toBeNull()
   })
 
   it('returns null for invalid JSON, wrong shape, or an empty board list', () => {

--- a/src/lib/firmware/manifest.ts
+++ b/src/lib/firmware/manifest.ts
@@ -1,9 +1,14 @@
 export const FALLBACK_BOARD_ID = 'crowpanel_28'
 
+export interface ArtifactRef {
+  file: string
+  sha256: string | null
+}
+
 export interface BoardArtifacts {
-  merged: string
-  firmware: string
-  spiffs: string
+  merged: ArtifactRef
+  firmware: ArtifactRef
+  spiffs: ArtifactRef
 }
 
 export interface BoardManifestEntry {
@@ -21,24 +26,41 @@ export interface BoardManifest {
   boards: BoardManifestEntry[]
 }
 
-const isArtifacts = (value: unknown): value is BoardArtifacts => {
-  if (typeof value !== 'object' || value === null) return false
-  const a = value as Record<string, unknown>
-  return (
-    typeof a.merged === 'string' && typeof a.firmware === 'string' && typeof a.spiffs === 'string'
-  )
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/
+
+const toArtifactRef = (value: unknown): ArtifactRef | null => {
+  if (typeof value === 'string') return value.length > 0 ? { file: value, sha256: null } : null
+  if (typeof value !== 'object' || value === null) return null
+  const ref = value as Record<string, unknown>
+  if (typeof ref.file !== 'string' || ref.file.length === 0) return null
+  const sha = typeof ref.sha256 === 'string' ? ref.sha256.toLowerCase() : null
+  return { file: ref.file, sha256: sha !== null && SHA256_HEX_RE.test(sha) ? sha : null }
 }
 
-const isEntry = (value: unknown): value is BoardManifestEntry => {
-  if (typeof value !== 'object' || value === null) return false
+const toArtifacts = (value: unknown): BoardArtifacts | null => {
+  if (typeof value !== 'object' || value === null) return null
+  const a = value as Record<string, unknown>
+  const merged = toArtifactRef(a.merged)
+  const firmware = toArtifactRef(a.firmware)
+  const spiffs = toArtifactRef(a.spiffs)
+  if (!merged || !firmware || !spiffs) return null
+  return { merged, firmware, spiffs }
+}
+
+const toEntry = (value: unknown): BoardManifestEntry | null => {
+  if (typeof value !== 'object' || value === null) return null
   const e = value as Record<string, unknown>
-  return (
-    typeof e.id === 'string' &&
-    typeof e.chip === 'string' &&
-    typeof e.display === 'string' &&
-    typeof e.touch === 'string' &&
-    isArtifacts(e.artifacts)
-  )
+  if (
+    typeof e.id !== 'string' ||
+    typeof e.chip !== 'string' ||
+    typeof e.display !== 'string' ||
+    typeof e.touch !== 'string'
+  ) {
+    return null
+  }
+  const artifacts = toArtifacts(e.artifacts)
+  if (!artifacts) return null
+  return { id: e.id, chip: e.chip, display: e.display, touch: e.touch, artifacts }
 }
 
 export const parseManifest = (raw: string): BoardManifest | null => {
@@ -53,7 +75,7 @@ export const parseManifest = (raw: string): BoardManifest | null => {
   if (typeof manifest.schema !== 'number') return null
   if (typeof manifest.version !== 'string' || typeof manifest.tag !== 'string') return null
   if (!Array.isArray(manifest.boards)) return null
-  const boards = manifest.boards.filter(isEntry)
+  const boards = manifest.boards.map(toEntry).filter((b): b is BoardManifestEntry => b !== null)
   if (boards.length === 0) return null
   return { schema: manifest.schema, version: manifest.version, tag: manifest.tag, boards }
 }

--- a/src/routes/FirmwareRoute.tsx
+++ b/src/routes/FirmwareRoute.tsx
@@ -63,7 +63,7 @@ const FirmwareRoute = () => {
     pickedRelease === null
       ? null
       : selectedBoard
-        ? findAssetByName(pickedRelease, selectedBoard.artifacts.merged)
+        ? findAssetByName(pickedRelease, selectedBoard.artifacts.merged.file)
         : findMergedAsset(pickedRelease)
 
   const pickRelease = (tag: string) => {
@@ -115,6 +115,7 @@ const FirmwareRoute = () => {
             selection={selection}
             pickedRelease={pickedRelease}
             mergedAsset={mergedAsset}
+            mergedSha256={selectedBoard?.artifacts.merged.sha256 ?? null}
             {...(expectedChip !== undefined ? { expectedChip } : {})}
           />
           <BoardProfileProvision />


### PR DESCRIPTION
The reader half of CANShift/canshift-firmware#119. **This has to land before the firmware side**, or a release cut in between publishes a manifest this parser rejects — `parseManifest` currently requires `artifacts.{merged,firmware,spiffs}` to be strings, and would drop every board, leaving the flasher with no board list at all.

## What changed

**`manifest.ts` normalises both shapes at the boundary.** Schema 1 publishes a bare filename, schema 2 publishes `{ file, sha256 }`. Both become `ArtifactRef { file, sha256: string | null }`, so nothing downstream branches on which release it is reading:

```ts
export interface ArtifactRef {
  file: string
  sha256: string | null
}
```

A checksum is kept only if it is 64 lowercase hex; uppercase is normalised, anything malformed degrades to `null` rather than rejecting the board. A missing filename in *either* shape still rejects the entry — that is the field the flasher cannot work without.

`isEntry`/`isArtifacts` type guards became `toEntry`/`toArtifacts` builders, since the parser now transforms rather than merely validates.

**`download.ts` gains the fallback #119 asks for.** `expectedDigestHex(asset, manifestSha256?)` prefers GitHub's `asset.digest`, falls back to the manifest checksum, and only refuses when neither yields a usable hash. The existing behaviour is unchanged when a digest is present, including the "unusable checksum" rejection — a *malformed* digest is still a hard error rather than silently falling through to the manifest, because a corrupt digest field is a signal, not an absence.

`FirmwareRoute` passes `selectedBoard.artifacts.merged.sha256` into `FlashActions`, which forwards it to the download.

## Tests

Four new cases in `manifest.test.ts` — schema 2 round-trip, uppercase normalisation, malformed checksum degrading to `null`, and both no-filename shapes rejected. The pre-existing schema-1 assertion now expects the normalised object, which is the compatibility guarantee itself.

335 tests pass. Note this is only the *reader*: nothing publishes schema 2 yet, so the fallback path is exercised by tests rather than by a real release until the firmware side ships.

## Follow-up

CANShift/canshift-firmware#119 — have the release workflow `sha256sum` each artifact and emit the object form with `schema: 2`.

## Test plan

- `npm run typecheck` / `lint` / `test` (335) / `format:check` — all clean