### PR TITLE
refactor(tuner): signal preview table to tailwind

### DIFF
--- a/eslint-inline-style-baseline.mjs
+++ b/eslint-inline-style-baseline.mjs
@@ -12,7 +12,6 @@ export const INLINE_STYLE_BASELINE = [
   'src/components/cli/CliOutput.tsx',
   'src/components/cli/CommandForm.tsx',
   'src/components/ecu/EcuCatalogueList.tsx',
-  'src/components/ecu/SignalPreviewTable.tsx',
   'src/components/ecu/XmlImportZone.tsx',
   'src/components/editor/AlignToolbar.tsx',
   'src/components/editor/Canvas.tsx',

--- a/src/components/ecu/SignalPreviewTable.tsx
+++ b/src/components/ecu/SignalPreviewTable.tsx
@@ -1,6 +1,7 @@
-import type { CSSProperties } from 'react'
 import type { SignalDef } from '@canshift/core'
-import { MONO_FONT } from '../../lib/typography'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+import { RoutePanel } from '../ui/route-shell'
 
 export interface SignalPreviewTableProps {
   signals: readonly SignalDef[]
@@ -8,49 +9,83 @@ export interface SignalPreviewTableProps {
   warnings?: readonly string[]
 }
 
+const HEAD_CELL = [
+  'sticky top-0 z-[1] bg-brand-chrome-bg py-[11px] pl-0 pr-5',
+  'border-b-2 border-brand-divider text-left',
+  'text-[10px] font-extrabold tracking-[0.18em] text-brand-neutral-600',
+].join(' ')
+
+const cell = cva(
+  [
+    'overflow-hidden text-ellipsis whitespace-nowrap tabular-nums',
+    'border-b border-brand-neutral-300 py-3 pl-0 pr-5',
+    'font-mono text-[13px] text-brand-text',
+  ].join(' '),
+  {
+    variants: {
+      tone: {
+        default: '',
+        id: 'text-brand-accent',
+        dim: 'text-brand-neutral-600',
+        bound: 'font-sans text-[12px]',
+        unbound: 'font-sans text-[12px] text-brand-neutral-500',
+      },
+      first: {
+        true: 'pl-5',
+        false: '',
+      },
+    },
+    defaultVariants: { tone: 'default', first: false },
+  }
+)
+
 export const SignalPreviewTable = ({
   signals,
   boundTo,
   warnings = [],
 }: SignalPreviewTableProps) => {
   if (signals.length === 0 && warnings.length === 0) {
-    return <div style={emptyStyle}>No signals to preview.</div>
+    return (
+      <div className="flex flex-1 items-center justify-center text-[13px] text-brand-neutral-500">
+        No signals to preview.
+      </div>
+    )
   }
 
   return (
-    <div style={wrapperStyle}>
+    <RoutePanel>
       {warnings.length > 0 && (
-        <div style={warningsBlockStyle}>
-          <div style={warningsTitleStyle}>
+        <div className="mx-5 mt-3 border border-brand-accent bg-[color-mix(in_srgb,hsl(var(--brand-accent))_8%,transparent)] px-3 py-2.5">
+          <div className="mb-1.5 text-[10px] font-extrabold tracking-[0.18em] text-brand-accent">
             {warnings.length} parser warning{warnings.length === 1 ? '' : 's'}
           </div>
-          <ul style={warningsListStyle}>
+          <ul className="m-0 flex list-none flex-col gap-1 p-0">
             {warnings.map((w, i) => (
-              <li key={i} style={warningItemStyle}>
+              <li key={i} className="font-mono text-[12px] text-brand-neutral-700">
                 {w}
               </li>
             ))}
           </ul>
         </div>
       )}
-      <div style={tableWrapStyle}>
-        <table style={tableStyle}>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <table className="w-full table-fixed border-separate border-spacing-0">
           <colgroup>
-            <col style={{ width: 160 }} />
-            <col style={{ width: 96 }} />
-            <col style={{ width: 84 }} />
-            <col style={{ width: 84 }} />
-            <col style={{ width: 84 }} />
+            <col className="w-40" />
+            <col className="w-24" />
+            <col className="w-[84px]" />
+            <col className="w-[84px]" />
+            <col className="w-[84px]" />
             <col />
           </colgroup>
           <thead>
             <tr>
-              <th style={thFirstStyle}>SIGNAL</th>
-              <th style={thStyle}>CAN ID</th>
-              <th style={thStyle}>BYTES</th>
-              <th style={thStyle}>SCALE</th>
-              <th style={thStyle}>UNIT</th>
-              <th style={thStyle}>BOUND TO</th>
+              <th className={cn(HEAD_CELL, 'pl-5')}>SIGNAL</th>
+              <th className={HEAD_CELL}>CAN ID</th>
+              <th className={HEAD_CELL}>BYTES</th>
+              <th className={HEAD_CELL}>SCALE</th>
+              <th className={HEAD_CELL}>UNIT</th>
+              <th className={HEAD_CELL}>BOUND TO</th>
             </tr>
           </thead>
           <tbody>
@@ -58,19 +93,23 @@ export const SignalPreviewTable = ({
               const bound = boundTo.get(s.name) ?? null
               return (
                 <tr key={s.name}>
-                  <td style={tdFirstStyle}>{s.name}</td>
-                  <td style={tdIdStyle}>{s.canFrameId}</td>
-                  <td style={tdDimStyle}>{formatBytes(s.startByte, s.byteLength)}</td>
-                  <td style={tdDimStyle}>{formatNumber(s.scale)}</td>
-                  <td style={tdDimStyle}>{s.unit || '—'}</td>
-                  <td style={bound ? tdBoundStyle : tdUnboundStyle}>{bound ?? 'not bound'}</td>
+                  <td className={cn(cell({ first: true }))}>{s.name}</td>
+                  <td className={cn(cell({ tone: 'id' }))}>{s.canFrameId}</td>
+                  <td className={cn(cell({ tone: 'dim' }))}>
+                    {formatBytes(s.startByte, s.byteLength)}
+                  </td>
+                  <td className={cn(cell({ tone: 'dim' }))}>{formatNumber(s.scale)}</td>
+                  <td className={cn(cell({ tone: 'dim' }))}>{s.unit || '—'}</td>
+                  <td className={cn(cell({ tone: bound ? 'bound' : 'unbound' }))}>
+                    {bound ?? 'not bound'}
+                  </td>
                 </tr>
               )
             })}
           </tbody>
         </table>
       </div>
-    </div>
+    </RoutePanel>
   )
 }
 
@@ -80,122 +119,4 @@ const formatBytes = (start: number, length: number): string =>
 const formatNumber = (n: number): string => {
   if (Number.isInteger(n)) return String(n)
   return n.toFixed(3).replace(/\.?0+$/, '')
-}
-
-const wrapperStyle: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  flex: 1,
-  minHeight: 0,
-}
-
-const tableWrapStyle: CSSProperties = {
-  flex: 1,
-  minHeight: 0,
-  overflowY: 'auto',
-}
-
-const tableStyle: CSSProperties = {
-  width: '100%',
-  borderCollapse: 'separate',
-  borderSpacing: 0,
-  tableLayout: 'fixed',
-}
-
-const thStyle: CSSProperties = {
-  position: 'sticky',
-  top: 0,
-  zIndex: 1,
-  background: 'hsl(var(--brand-chrome-bg))',
-  padding: '11px 20px 11px 0',
-  borderBottom: '2px solid var(--brand-divider)',
-  textAlign: 'left',
-  fontWeight: 800,
-  fontSize: 10,
-  letterSpacing: '0.18em',
-  color: 'hsl(var(--brand-neutral-600))',
-}
-
-const thFirstStyle: CSSProperties = {
-  ...thStyle,
-  paddingLeft: 20,
-}
-
-const tdBase: CSSProperties = {
-  padding: '12px 20px 12px 0',
-  borderBottom: '1px solid hsl(var(--brand-neutral-300))',
-  fontFamily: MONO_FONT,
-  fontSize: 13,
-  color: 'hsl(var(--brand-text))',
-  fontVariantNumeric: 'tabular-nums',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-}
-
-const tdFirstStyle: CSSProperties = {
-  ...tdBase,
-  paddingLeft: 20,
-}
-
-const tdIdStyle: CSSProperties = {
-  ...tdBase,
-  color: 'hsl(var(--brand-accent))',
-}
-
-const tdDimStyle: CSSProperties = {
-  ...tdBase,
-  color: 'hsl(var(--brand-neutral-600))',
-}
-
-const tdBoundStyle: CSSProperties = {
-  ...tdBase,
-  fontFamily: 'var(--font-ui)',
-  fontSize: 12,
-}
-
-const tdUnboundStyle: CSSProperties = {
-  ...tdBase,
-  fontFamily: 'var(--font-ui)',
-  fontSize: 12,
-  color: 'hsl(var(--brand-neutral-500))',
-}
-
-const emptyStyle: CSSProperties = {
-  flex: 1,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  color: 'hsl(var(--brand-neutral-500))',
-  fontSize: 13,
-}
-
-const warningsBlockStyle: CSSProperties = {
-  margin: '12px 20px 0',
-  padding: '10px 12px',
-  border: '1px solid hsl(var(--brand-accent))',
-  background: 'color-mix(in srgb, hsl(var(--brand-accent)) 8%, transparent)',
-}
-
-const warningsTitleStyle: CSSProperties = {
-  fontSize: 10,
-  fontWeight: 800,
-  letterSpacing: '0.18em',
-  color: 'hsl(var(--brand-accent))',
-  marginBottom: 6,
-}
-
-const warningsListStyle: CSSProperties = {
-  listStyle: 'none',
-  padding: 0,
-  margin: 0,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 4,
-}
-
-const warningItemStyle: CSSProperties = {
-  fontSize: 12,
-  color: 'hsl(var(--brand-neutral-700))',
-  fontFamily: MONO_FONT,
 }


### PR DESCRIPTION
Fourth per-surface conversion under #75. `SignalPreviewTable` had 17 `CSSProperties` objects; it now has zero and drops out of the baseline (99 → 98).

The file used the "base object spread into five variants" pattern (`tdBase` → `tdFirst` / `tdId` / `tdDim` / `tdBound` / `tdUnbound`), which is what `cva` is for. The variants stay local to this file rather than going into `src/components/ui/` — it is the only table in the codebase so far, so there is no second copy to justify promoting a primitive yet. The wrapper was byte-identical to `RoutePanel`.

## A bug this caught, that lint and tests did not

First attempt rendered the CAN ID column in `brand-text` instead of the accent, and the "bound to" column at 13px instead of 12px. Typecheck, ESLint, Prettier and all 335 tests were green.

The cause: `cva()` returns a plain concatenated string, so base and variant classes both survive — `font-mono text-[13px] text-brand-text` *and* `text-brand-accent` were on the same element, and which one applies is decided by Tailwind's stylesheet emission order, not by the order in the attribute. The base happened to win.

The fix is the same one `Button` already uses and I had skipped: pass the result through `cn()`, so `tailwind-merge` resolves the conflict last-wins and the variant actually overrides. **`cva(...)` output must always go through `cn()`** — a bare `cva()` call, or a template-literal class string with two values from the same utility family, is silently order-dependent.

This is exactly the class of regression the pixel diff exists to catch, and it is invisible to every other gate.

## Visual verification

| State | Diff |
| --- | --- |
| ECU route, initial | **0 px — pixel-identical** |
| ECU route, MaxxECU profile selected (99 rows, all five cell tones) | **0 px — pixel-identical** |

## Harness fix, and a correction to #127

Deep-linking to a route on a cold load does not work: `DisconnectedGuard` runs before `useSimulationBootstrap`'s effect has entered simulation, so it bounces to `/`, which then lands on `/dashboard`. Every capture has to load `/` first, let simulation settle, then client-navigate via `history.pushState`.

That means two captures in #127 were not measuring what they claimed. I used `/board-config` and `/editor`, which are not routes at all — the real paths are `/board` and `/dashboard` — so both "0 px" results were comparing the dashboard against itself. `BoardConfigRoute` was converted in that PR and therefore went unverified.

I have now verified it properly with the corrected harness: **`/board` is 0 px against `main`**. No harm done, but the claim in #127 was not supported by what it actually ran.

## Pre-existing issue, not from this PR

The ECU catalogue logs a React duplicate-key warning (`channel_254`) when the MaxxECU profile loads — that profile has two signals with the same name. It reproduces identically on `main`, so it is out of scope here, but it is worth its own issue: `SignalPreviewTable` keys rows by `s.name`, so duplicates are actually dropped from the render.

## Test plan

- `npm run typecheck`, `lint`, `format:check`, `test` (53 files, 335 tests), `build` — all green
- Baseline at 98, consistency asserted (no stale entries)
- Pixel diff against `main` on both ECU states plus the retro-check of `/board`, as above
