### PR TITLE
fix(tuner): gear preview mirrors the firmware widget

### DIFF
--- a/src/components/editor/widget-preview.styles.ts
+++ b/src/components/editor/widget-preview.styles.ts
@@ -1,4 +1,39 @@
+import type { CSSProperties } from 'react'
+import { uiLabelAtSize } from '../../lib/typography'
+
 export const BLINK_ANIM = 'canshift-blink 0.7s step-end infinite'
+
+export const WIDGET_DIM_COLOR = '#888888'
+
+const KICKER_FONT_PX = 10
+const KICKER_INSET_PX = 4
+
+export const widgetKickerStyle: CSSProperties = {
+  ...uiLabelAtSize(KICKER_FONT_PX),
+  position: 'absolute',
+  top: KICKER_INSET_PX,
+  left: KICKER_INSET_PX,
+  color: WIDGET_DIM_COLOR,
+  lineHeight: 1,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  maxWidth: `calc(100% - ${String(KICKER_INSET_PX * 2)}px)`,
+}
+
+export const widgetTopRuleStyle = (
+  rulePx: number,
+  color: string,
+  blink: boolean
+): CSSProperties => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  height: rulePx,
+  background: color,
+  animation: blink ? BLINK_ANIM : undefined,
+})
 
 export const thresholdPct = (level: number, min: number, max: number): number => {
   const range = max - min || 1

--- a/src/components/editor/widget-previews/GaugeNumeric.tsx
+++ b/src/components/editor/widget-previews/GaugeNumeric.tsx
@@ -7,10 +7,15 @@ import {
   valueUnitFontSize,
   widgetTopRulePx,
 } from '@canshift/core'
-import { BLINK_ANIM } from '../widget-preview.styles'
+import {
+  BLINK_ANIM,
+  WIDGET_DIM_COLOR,
+  widgetKickerStyle,
+  widgetTopRuleStyle,
+} from '../widget-preview.styles'
 import { effectiveValue } from './gauge-math'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
-import { MONO_FONT, uiLabelAtSize } from '../../../lib/typography'
+import { MONO_FONT } from '../../../lib/typography'
 
 export interface GaugeNumericRendererProps extends BaseRendererProps {
   danger: boolean
@@ -71,18 +76,7 @@ export const GaugeNumericPreview = memo(function GaugeNumericPreview({
         gap: 0,
       }}
     >
-      <span
-        aria-hidden="true"
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          height: rulePx,
-          background: ruleColor,
-          animation: danger ? BLINK_ANIM : undefined,
-        }}
-      />
+      <span aria-hidden="true" style={widgetTopRuleStyle(rulePx, ruleColor, danger)} />
       {showBar && (
         <span
           aria-hidden="true"
@@ -105,25 +99,7 @@ export const GaugeNumericPreview = memo(function GaugeNumericPreview({
           />
         </span>
       )}
-      <span
-        style={{
-          position: 'absolute',
-          top: 4,
-          left: 4,
-          ...uiLabelAtSize(9),
-          fontWeight: 500,
-          color: '#888888',
-          lineHeight: 1,
-          whiteSpace: 'nowrap',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          maxWidth: `calc(100% - 8px)`,
-          letterSpacing: '0.06em',
-          textTransform: 'uppercase',
-        }}
-      >
-        {signalLabel.toUpperCase()}
-      </span>
+      <span style={widgetKickerStyle}>{signalLabel.toUpperCase()}</span>
       <div
         style={{
           display: 'flex',
@@ -154,7 +130,7 @@ export const GaugeNumericPreview = memo(function GaugeNumericPreview({
         {signalUnit !== '' && (
           <span
             style={{
-              color: '#888888',
+              color: WIDGET_DIM_COLOR,
               fontSize: valueUnitFontSize(Math.round(fontSize)),
               fontFamily: MONO_FONT,
               fontWeight: 500,

--- a/src/components/editor/widget-previews/Gear.tsx
+++ b/src/components/editor/widget-previews/Gear.tsx
@@ -1,11 +1,28 @@
 import { memo } from 'react'
-import { STALE_PLACEHOLDER } from '@canshift/core'
-import type { BaseRendererProps } from './shared'
+import {
+  STALE_PLACEHOLDER,
+  WIDGET_TOP_RULE,
+  deviceValueFontPx,
+  widgetTopRulePx,
+} from '@canshift/core'
+import { type BaseRendererProps, formatSignalLabel } from './shared'
 import { MONO_FONT } from '../../../lib/typography'
+import { widgetKickerStyle, widgetTopRuleStyle } from '../widget-preview.styles'
 
 interface GearRendererProps extends BaseRendererProps {
   unbound?: boolean
 }
+
+const AUTO_FONT_MIN_PX = 10
+const AUTO_FONT_MAX_PX = 48
+const AUTO_FONT_WIDTH_RATIO = 0.72
+const AUTO_FONT_HEIGHT_RATIO = 0.85
+
+const autoFontPx = (w: number, h: number): number =>
+  Math.max(
+    AUTO_FONT_MIN_PX,
+    Math.min(AUTO_FONT_MAX_PX, w * AUTO_FONT_WIDTH_RATIO, h * AUTO_FONT_HEIGHT_RATIO)
+  )
 
 export const GearPreview = memo(function GearPreview({
   widget,
@@ -14,8 +31,11 @@ export const GearPreview = memo(function GearPreview({
   unbound = false,
 }: GearRendererProps) {
   if (widget.config.type !== 'gear') return null
+  const cfg = widget.config
   const st = widget.style
-  const fontSize = Math.min(w * 0.72, h * 0.85)
+  const fontSize = cfg.big !== undefined ? deviceValueFontPx(cfg.big) : autoFontPx(w, h)
+  const rulePx = widgetTopRulePx(Math.round(fontSize))
+  const ruleColor = rulePx === WIDGET_TOP_RULE.primaryPx ? st.textColor : WIDGET_TOP_RULE.trackColor
 
   return (
     <div
@@ -31,6 +51,8 @@ export const GearPreview = memo(function GearPreview({
         overflow: 'hidden',
       }}
     >
+      <span aria-hidden="true" style={widgetTopRuleStyle(rulePx, ruleColor, false)} />
+      <span style={widgetKickerStyle}>{formatSignalLabel(widget.signal)}</span>
       <div
         style={{
           display: 'flex',
@@ -42,7 +64,7 @@ export const GearPreview = memo(function GearPreview({
       >
         <span
           style={{
-            color: st.primaryColor,
+            color: st.textColor,
             fontSize,
             fontWeight: 800,
             fontFamily: MONO_FONT,


### PR DESCRIPTION
Closes #156, part of #153.

#156 asked which of two fixes was right — the preview reading the wrong field, or the config carrying the wrong colour. **The firmware settles it**: `gear_widget.cpp` reads `cfg.style.textColor` on all six of its colour paths and never touches `primaryColor`. Across the whole firmware, `primaryColor` is read by exactly two widgets — `button_widget` and `cruise_control_widget` — which is precisely the "`#FF4747` means *this function is on*" rule in `DASH_DESIGN_SYSTEM.md` §. The device has always drawn the gear in Ink; the tuner preview was the drifted side. So: option 1, no config change, every existing config fixed at once.

Reading `gear_widget.cpp` next to `Gear.tsx` turned up three more drifts in the same widget, all of them the same class of bug and none worth a second PR.

## What the firmware does that the preview did not

| `gear_widget.cpp` | `Gear.tsx` before |
| --- | --- |
| `cfg.style.textColor` | `st.primaryColor` |
| `selectFont`: `cfg.label.big > 0 → deviceFontPxForBig(big)` | `big` ignored entirely |
| auto-fit clamped to `[10, 48]` | `min(w*0.72, h*0.85)`, unclamped |
| `makeTopRule(...)`, primary tier in text colour | no rule |
| `applySignalHeader(cont, cfg.signalId)` | no kicker |

The `big` one is the gear-shaped half of the bug #155 just fixed for `GaugeNumeric`: #155 **did** set `big` on the gear widgets (street 96, track 88), the renderer just never read it. So street/track gears were auto-fitting to roughly 72 px against a spec hero of 48, which is why the red 3 was visually the loudest thing on the page. The clamp is what the firmware would have applied.

The rule and the kicker are not decoration — `DASH_DESIGN_SYSTEM.md` opens with "a widget is a rule, a kicker and a value", and `DASH_PAGES.json` gives the gear `{ "kicker": "GEAR", "class": "hero" }` on page 1 and `heroTrack` on page 2. A gear with neither was not a styling nit, it was a missing two thirds of the widget.

## Shape

The rule and the kicker existed once already, inline in `GaugeNumeric`. Adding a second copy to `Gear` is the thing `CLAUDE.md` names, so both now come from `widget-preview.styles.ts` as `widgetTopRuleStyle(rulePx, color, blink)` and `widgetKickerStyle`. `#888888` picked up a name (`WIDGET_DIM_COLOR`) on the way — it was literal in four places in the preview tree.

`GaugeNumeric` moving onto the shared kicker **changes its rendering**, deliberately: its inline copy overrode `uiLabelAtSize` down to 9 px, weight 500 and `0.06em`, where the shared helper's own defaults — 10 px, weight 800, `0.18em` — are already exactly what `DASH_DESIGN_SYSTEM.md` §3 specifies for a kicker. The override was the drift; deleting it *is* the fix. Same reasoning as #155: the reference here is the comp, not `main`.

## Pixel diff vs `main`

Not zero, and intended to not be zero.

| Page | Diff | What |
| --- | --- | --- |
| 1 street | 3479 px (0.268%) | gear: red→Ink, ~72→48 px, gains rule + kicker; all kickers restyled |
| 2 track | 2705 px (0.209%) | same, gear at 44 |
| 3 | 930 px (0.072%) | kickers only |
| 4 | 924 px (0.071%) | kickers only |
| 5 timing | 3153 px (0.243%) | gear (no `big` here, so auto-fit + clamp) + kickers |
| 6 controls | 392 px (0.030%) | kickers only |

Pages 3, 4 and 6 carry no gear, so their diff mask is the control: it lights up on the kickers and **nowhere else** — values, rules, bars and layout are untouched. Mask checked page by page.

## Left alone

- **`Timer` also ignores `big`**, and `timer_widget.cpp` honours it. No timer widget has `big` set today, because #155 deliberately skipped the timing and controls pages whose compositions do not match the spec. Fixing the renderer with no data to act on would be unverifiable — it belongs with the Timing rebuild.
- **The kicker colour is still `#888888`.** The spec wants `CS_DIM` `#BABAB8`. That value is core's `textDim` schema default, so it is a core change with a firmware counterpart, not a tuner one. Filed separately.

## Test plan

- `npm run typecheck`, `lint`, `format:check`, `test` (53 files, 335 tests), `build` — all green
- Six dash pages captured before/after in Helium at 1440×900, diffed with pixelmatch, every mask inspected
- No console errors on either run