### PR TITLE
refactor(tuner): sidebar to tailwind, extract ActiveBar

### DIFF
--- a/eslint-inline-style-baseline.mjs
+++ b/eslint-inline-style-baseline.mjs
@@ -77,8 +77,6 @@ export const INLINE_STYLE_BASELINE = [
   'src/components/shell/FirmwareSlot.tsx',
   'src/components/shell/Header.tsx',
   'src/components/shell/HeaderView.tsx',
-  'src/components/shell/Sidebar.tsx',
-  'src/components/shell/SidebarView.tsx',
   'src/components/shell/ThemeToggleButton.tsx',
   'src/components/themes/ThemeCard.tsx',
   'src/components/themes/ThemeControls.tsx',

--- a/src/components/shell/Sidebar.tsx
+++ b/src/components/shell/Sidebar.tsx
@@ -7,8 +7,8 @@ import { useDashboardStore } from '../../stores/dashboard.store'
 import { useDeviceStore } from '../../stores/device.store'
 import { useUiStore } from '../../stores/ui.store'
 
-const RouterLink = ({ to, style, className, children, title }: SidebarLinkProps) => (
-  <NavLink to={to} end={to === '/'} style={style} className={className ?? ''} title={title}>
+const RouterLink = ({ to, className, children, title }: SidebarLinkProps) => (
+  <NavLink to={to} end={to === '/'} className={className} title={title}>
     {children}
   </NavLink>
 )

--- a/src/components/shell/SidebarView.tsx
+++ b/src/components/shell/SidebarView.tsx
@@ -1,5 +1,8 @@
-import type { ComponentType, CSSProperties, ReactNode } from 'react'
-import { MONO_FONT } from '../../lib/typography'
+import type { ComponentType, ReactNode } from 'react'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+import { ActiveBar } from '../ui/active-bar'
+import { MetaText } from '../ui/meta-text'
 import { CollapseButton } from './CollapseRail'
 
 export type SidebarRoute =
@@ -62,12 +65,9 @@ export const SIDEBAR_GROUPS: readonly NavGroup[] = [
   },
 ]
 
-const SIDEBAR_WIDTH = 236
-
 export interface SidebarLinkProps {
   to: string
-  style: CSSProperties
-  className?: string | undefined
+  className: string
   children: ReactNode
   title?: string
 }
@@ -81,14 +81,8 @@ export interface SidebarViewProps {
   onCollapse?: () => void
 }
 
-const DefaultLink: ComponentType<SidebarLinkProps> = ({
-  to,
-  style,
-  className,
-  children,
-  title,
-}) => (
-  <a href={to} style={style} className={className} title={title}>
+const DefaultLink: ComponentType<SidebarLinkProps> = ({ to, className, children, title }) => (
+  <a href={to} className={className} title={title}>
     {children}
   </a>
 )
@@ -101,17 +95,20 @@ export const SidebarView = ({
   LinkComponent = DefaultLink,
   onCollapse,
 }: SidebarViewProps) => (
-  <nav aria-label="Primary" style={navStyle}>
+  <nav
+    aria-label="Primary"
+    className="flex w-[236px] shrink-0 flex-col border-r-2 border-brand-divider bg-brand-neutral-100"
+  >
     {onCollapse && (
-      <div style={collapseHeaderStyle}>
+      <div className="flex justify-end px-2 pt-2">
         <CollapseButton side="left" label="Menu" onCollapse={onCollapse} />
       </div>
     )}
-    <div style={scrollAreaStyle}>
+    <div className="flex-1 overflow-y-auto py-4">
       {SIDEBAR_GROUPS.map((group, groupIdx) => (
         <div key={group.label ?? 'top'}>
           {group.label !== null && (
-            <div style={groupIdx === 1 ? firstGroupLabelStyle : groupLabelStyle}>{group.label}</div>
+            <div className={cn(GROUP_LABEL, groupIdx === 1 && 'pt-[14px]')}>{group.label}</div>
           )}
           {group.items.map((item) => (
             <SidebarItem
@@ -125,17 +122,17 @@ export const SidebarView = ({
         </div>
       ))}
     </div>
-    <div style={footerStyle}>
-      <div style={footerRowStyle}>
+    <div className="flex flex-col gap-2.5 border-t-2 border-brand-divider px-[18px] py-3.5">
+      <MetaText className="flex justify-between">
         <span>TARGET</span>
-        <span style={footerValueStyle}>{targetLabel ?? '—'}</span>
-      </div>
-      <div style={footerRowStyle}>
+        <span className="text-brand-text">{targetLabel ?? '—'}</span>
+      </MetaText>
+      <MetaText className="flex justify-between">
         <span>FIRMWARE</span>
-        <span style={footerValueStyle}>
+        <span className="text-brand-text">
           {firmwareVersion !== null ? `v${firmwareVersion}` : '—'}
         </span>
-      </div>
+      </MetaText>
     </div>
   </nav>
 )
@@ -156,7 +153,7 @@ const SidebarItem = ({ item, active, disabled, LinkComponent }: SidebarItemProps
         aria-disabled="true"
         aria-label={`${item.label} — connect a device to access this section`}
         title="Connect a device to access this section"
-        style={disabledItemStyle}
+        className={cn(navItem({ state: 'disabled' }))}
       >
         {item.label}
       </div>
@@ -165,98 +162,27 @@ const SidebarItem = ({ item, active, disabled, LinkComponent }: SidebarItemProps
   return (
     <LinkComponent
       to={item.to}
-      style={active ? activeItemStyle : itemStyle}
-      className={active ? undefined : 'shell-nav-item'}
+      className={cn(navItem({ state: active ? 'active' : 'default' }), !active && 'shell-nav-item')}
     >
-      {active && <span aria-hidden="true" style={activeBarStyle} />}
+      {active && <ActiveBar />}
       {item.label}
     </LinkComponent>
   )
 }
 
-const navStyle: CSSProperties = {
-  width: SIDEBAR_WIDTH,
-  flexShrink: 0,
-  background: 'hsl(var(--brand-neutral-100))',
-  borderRight: '2px solid var(--brand-divider)',
-  display: 'flex',
-  flexDirection: 'column',
-}
+const GROUP_LABEL =
+  'px-[18px] pb-2 pt-[22px] text-[9px] font-extrabold tracking-[0.22em] text-brand-neutral-600'
 
-const collapseHeaderStyle: CSSProperties = {
-  display: 'flex',
-  justifyContent: 'flex-end',
-  padding: '8px 8px 0',
-}
-
-const scrollAreaStyle: CSSProperties = {
-  flex: 1,
-  overflowY: 'auto',
-  padding: '16px 0',
-}
-
-const groupLabelStyle: CSSProperties = {
-  padding: '22px 18px 8px',
-  fontWeight: 800,
-  fontSize: 9,
-  letterSpacing: '0.22em',
-  color: 'hsl(var(--brand-neutral-600))',
-}
-
-const firstGroupLabelStyle: CSSProperties = {
-  ...groupLabelStyle,
-  paddingTop: 14,
-}
-
-const itemStyle: CSSProperties = {
-  position: 'relative',
-  width: '100%',
-  display: 'flex',
-  alignItems: 'center',
-  padding: '9px 18px 9px 21px',
-  fontSize: 13,
-  textDecoration: 'none',
-  color: 'hsl(var(--brand-neutral-700))',
-}
-
-const activeItemStyle: CSSProperties = {
-  ...itemStyle,
-  background: 'hsl(var(--brand-neutral-200))',
-  color: 'hsl(var(--brand-text))',
-  fontWeight: 800,
-}
-
-const disabledItemStyle: CSSProperties = {
-  ...itemStyle,
-  color: 'hsl(var(--brand-neutral-500))',
-  cursor: 'not-allowed',
-}
-
-const activeBarStyle: CSSProperties = {
-  position: 'absolute',
-  left: 0,
-  top: 0,
-  bottom: 0,
-  width: 3,
-  background: 'hsl(var(--brand-accent))',
-}
-
-const footerStyle: CSSProperties = {
-  borderTop: '2px solid var(--brand-divider)',
-  padding: '14px 18px',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 10,
-}
-
-const footerRowStyle: CSSProperties = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  fontFamily: MONO_FONT,
-  fontSize: 11,
-  color: 'hsl(var(--brand-neutral-600))',
-}
-
-const footerValueStyle: CSSProperties = {
-  color: 'hsl(var(--brand-text))',
-}
+const navItem = cva(
+  'relative flex w-full items-center py-[9px] pl-[21px] pr-[18px] text-[13px] no-underline',
+  {
+    variants: {
+      state: {
+        default: 'text-brand-neutral-700',
+        active: 'bg-brand-neutral-200 font-extrabold text-brand-text',
+        disabled: 'cursor-not-allowed text-brand-neutral-500',
+      },
+    },
+    defaultVariants: { state: 'default' },
+  }
+)

--- a/src/components/ui/active-bar.tsx
+++ b/src/components/ui/active-bar.tsx
@@ -1,0 +1,12 @@
+import { cn } from '@/lib/utils'
+
+export interface ActiveBarProps {
+  className?: string | undefined
+}
+
+export const ActiveBar = ({ className }: ActiveBarProps) => (
+  <span
+    aria-hidden="true"
+    className={cn('absolute bottom-0 left-0 top-0 w-[3px] bg-brand-accent', className)}
+  />
+)


### PR DESCRIPTION
Eighth per-surface conversion under #75. `SidebarView` had 14 `CSSProperties` objects; zero now, and `Sidebar` drops out too. Baseline 95 → 93.

## A prop contract changed

`SidebarLinkProps` required a `style: CSSProperties` — the sidebar handed a style object to whatever link component it was given. With the styles gone that prop is meaningless, so the contract is now `className: string` (required, no longer optional alongside `style`).

One consumer, `Sidebar.tsx`, which only forwarded both to `NavLink`. It forwards `className` alone now, and `className={className ?? ''}` loses its fallback since the prop is no longer optional.

## ActiveBar extracted

The 3px accent rail was flagged in #127 and #134 as three identical copies. It now lives in `src/components/ui/active-bar.tsx` and this PR is its first consumer. The other two — `page-cell` and `WidgetListPanel` — stay on their local copies until the editor-surface PR, which should just swap the import.

Still open for that PR: `EcuCatalogueList` renders the same visual as `box-shadow: inset 3px` rather than a positioned child (#134). Worth deciding whether `ActiveBar` grows a shadow variant or the two mechanisms stay separate — the shadow avoids the extra element, so it is not obviously the one to drop.

## Three-state item

`itemStyle` / `activeItemStyle` / `disabledItemStyle` were a base object spread twice. They are mutually exclusive, so this is a single `state: 'default' | 'active' | 'disabled'` variant rather than two booleans — the repo rule about a union that lost its type applies.

`SIDEBAR_WIDTH = 236` is deleted: it had exactly one reader, the style object, and is now `w-[236px]` at its only use. An exported-looking constant nothing reads is a bug per `CLAUDE.md`.

The footer rows were an exact `MetaText` match.

## Visual verification

| State | Diff |
| --- | --- |
| sidebar in simulation, `/` active | **0 px** |
| after navigating to `/logs` (active item + accent rail moves) | **0 px** |
| offline — 11 disabled items, only Welcome live | **0 px** |

All pixel-identical, no console errors. The offline state was reached by setting `simulationMode: false` with `simulationDismissed: true` on the device store from the page, which stops `useSimulationBootstrap` re-entering simulation.

## Test plan

- `npm run typecheck`, `lint`, `format:check`, `test` (53 files, 335 tests), `build` — all green
- Baseline at 93, consistency asserted
- Pixel diff against `main` on three states, as above
