### PR TITLE
fix(tuner): restore the dash value tiers from the design spec

### DIFF
--- a/docs/design/DASH_DESIGN_SYSTEM.md
+++ b/docs/design/DASH_DESIGN_SYSTEM.md
@@ -1,0 +1,213 @@
+# CANShift dash — design system
+
+The binding specification for the firmware UI (LVGL, CrowPanel 2.8″, 320 × 240, landscape).
+Visual references: `CANShift Dash Pages.dc.html` (the six pages rendered at 2×) and `DASH_PAGES.json`
+(the same six pages as data). Where the firmware and this document disagree, the firmware is wrong.
+
+Read the whole document before writing code. Then: audit, list deviations, fix in the order at the end.
+
+---
+
+## 0. The two rules everything else follows from
+
+1. **A widget is a rule, a kicker and a value.** Not a card. There is no box, no fill, no border and no
+   background behind a value anywhere on the dash. The horizontal rule above the widget is what separates
+   it from its neighbour. The single exception is the button widget (§6), which is a 2 px outlined box.
+2. **Nothing is centred, nothing is rounded, nothing eases.** Everything is flush left against its
+   column. Radius is 0. The only motion is the six behaviours listed in §9.
+
+If you are about to draw a rounded rectangle with a grey fill behind a number, stop — that is the drift
+this document exists to correct.
+
+## 1. Scale
+
+The design references are authored at **2×**: a 640 × 480 box standing for the 320 × 240 panel.
+
+- **Implement the device column.** Halve any measurement taken off a reference screenshot.
+- Type is the exception: fonts are generated at the device sizes in §3, and no label goes below 10 px
+  real. Where halving would give less than 10, use 10.
+
+## 2. Colour
+
+Two themes. Danger and engaged are the same in both — they are safety colours, not theme colours.
+
+| Role                                               | Token        | NIGHT (default) | DAY       |
+| -------------------------------------------------- | ------------ | --------------- | --------- |
+| Ground                                             | `CS_BG`      | `#121212`       | `#DDDDDD` |
+| Ink — values, primary rules, button outlines       | `CS_INK`     | `#FFFFFF`       | `#000000` |
+| Dim — kickers, units, status row                   | `CS_DIM`     | `#BABAB8`       | `#5A5A5A` |
+| Track — bar grounds, unlit shift cells, 1 px rules | `CS_TRACK`   | `#222222`       | `#C4C4C4` |
+| Danger                                             | `CS_DANGER`  | `#FF4444`       | `#FF4444` |
+| Engaged                                            | `CS_ENGAGED` | `#FF4747`       | `#FF4747` |
+
+Six colours. There is no seventh. No gradient, no shadow, no tint, no opacity below 100 % except the
+75 % white used for a kicker on an engaged button and the pulse in §9.
+
+**Danger vs engaged.** `#FF4444` means _this reading is out of range_ — it colours the widget's rule,
+kicker and value. `#FF4747` means _this function is on_ — it fills a button. They are never swapped and
+never mixed on the same widget.
+
+## 3. Type
+
+Two LVGL bitmap fonts, generated with `lv_font_conv`. Generate exactly the sizes used — no scaling at
+runtime.
+
+- **Archivo 800** — kickers and button state words only.
+- **JetBrains Mono** — every value, every unit, the status row. **Tabular numerals are mandatory**: a
+  value must not change width as its digits change.
+
+| Class       | Device | Canvas (2×) | Tracking | Line-height | Used for                                          |
+| ----------- | ------ | ----------- | -------- | ----------- | ------------------------------------------------- |
+| `hero`      | 48     | 96          | -0.045em | 0.92        | Street speed/gear, Timing lap/delta               |
+| `heroTrack` | 44     | 88          | -0.045em | 0.92        | Track rpm/gear, Tuning boost, Controls launch rpm |
+| `primary`   | 32     | 64          | -0.045em | 0.92        | the main readings of Engine, Tuning, Track        |
+| `mid`       | 22     | 44          | -0.03em  | 0.92        | Street rpm, Timing best/last/laps                 |
+| `secondary` | 17     | 34          | -0.03em  | 0.92        | every small reading                               |
+| `button`    | 14     | 28          | 0        | 1           | button state word                                 |
+| `kicker`    | 10     | 10          | 0.18em   | —           | every widget label, UPPERCASE, in Dim             |
+| `unit`      | 10     | 16          | —        | —           | in Dim, inline after the value                    |
+| `statusRow` | 10     | 12          | 0.1em    | —           | the three status fields, in Dim                   |
+
+Units are lowercase as the car states them (`km/h`, `rpm`, `bar`, `°C`, `%`, `V`, `km`, `λ`, `s`), set in
+Dim, on the same baseline, one space after the value. Kickers are uppercase. No unit on a gear, a lap
+time, a knock count or a button.
+
+## 4. Frame and grid
+
+|                               | Device    | Canvas    |
+| ----------------------------- | --------- | --------- |
+| Panel                         | 320 × 240 | 640 × 480 |
+| Outer padding, all four sides | 8         | 16        |
+| Column count                  | 12        | 12        |
+| Column gap                    | 6         | 12        |
+| Row gap                       | 6         | 12        |
+| Snap step used by the Tuner   | 8         | 8         |
+
+Content stacks: shift light (only where the page declares one) → status row → widget grid. The grid is
+`align-content: start` — widgets keep their natural height and the page ends where the content ends. The
+empty ground at the bottom of a short page is correct; do not stretch widgets to fill it.
+
+Spans are out of 12 and are given per page in `DASH_PAGES.json`. Reproduce them exactly — they are what
+the Tuner writes into the config.
+
+## 5. Value widget
+
+```
+┌──────────────────────────  rule: 2px INK (primary) | 1px TRACK (secondary) | 2px DANGER
+  KICKER                     Archivo 800, 10px, 0.18em, UPPERCASE, DIM
+  184203 km                  Mono, class size, INK; unit 10px DIM
+  ▓▓▓▓▓▓░░░░░░░░             optional bar, only when the signal is a percentage of a range
+```
+
+Device metrics:
+
+|                      | Primary (`hero`/`heroTrack`/`primary`) | Secondary (`mid`/`secondary`) |
+| -------------------- | -------------------------------------- | ----------------------------- |
+| Rule                 | 2 px `CS_INK`                          | 1 px `CS_TRACK`               |
+| Padding top / bottom | 4 / 3                                  | 3 / 2                         |
+| Padding right        | 8                                      | 8                             |
+| Padding left         | **0**                                  | **0**                         |
+| Kicker → value gap   | 2                                      | 1                             |
+
+- **Left padding is zero.** The kicker and the value sit flush on the column edge; only the right side is
+  inset so two widgets do not touch.
+- **Danger variant**: rule, kicker and value all in `CS_DANGER`; the unit stays Dim. Nothing else changes
+  — no fill, no icon, no box, no blink.
+- **Bar gauge** (only where `DASH_PAGES.json` gives a `bar`): 2 px tall device, ground `CS_TRACK`, fill
+  `CS_INK` (or `CS_DANGER` in a danger widget), 4 px above it, right margin matching the widget, square
+  ends, no border, no label.
+
+## 6. Button widget
+
+The only boxed widget. Used on Controls and for the Timing timer.
+
+|            | Device                                                              |
+| ---------- | ------------------------------------------------------------------- |
+| Border     | 2 px                                                                |
+| Min height | 48                                                                  |
+| Padding    | 6 vertical / 7 horizontal                                           |
+| Content    | kicker above, state word below, both flush left, vertically centred |
+
+- **Idle**: border `CS_INK`, ground = the page ground, kicker Dim, state word Ink.
+- **Engaged**: border **and** ground `CS_ENGAGED`, kicker white at 75 %, state word white.
+- Real touch target never below 48 × 50 px device — widen the span rather than shrink the box.
+- No unit, no icon, no state dot.
+
+## 7. Shift light
+
+Only on a page that declares it (Track). One row across the full content width:
+
+- 12 equal cells, height 7 px device, gaps 2 px device, square, no border.
+- Cells 1–7 `CS_INK`, cells 8–9 `CS_DANGER`, cells 10–12 `CS_TRACK` when unlit.
+- Fills left to right with rpm. At the limiter the whole row blinks (§9).
+
+## 8. Status row
+
+One line, mono, Dim, 0.1em tracking, exactly three fields — left, centre, right:
+
+| Page     | Left         | Centre   | Right             |
+| -------- | ------------ | -------- | ----------------- |
+| Street   | `CAN 842 Hz` | `MAP 1`  | `TRIP 128 km`     |
+| Track    | `CAN 842 Hz` | `MAP 1`  | `LAP 4 — 1:38.42` |
+| Engine   | `CAN 842 Hz` | `MAP 1`  | `MAX OIL 128`     |
+| Tuning   | `CAN 842 Hz` | `MAP 2`  | `PEAK 1.61`       |
+| Timing   | `CAN 842 Hz` | `LAP 4`  | `BEST 1:36.08`    |
+| Controls | `CAN 842 Hz` | `ALS ON` | `ARMED`           |
+
+Never a fourth field, never an icon, never a coloured status. The left field is always the bus rate.
+
+## 9. Motion — the complete list
+
+Nothing else on the dash moves.
+
+| Behaviour                           | Rule                                            |
+| ----------------------------------- | ----------------------------------------------- |
+| Value update                        | **snap**. Never tween a numeral.                |
+| Bar gauge / arc                     | catch up in 120 ms **linear**                   |
+| Rev limit                           | hard on/off blink at 6 Hz, no easing            |
+| Engaged / armed state               | 1 s ease-in-out pulse, 100 % → 35 % opacity     |
+| Stale signal (500 ms with no frame) | value drops to Dim and renders `- -`, unit kept |
+| Page change                         | instant cut — no slide, no fade                 |
+
+`- -` means **the sensor went quiet**. It is not the "no device" state, not a placeholder, and must never
+appear in a preview or a demo.
+
+## 10. The critical alert
+
+Preempts every page. Full `CS_DANGER` ground, pulsing per §9; signal name in Archivo 800 tracked wide;
+value in huge mono; `STOP THE ENGINE` pinned at the bottom. No status row, no page nav. Holds until
+acknowledged on the dash or from the phone.
+
+## 11. Overflow
+
+The dash never auto-scales, wraps, ellipsises or clips a widget to make it fit. A layout that does not
+fit 320 × 240 is **rejected at config load**, and the Tuner flags it before writing. Assert this on
+`PUT_CONFIG` and fail loudly.
+
+## 12. Checklist before you open a PR
+
+- [ ] No fill, box, border or background behind any value widget.
+- [ ] Left padding on every widget is 0; nothing is centred.
+- [ ] Rules: 2 px ink on primaries, 1 px track on secondaries, 2 px danger on danger widgets.
+- [ ] Kickers uppercase Archivo 800 at 10 px in Dim; values mono with tabular numerals.
+- [ ] Units lowercase, in Dim, inline after the value; none on gear, lap, knock or a button.
+- [ ] Spans match `DASH_PAGES.json` on all six pages.
+- [ ] Status row has exactly three fields, bus rate on the left.
+- [ ] Shift light: 7 ink + 2 danger + 3 track, 12 cells.
+- [ ] Engaged buttons filled `#FF4747`; danger readings `#FF4444`; the two never swapped.
+- [ ] No animation outside §9; page change is a cut.
+- [ ] Radius 0, no shadow, no gradient, no seventh colour.
+
+## 13. Order of work
+
+1. Regenerate the two LVGL fonts at the §3 device sizes.
+2. Theme tokens (§2), both themes.
+3. The widget grammar (§5) — this is where the drift is; strip any card/box/fill first.
+4. Grid and spans per page from `DASH_PAGES.json` (§4).
+5. Shift light and status row (§7, §8).
+6. Buttons (§6).
+7. Motion (§9), then the alert (§10) and the overflow assert (§11).
+
+Follow the firmware's own ownership rules (`2.3 LVGL ownership`, `2.4 Page lifecycle`): widgets are
+rebuilt on page change, never mutated across pages; no `lv_obj_clean` outside page teardown. If a memory
+or font-budget constraint forces a deviation, keep the grammar and document what changed and why.

--- a/docs/design/DASH_PAGES.json
+++ b/docs/design/DASH_PAGES.json
@@ -1,0 +1,217 @@
+{
+  "note": "CANShift dash — the six default pages, as data. Every geometry number here is in DEVICE pixels (320 x 240). The design references render at 2x; multiply by 2 to compare with a screenshot of CANShift Dash Pages.dc.html.",
+  "panel": {
+    "width": 320,
+    "height": 240,
+    "padding": 8,
+    "gridColumns": 12,
+    "gridGap": 6,
+    "rowGap": 6,
+    "snap": 8
+  },
+  "valueClasses": {
+    "hero": {
+      "device": 48,
+      "canvas": 96,
+      "tracking": -0.045,
+      "lineHeight": 0.92,
+      "rule": "2px ink"
+    },
+    "heroTrack": {
+      "device": 44,
+      "canvas": 88,
+      "tracking": -0.045,
+      "lineHeight": 0.92,
+      "rule": "2px ink"
+    },
+    "primary": {
+      "device": 32,
+      "canvas": 64,
+      "tracking": -0.045,
+      "lineHeight": 0.92,
+      "rule": "2px ink"
+    },
+    "mid": {
+      "device": 22,
+      "canvas": 44,
+      "tracking": -0.03,
+      "lineHeight": 0.92,
+      "rule": "1px track"
+    },
+    "secondary": {
+      "device": 17,
+      "canvas": 34,
+      "tracking": -0.03,
+      "lineHeight": 0.92,
+      "rule": "1px track"
+    },
+    "button": { "device": 14, "canvas": 28, "tracking": 0, "lineHeight": 1, "rule": "2px box" },
+    "kicker": { "device": 10, "canvas": 10, "tracking": 0.18, "case": "upper" },
+    "unit": { "device": 10, "canvas": 16 },
+    "statusRow": { "device": 10, "canvas": 12, "tracking": 0.1 }
+  },
+  "pages": [
+    {
+      "id": "street",
+      "num": "01",
+      "name": "Street",
+      "shiftLight": false,
+      "status": ["CAN 842 Hz", "MAP 1", "TRIP 128 km"],
+      "widgets": [
+        { "kicker": "SPEED", "span": 7, "class": "hero", "value": "82", "unit": "km/h" },
+        { "kicker": "GEAR", "span": 5, "class": "hero", "value": "4" },
+        { "kicker": "RPM", "span": 6, "class": "mid", "value": "2400", "unit": "rpm", "bar": 0.29 },
+        { "kicker": "WATER", "span": 3, "class": "secondary", "value": "88", "unit": "\u00b0C" },
+        {
+          "kicker": "FUEL",
+          "span": 3,
+          "class": "secondary",
+          "value": "46",
+          "unit": "%",
+          "bar": 0.46
+        },
+        { "kicker": "BATT", "span": 4, "class": "secondary", "value": "13.8", "unit": "V" },
+        { "kicker": "ODO", "span": 8, "class": "secondary", "value": "184203", "unit": "km" }
+      ]
+    },
+    {
+      "id": "track",
+      "num": "02",
+      "name": "Track",
+      "shiftLight": true,
+      "shiftLightLit": 9,
+      "status": ["CAN 842 Hz", "MAP 1", "LAP 4 \u2014 1:38.42"],
+      "widgets": [
+        { "kicker": "RPM", "span": 7, "class": "heroTrack", "value": "5200", "unit": "rpm" },
+        { "kicker": "GEAR", "span": 5, "class": "heroTrack", "value": "3" },
+        { "kicker": "SPEED", "span": 6, "class": "primary", "value": "195", "unit": "km/h" },
+        {
+          "kicker": "OIL PRESS",
+          "span": 6,
+          "class": "primary",
+          "value": "1.1",
+          "unit": "bar",
+          "danger": true
+        },
+        { "kicker": "WATER", "span": 3, "class": "secondary", "value": "78", "unit": "\u00b0C" },
+        { "kicker": "OIL T", "span": 3, "class": "secondary", "value": "112", "unit": "\u00b0C" },
+        { "kicker": "BOOST", "span": 3, "class": "secondary", "value": "1.42", "unit": "bar" },
+        { "kicker": "BATT", "span": 3, "class": "secondary", "value": "13.3", "unit": "V" }
+      ]
+    },
+    {
+      "id": "engine",
+      "num": "03",
+      "name": "Engine",
+      "shiftLight": false,
+      "status": ["CAN 842 Hz", "MAP 1", "MAX OIL 128"],
+      "widgets": [
+        {
+          "kicker": "WATER",
+          "span": 6,
+          "class": "primary",
+          "value": "98",
+          "unit": "\u00b0C",
+          "bar": 0.7
+        },
+        {
+          "kicker": "OIL TEMP",
+          "span": 6,
+          "class": "primary",
+          "value": "112",
+          "unit": "\u00b0C",
+          "bar": 0.78
+        },
+        {
+          "kicker": "OIL PRESS",
+          "span": 6,
+          "class": "primary",
+          "value": "1.1",
+          "unit": "bar",
+          "danger": true,
+          "bar": 0.22
+        },
+        {
+          "kicker": "FUEL PRESS",
+          "span": 6,
+          "class": "primary",
+          "value": "3.8",
+          "unit": "bar",
+          "bar": 0.63
+        },
+        { "kicker": "GEARBOX", "span": 4, "class": "secondary", "value": "96", "unit": "\u00b0C" },
+        { "kicker": "DIFF", "span": 4, "class": "secondary", "value": "104", "unit": "\u00b0C" },
+        { "kicker": "BATT", "span": 4, "class": "secondary", "value": "13.3", "unit": "V" }
+      ]
+    },
+    {
+      "id": "tuning",
+      "num": "04",
+      "name": "Tuning",
+      "shiftLight": false,
+      "status": ["CAN 842 Hz", "MAP 2", "PEAK 1.61"],
+      "widgets": [
+        {
+          "kicker": "BOOST",
+          "span": 7,
+          "class": "heroTrack",
+          "value": "1.42",
+          "unit": "bar",
+          "bar": 0.68
+        },
+        { "kicker": "TARGET", "span": 5, "class": "primary", "value": "1.50", "unit": "bar" },
+        {
+          "kicker": "LAMBDA",
+          "span": 6,
+          "class": "primary",
+          "value": "0.88",
+          "unit": "\u03bb",
+          "danger": true
+        },
+        {
+          "kicker": "THROTTLE",
+          "span": 6,
+          "class": "primary",
+          "value": "92",
+          "unit": "%",
+          "bar": 0.92
+        },
+        { "kicker": "IAT", "span": 4, "class": "secondary", "value": "34", "unit": "\u00b0C" },
+        { "kicker": "EGT", "span": 4, "class": "secondary", "value": "912", "unit": "\u00b0C" },
+        { "kicker": "KNOCK", "span": 4, "class": "secondary", "value": "0" }
+      ]
+    },
+    {
+      "id": "timing",
+      "num": "05",
+      "name": "Timing",
+      "shiftLight": false,
+      "status": ["CAN 842 Hz", "LAP 4", "BEST 1:36.08"],
+      "widgets": [
+        { "kicker": "LAP", "span": 7, "class": "hero", "value": "1:38.42" },
+        { "kicker": "DELTA", "span": 5, "class": "hero", "value": "\u22120.42", "unit": "s" },
+        { "kicker": "BEST", "span": 6, "class": "mid", "value": "1:36.08" },
+        { "kicker": "LAST", "span": 4, "class": "mid", "value": "1:37.19" },
+        { "kicker": "LAPS", "span": 2, "class": "mid", "value": "4" },
+        { "kicker": "TIMER", "span": 6, "class": "button", "value": "RUNNING", "engaged": true },
+        { "kicker": "RESET LAP", "span": 6, "class": "button", "value": "RESET" }
+      ]
+    },
+    {
+      "id": "controls",
+      "num": "06",
+      "name": "Controls",
+      "shiftLight": false,
+      "status": ["CAN 842 Hz", "ALS ON", "ARMED"],
+      "widgets": [
+        { "kicker": "LAUNCH RPM", "span": 7, "class": "heroTrack", "value": "4200", "unit": "rpm" },
+        { "kicker": "CLUTCH", "span": 5, "class": "primary", "value": "IN" },
+        { "kicker": "LAUNCH", "span": 6, "class": "button", "value": "ARMED", "engaged": true },
+        { "kicker": "ANTI-LAG", "span": 6, "class": "button", "value": "ON", "engaged": true },
+        { "kicker": "ECU MAP", "span": 4, "class": "button", "value": "MAP 1" },
+        { "kicker": "PIT LIMIT", "span": 4, "class": "button", "value": "OFF" },
+        { "kicker": "CRUISE", "span": 4, "class": "button", "value": "110" }
+      ]
+    }
+  ]
+}

--- a/src/config/default-sim-config.json
+++ b/src/config/default-sim-config.json
@@ -70,7 +70,8 @@
             "maxValue": 300,
             "dangerLevel": 280,
             "decimalPlaces": 0,
-            "iconName": "speed"
+            "iconName": "speed",
+            "big": 96
           }
         },
         {
@@ -94,7 +95,8 @@
           },
           "config": {
             "type": "gear",
-            "decimalPlaces": 0
+            "decimalPlaces": 0,
+            "big": 96
           }
         },
         {
@@ -123,7 +125,8 @@
             "maxValue": 8000,
             "dangerLevel": 7000,
             "decimalPlaces": 0,
-            "iconName": "rpm"
+            "iconName": "rpm",
+            "big": 44
           }
         },
         {
@@ -152,7 +155,8 @@
             "maxValue": 120,
             "dangerLevel": 110,
             "decimalPlaces": 0,
-            "iconName": "coolant"
+            "iconName": "coolant",
+            "big": 34
           }
         },
         {
@@ -181,7 +185,8 @@
             "maxValue": 6,
             "dangerLevel": 5.5,
             "decimalPlaces": 1,
-            "iconName": "fuel"
+            "iconName": "fuel",
+            "big": 34
           }
         },
         {
@@ -210,7 +215,8 @@
             "maxValue": 15,
             "dangerLevel": 14.8,
             "decimalPlaces": 1,
-            "iconName": "battery"
+            "iconName": "battery",
+            "big": 34
           }
         },
         {
@@ -305,7 +311,8 @@
             "maxValue": 8000,
             "dangerLevel": 7000,
             "decimalPlaces": 0,
-            "iconName": "rpm"
+            "iconName": "rpm",
+            "big": 88
           }
         },
         {
@@ -329,7 +336,8 @@
           },
           "config": {
             "type": "gear",
-            "decimalPlaces": 0
+            "decimalPlaces": 0,
+            "big": 88
           }
         },
         {
@@ -358,7 +366,8 @@
             "maxValue": 300,
             "dangerLevel": 280,
             "decimalPlaces": 0,
-            "iconName": "speed"
+            "iconName": "speed",
+            "big": 64
           }
         },
         {
@@ -387,7 +396,8 @@
             "maxValue": 6,
             "dangerLevel": 5.8,
             "decimalPlaces": 1,
-            "iconName": "oil_pressure"
+            "iconName": "oil_pressure",
+            "big": 64
           }
         },
         {
@@ -416,7 +426,8 @@
             "maxValue": 120,
             "dangerLevel": 110,
             "decimalPlaces": 0,
-            "iconName": "coolant"
+            "iconName": "coolant",
+            "big": 34
           }
         },
         {
@@ -445,7 +456,8 @@
             "maxValue": 150,
             "dangerLevel": 140,
             "decimalPlaces": 0,
-            "iconName": "oil_temp"
+            "iconName": "oil_temp",
+            "big": 34
           }
         },
         {
@@ -474,7 +486,8 @@
             "maxValue": 300,
             "dangerLevel": 270,
             "decimalPlaces": 0,
-            "iconName": "boost"
+            "iconName": "boost",
+            "big": 34
           }
         },
         {
@@ -503,7 +516,8 @@
             "maxValue": 15,
             "dangerLevel": 14.8,
             "decimalPlaces": 1,
-            "iconName": "battery"
+            "iconName": "battery",
+            "big": 34
           }
         }
       ]
@@ -540,7 +554,8 @@
             "maxValue": 120,
             "dangerLevel": 110,
             "decimalPlaces": 0,
-            "iconName": "coolant"
+            "iconName": "coolant",
+            "big": 64
           }
         },
         {
@@ -569,7 +584,8 @@
             "maxValue": 150,
             "dangerLevel": 140,
             "decimalPlaces": 0,
-            "iconName": "oil_temp"
+            "iconName": "oil_temp",
+            "big": 64
           }
         },
         {
@@ -598,7 +614,8 @@
             "maxValue": 6,
             "dangerLevel": 5.8,
             "decimalPlaces": 1,
-            "iconName": "oil_pressure"
+            "iconName": "oil_pressure",
+            "big": 64
           }
         },
         {
@@ -627,7 +644,8 @@
             "maxValue": 6,
             "dangerLevel": 5.5,
             "decimalPlaces": 1,
-            "iconName": "fuel"
+            "iconName": "fuel",
+            "big": 64
           }
         },
         {
@@ -656,7 +674,8 @@
             "maxValue": 80,
             "dangerLevel": 60,
             "decimalPlaces": 0,
-            "iconName": "iat"
+            "iconName": "iat",
+            "big": 34
           }
         },
         {
@@ -685,7 +704,8 @@
             "maxValue": 300,
             "dangerLevel": 270,
             "decimalPlaces": 0,
-            "iconName": "boost"
+            "iconName": "boost",
+            "big": 34
           }
         },
         {
@@ -714,7 +734,8 @@
             "maxValue": 15,
             "dangerLevel": 14.8,
             "decimalPlaces": 1,
-            "iconName": "battery"
+            "iconName": "battery",
+            "big": 34
           }
         }
       ]
@@ -751,7 +772,8 @@
             "maxValue": 300,
             "dangerLevel": 270,
             "decimalPlaces": 0,
-            "iconName": "boost"
+            "iconName": "boost",
+            "big": 88
           }
         },
         {
@@ -780,7 +802,8 @@
             "maxValue": 1.3,
             "dangerLevel": 1.2,
             "decimalPlaces": 2,
-            "iconName": "afr"
+            "iconName": "afr",
+            "big": 64
           }
         },
         {
@@ -810,7 +833,8 @@
             "dangerLevel": 95,
             "decimalPlaces": 0,
             "showBar": true,
-            "iconName": "throttle"
+            "iconName": "throttle",
+            "big": 64
           }
         },
         {
@@ -839,7 +863,8 @@
             "maxValue": 80,
             "dangerLevel": 60,
             "decimalPlaces": 0,
-            "iconName": "iat"
+            "iconName": "iat",
+            "big": 64
           }
         },
         {
@@ -868,7 +893,8 @@
             "maxValue": 8000,
             "dangerLevel": 7000,
             "decimalPlaces": 0,
-            "iconName": "rpm"
+            "iconName": "rpm",
+            "big": 34
           }
         },
         {
@@ -897,7 +923,8 @@
             "maxValue": 6,
             "dangerLevel": 5.5,
             "decimalPlaces": 1,
-            "iconName": "fuel"
+            "iconName": "fuel",
+            "big": 34
           }
         },
         {
@@ -926,7 +953,8 @@
             "maxValue": 15,
             "dangerLevel": 14.8,
             "decimalPlaces": 1,
-            "iconName": "battery"
+            "iconName": "battery",
+            "big": 34
           }
         }
       ]


### PR DESCRIPTION
Part of #153. **This one is deliberately not a zero-pixel change** — unlike the rest of the Tailwind chantier, the goal here is to move the preview *toward* the design comp, so the reference is `DASH_PAGES.json`, not `main`.

## The bug

`widget-previews/GaugeNumeric` picks its font size like this:

```ts
const fontSize = cfg.big !== undefined ? deviceValueFontPx(cfg.big) : autoSize
```

`big` was set on **0 of 40 widgets** across all six default pages. So every value rendered at a size auto-fitted to its box instead of the spec's tier — and the type hierarchy is the backbone of the design system. That single omission was the dominant reason the preview looked wrong.

Core's ladder already matched the spec exactly, so this is a data fix: feeding the canvas value from the spec's `valueClasses` through `deviceValueFontPx` reproduces hero 48, heroTrack 44, primary 32, mid 22 and secondary 17 device px on the nose.

**`big` set on 28 widgets**, derived mechanically from `DASH_PAGES.json` — no hand-tuning.

## Verified against the comp, not against main

Rendered `CANShift Dash Pages.dc.html` in the browser and compared page by page. Street now matches the comp's structure: SPEED and GEAR hero on row 0, RPM mid on row 1 with WATER and FUEL secondary, BATT on row 2. Before, all seven were within a few px of each other.

Pixel change vs `main`, for the record: page 1 10233 px, page 2 12300, page 3 13671, page 4 10933, pages 5–6 1489 each (they only shift because the strip thumbnails re-render — their compositions are untouched, see below).

## Deliberately not touched

Three widgets skipped, with reasons, rather than forced:

- **`street/ODO`** — the spec wants a `secondary` value; the tuner has a **button** in that slot. Setting `big` on a button is meaningless. Composition work.
- **`timing`** and **`controls`** — the compositions differ (5 widgets vs the spec's 7, and different content), so index-aligning `big` would attach sizes to the wrong widgets. Left alone entirely.

`track` **was** aligned: its spec list matches one-for-one after skipping the tuner's leading full-width shift-light widget, which the spec models as a page-level flag instead.

## Also in this PR

`docs/design/DASH_DESIGN_SYSTEM.md` and `docs/design/DASH_PAGES.json` are committed from the design package, which was sitting in `~/Downloads`. The JSON is the machine-readable source for the remaining work, so it belongs in the repo. The `.dc.html` comps are not included — those belong in `canshift-brand`, which already carries the brand book.

## Remaining gaps, now visible

With the tiers restored, what is left is easy to read off a screenshot:

1. **Status row is global.** Street shows `LAP 4 1:38.42`; the comp wants `TRIP 128 km`. Needs the per-page right-slot schema change.
2. **FUEL is the wrong signal** — `fuel_press_bar` (3.9 bar) where the comp wants a level, `46 %` with a bar. Needs `fuel_level_pct`.
3. **ODO has no signal** and sits in a button.
4. **GEAR renders red.** `Gear.tsx:45` uses `st.primaryColor` (`#FF4747`) while the comp shows Ink white; the widget's own `textColor` is already `#FFFFFF`. Either the preview should read `textColor` or the config's `primaryColor` is wrong — a spec question, not a data one, so I left it. Worth its own issue.
5. **The button tier cannot be expressed.** `BIG_TO_DEVICE_FONT` floors at 17 px and has no 14 px step, so a `button`-class value (spec: 14 device) is unreachable via `big`. Needs a core step before Timing and Controls can be rebuilt faithfully.

## Test plan

- `npm run typecheck`, `lint`, `format:check`, `test` (53 files, 335 tests), `build` — all green
- The edited JSON re-validated through `DashboardConfigSchema` (the same parse `default-sim-config.ts` performs at load)
- Six dash pages captured before and after, and the comp rendered alongside for the structural comparison
