### PR TITLE
refactor(tuner): ecu catalogue list to tailwind

### DIFF
--- a/eslint-inline-style-baseline.mjs
+++ b/eslint-inline-style-baseline.mjs
@@ -11,7 +11,6 @@ export const INLINE_STYLE_BASELINE = [
   'src/components/cli/CliOfflineState.tsx',
   'src/components/cli/CliOutput.tsx',
   'src/components/cli/CommandForm.tsx',
-  'src/components/ecu/EcuCatalogueList.tsx',
   'src/components/ecu/XmlImportZone.tsx',
   'src/components/editor/AlignToolbar.tsx',
   'src/components/editor/Canvas.tsx',

--- a/src/components/ecu/EcuCatalogueList.tsx
+++ b/src/components/ecu/EcuCatalogueList.tsx
@@ -1,9 +1,11 @@
-import type { CSSProperties } from 'react'
 import { useEffect, useMemo, useState } from 'react'
+import { cva } from 'class-variance-authority'
 import { formatBytes } from '../../lib/format'
+import { cn } from '@/lib/utils'
 import { Input } from '../ui/input'
 import { TogglePill } from '../ui/toggle-pill'
-import { MONO_FONT } from '../../lib/typography'
+import { RoutePanel } from '../ui/route-shell'
+import { Eyebrow, MetaText } from '../ui/meta-text'
 import { errorMessage } from '../../lib/error-message'
 
 export interface CatalogueItem {
@@ -92,9 +94,9 @@ export const EcuCatalogueList = ({ activeKey, selectedId, onSelect }: EcuCatalog
   }, [state, query, sortKey])
 
   return (
-    <div style={wrapperStyle}>
-      <div style={panelHeaderStyle}>PROFILES</div>
-      <div style={toolbarStyle}>
+    <RoutePanel className="gap-2">
+      <Eyebrow className="block border-b-2 border-brand-divider px-[18px] py-3">PROFILES</Eyebrow>
+      <div className="flex flex-col gap-2 px-[18px]">
         <Input
           type="search"
           value={query}
@@ -105,7 +107,7 @@ export const EcuCatalogueList = ({ activeKey, selectedId, onSelect }: EcuCatalog
           className="h-9 text-xs"
           disabled={state.kind !== 'ready'}
         />
-        <div style={sortPillsStyle}>
+        <div className="flex gap-1">
           <TogglePill active={sortKey === 'vendor'} onClick={() => setSortKey('vendor')}>
             Vendor
           </TogglePill>
@@ -118,27 +120,35 @@ export const EcuCatalogueList = ({ activeKey, selectedId, onSelect }: EcuCatalog
         </div>
       </div>
 
-      {state.kind === 'loading' && <div style={hintStyle}>Loading catalogue…</div>}
+      {state.kind === 'loading' && (
+        <div className="px-[18px] py-3 text-[12px] text-brand-neutral-500">Loading catalogue…</div>
+      )}
       {state.kind === 'error' && (
-        <div style={errorStyle}>Failed to load catalogue: {state.message}</div>
+        <div className="mx-[18px] border border-brand-accent bg-[color-mix(in_srgb,hsl(var(--brand-accent))_8%,transparent)] p-2.5 text-[12px] text-brand-accent">
+          Failed to load catalogue: {state.message}
+        </div>
       )}
 
       {state.kind === 'ready' && (
         <>
-          <div style={metaStyle}>
+          <div className="px-[18px] text-[10px] uppercase tracking-[0.06em] text-brand-neutral-500">
             {filtered.length} of {state.manifest.entries.length} entr
             {state.manifest.entries.length === 1 ? 'y' : 'ies'} ·{' '}
             <a
               href={state.manifest.source}
               target="_blank"
               rel="noreferrer"
-              style={attributionLinkStyle}
+              className="text-brand-neutral-600 underline"
             >
               upstream
             </a>{' '}
             · {state.manifest.license}
           </div>
-          <div style={listStyle} role="listbox" aria-label="ECU catalogue">
+          <div
+            className="flex min-h-0 flex-1 flex-col overflow-y-auto"
+            role="listbox"
+            aria-label="ECU catalogue"
+          >
             {filtered.map((item) => {
               const isSelected = selectedId === item.id
               const isActive = activeKey === `catalogue:${item.id}`
@@ -151,147 +161,50 @@ export const EcuCatalogueList = ({ activeKey, selectedId, onSelect }: EcuCatalog
                   onClick={() => {
                     void onSelect(item)
                   }}
-                  style={itemStyle(isSelected)}
+                  className={cn(item_({ selected: isSelected }))}
                 >
-                  <div style={titleRowStyle}>
-                    <span style={itemTitleStyle}>{item.label}</span>
-                    {isActive && <span style={activeTagStyle}>active</span>}
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-[13px]">{item.label}</span>
+                    {isActive && (
+                      <span className="border border-brand-accent px-1.5 py-px text-[9px] font-extrabold uppercase tracking-[0.08em] text-brand-accent">
+                        active
+                      </span>
+                    )}
                   </div>
-                  <div style={itemMetaStyle}>
+                  <MetaText
+                    size="sm"
+                    className="flex justify-between font-normal uppercase tracking-[0.04em] text-brand-neutral-500"
+                  >
                     <span>{item.vendor}</span>
-                    <span style={{ color: 'hsl(var(--text-muted))' }}>
-                      {formatBytes(item.sizeBytes)}
-                    </span>
-                  </div>
+                    <span className="text-text-muted">{formatBytes(item.sizeBytes)}</span>
+                  </MetaText>
                 </button>
               )
             })}
             {filtered.length === 0 && (
-              <div style={emptyStyle}>No catalogue entry matches the current search.</div>
+              <div className="px-[18px] py-6 text-center text-[12px] text-brand-neutral-500">
+                No catalogue entry matches the current search.
+              </div>
             )}
           </div>
         </>
       )}
-    </div>
+    </RoutePanel>
   )
 }
 
-const wrapperStyle: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 8,
-  flex: 1,
-  minHeight: 0,
-}
-
-const panelHeaderStyle: CSSProperties = {
-  padding: '12px 18px',
-  borderBottom: '2px solid var(--brand-divider)',
-  fontWeight: 800,
-  fontSize: 10,
-  letterSpacing: '0.2em',
-  color: 'hsl(var(--brand-neutral-600))',
-}
-
-const toolbarStyle: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 8,
-  padding: '0 18px',
-}
-
-const sortPillsStyle: CSSProperties = {
-  display: 'flex',
-  gap: 4,
-}
-
-const metaStyle: CSSProperties = {
-  fontSize: 10,
-  letterSpacing: '0.06em',
-  textTransform: 'uppercase',
-  color: 'hsl(var(--brand-neutral-500))',
-  padding: '0 18px',
-}
-
-const attributionLinkStyle: CSSProperties = {
-  color: 'hsl(var(--brand-neutral-600))',
-  textDecoration: 'underline',
-}
-
-const listStyle: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  overflowY: 'auto',
-  flex: 1,
-  minHeight: 0,
-}
-
-const itemStyle = (selected: boolean): CSSProperties => ({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 2,
-  padding: '11px 18px',
-  background: selected ? 'hsl(var(--brand-neutral-200))' : 'none',
-  border: 'none',
-  borderBottom: '1px solid hsl(var(--brand-neutral-300))',
-  boxShadow: selected ? 'inset 3px 0 0 hsl(var(--brand-accent))' : undefined,
-  textAlign: 'left',
-  cursor: 'pointer',
-  color: selected ? 'hsl(var(--brand-text))' : 'hsl(var(--brand-neutral-700))',
-  fontWeight: selected ? 800 : 400,
-  fontFamily: 'inherit',
-})
-
-const titleRowStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: 8,
-  flexWrap: 'wrap',
-}
-
-const itemTitleStyle: CSSProperties = {
-  fontSize: 13,
-}
-
-const activeTagStyle: CSSProperties = {
-  fontSize: 9,
-  fontWeight: 800,
-  letterSpacing: '0.08em',
-  textTransform: 'uppercase',
-  color: 'hsl(var(--brand-accent))',
-  border: '1px solid hsl(var(--brand-accent))',
-  padding: '1px 6px',
-}
-
-const itemMetaStyle: CSSProperties = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  fontSize: 10,
-  fontWeight: 400,
-  color: 'hsl(var(--brand-neutral-500))',
-  letterSpacing: '0.04em',
-  textTransform: 'uppercase',
-  fontFamily: MONO_FONT,
-}
-
-const hintStyle: CSSProperties = {
-  padding: '12px 18px',
-  fontSize: 12,
-  color: 'hsl(var(--brand-neutral-500))',
-}
-
-const errorStyle: CSSProperties = {
-  margin: '0 18px',
-  padding: '10px',
-  fontSize: 12,
-  color: 'hsl(var(--brand-accent))',
-  border: '1px solid hsl(var(--brand-accent))',
-  background: 'color-mix(in srgb, hsl(var(--brand-accent)) 8%, transparent)',
-}
-
-const emptyStyle: CSSProperties = {
-  padding: '24px 18px',
-  fontSize: 12,
-  color: 'hsl(var(--brand-neutral-500))',
-  textAlign: 'center',
-}
+const item_ = cva(
+  [
+    'flex cursor-pointer flex-col gap-0.5 border-none px-[18px] py-[11px] text-left font-[inherit]',
+    'border-b border-solid border-b-brand-neutral-300',
+  ].join(' '),
+  {
+    variants: {
+      selected: {
+        true: 'bg-brand-neutral-200 font-extrabold text-brand-text shadow-[inset_3px_0_0_hsl(var(--brand-accent))]',
+        false: 'bg-transparent font-normal text-brand-neutral-700',
+      },
+    },
+    defaultVariants: { selected: false },
+  }
+)


### PR DESCRIPTION
Fifth per-surface conversion under #75, and it finishes the `/ecu` route — `EcuRoute` (#127), `SignalPreviewTable` (#132) and now `EcuCatalogueList` are all inline-style free. 16 `CSSProperties` objects gone; baseline 98 → 97.

## Shape

Mostly primitive reuse again: the wrapper is `RoutePanel` (with a `gap-2` override), the panel header is `Eyebrow`, and the per-item vendor/size line is `MetaText`. The only new local abstraction is a `cva` for the list item, which had a genuine two-way conditional across six properties — background, text colour, font weight, and the `inset 3px` accent shadow that marks the selection.

`cva` output goes through `cn()`, per the lesson from #132.

That inset shadow is worth noting for the editor-surface PR: it is a third rendering of the "3px accent rail" idea, alongside the absolutely-positioned `ActiveBar` divs in `SidebarView`, `page-cell` and `WidgetListPanel`. Whoever extracts `ActiveBar` should decide whether this one folds in — it is the same visual language via a different mechanism, and `box-shadow` avoids the positioned child.

All font sizes are arbitrary values (`text-[13px]`, `text-[10px]`, `text-[9px]`), so they inherit the `body` line-height ratio and the trap from #128 does not apply here.

## Visual verification

Eight states, element-level shots of the listbox plus full-viewport where relevant:

| State | Diff |
| --- | --- |
| list, initial | **0 px** |
| route, initial | **0 px** |
| item selected (accent inset rail, bold, tinted background) | **0 px** |
| route with selection, full viewport | **0 px** |
| filtered by search ("maxx") | **0 px** |
| no match ("zzzznope") — empty state | **0 px** |
| re-sorted by Size (pill toggle) | **0 px** |
| profile applied — `active` tag rendered | **0 px** |

All eight pixel-identical, no console errors. The `active` tag needed the profile to actually be applied through the confirm dialog, so that path is exercised too.

## Not verified by screenshot

The loading and fetch-error states of the catalogue — both are single divs, and reaching the error state means failing the `/ecu-catalogue/index.json` request, which is not worth stubbing for two class translations.

## Test plan

- `npm run typecheck`, `lint`, `format:check`, `test` (53 files, 335 tests), `build` — all green
- Baseline at 97, consistency asserted (no stale entries)
- Pixel diff against `main` on eight states, as above
