### PR TITLE
fix(tuner): key signal preview rows uniquely

### DIFF
--- a/src/components/ecu/SignalPreviewTable.test.ts
+++ b/src/components/ecu/SignalPreviewTable.test.ts
@@ -1,0 +1,38 @@
+import type { SignalDef } from '@canshift/core'
+import { describe, expect, it } from 'vitest'
+import { signalRowKey } from './SignalPreviewTable'
+
+const signal = (name: string, canFrameId: string, startByte: number): SignalDef =>
+  ({
+    name,
+    canFrameId,
+    startByte,
+    byteLength: 2,
+    scale: 1,
+    offset: 0,
+    signed: false,
+    bigEndian: false,
+    unit: '',
+    min: 0,
+    max: 100,
+  }) as SignalDef
+
+describe('signalRowKey', () => {
+  it('keeps colliding signal names on distinct keys so neither row is dropped', () => {
+    const lambdaA = signal('channel_254', '0x520', 6)
+    const lambdaB = signal('channel_254', '0x521', 0)
+
+    expect(signalRowKey(lambdaA, 0)).not.toBe(signalRowKey(lambdaB, 1))
+  })
+
+  it('separates rows that collide on every field a profile can repeat', () => {
+    const placeholders = Array.from({ length: 8 }, () => signal('channel_placeholder', '0x600', 0))
+    const keys = placeholders.map(signalRowKey)
+
+    expect(new Set(keys).size).toBe(placeholders.length)
+  })
+
+  it('carries the signal name so a key stays readable next to the rendered row', () => {
+    expect(signalRowKey(signal('rpm', '0x100', 0), 3)).toContain('rpm')
+  })
+})

--- a/src/components/ecu/SignalPreviewTable.tsx
+++ b/src/components/ecu/SignalPreviewTable.tsx
@@ -34,6 +34,9 @@ const cell = cva(
   }
 )
 
+export const signalRowKey = (signal: SignalDef, index: number): string =>
+  `${String(index)}:${signal.name}`
+
 export const SignalPreviewTable = ({
   signals,
   boundTo,
@@ -84,10 +87,10 @@ export const SignalPreviewTable = ({
             </tr>
           </thead>
           <tbody>
-            {signals.map((s) => {
+            {signals.map((s, i) => {
               const bound = boundTo.get(s.name) ?? null
               return (
-                <tr key={s.name}>
+                <tr key={signalRowKey(s, i)}>
                   <td className={cn(cell({ first: true }))}>{s.name}</td>
                   <td className={cn(cell({ tone: 'id' }))}>{s.canFrameId}</td>
                   <td className={cn(cell({ tone: 'dim' }))}>


### PR DESCRIPTION
Closes #133.

The console warning in #133 is real. Its diagnosis is not: the issue says the duplicate row is **silently missing from the preview**, and it is not. React warns on a duplicate key but still renders both children on first paint. On `main` today, loading the MaxxECU profile shows all 99 rows, both `channel_254` among them — the header and the table already agree.

The actual failure needs an *update* to show itself, and it is the opposite of a dropped row.

## What really happens

Driving `/ecu` through MaxxECU → Haltech V3 → MaxxECU, counting rows at each step:

| Step | `main` | this branch | Expected |
| --- | --- | --- | --- |
| MaxxECU | 99 | 99 | 99 |
| Haltech V3 | **111** | 110 | 110 |
| back to MaxxECU | **100** | 99 | 99 |

On `main` the Haltech table renders a row that does not belong to it — `channel_254  0x520  6–7  0.001`, MaxxECU's Lambda 1, stranded from the previous profile. Coming back, MaxxECU shows `channel_254 0x520` **twice**. So the bug is row duplication and cross-profile leakage, not omission: with two children under one key, React cannot tell which of the two an incoming row corresponds to, keeps the wrong one alive across the swap, and the extra never unmounts.

A stale row from another ECU sitting in a signal table, with a plausible CAN ID and a plausible scale, is worse than a missing one — nothing about it looks wrong.

## The fix

`signalRowKey(signal, index)` — the index disambiguates, the name keeps the key legible in devtools. Positional identity is right here: the list is a static parse of one profile, never sorted or filtered, so index *is* row identity.

Not `name + canFrameId + startByte`: it happens to be unique for MaxxECU, but `syvecs_default_can.xml` has eight values sharing `targetId="placeholder"`, and nothing guarantees they differ on frame and offset.

## This is not one bad profile

The issue asks whether other catalogue entries have the same problem. Nine do — 33 rows across the catalogue currently sit under a colliding key:

| Profile | Colliding rows | Collision |
| --- | --- | --- |
| `tiremagic_tpms.xml` | 15 | 5 names × 4 sensors |
| `syvecs_default_can.xml` | 9 | `channel_placeholder` ×8, `channel_254`, `channel_255` |
| `toyota_corolla_e150.xml` | 2 | `channel_164`, `channel_179` |
| `flagtronics_can_v0_4.xml` | 2 | two literal `name` attributes |
| `haltech_v3_can.xml` | 1 | `channel_38` |
| `dominator_and_terminator_x_can.xml` | 1 | `Holley EFI: Sensor Caution` |
| `displaylink.xml` | 1 | `channel_119` |
| `maxxecu_default_can.xml` | 1 | `channel_254` |
| `turbolamik_tcu.xml` | 1 | `channel_42` |

Two different origins. `tiremagic`, `flagtronics` and `holley` genuinely ship two values under one `name` — the vendor's data. The six `channel_*` ones are **generated** by core: `value-to-signal.ts` derives `channel_${targetId}` when a value has no `name`, and a profile is free to reuse a `targetId` across frames. MaxxECU's two Lambda 1 entries on `0x520` and `0x521` are exactly that.

So #133's second half — "the profile should not ship two signals with the same name, since `name` is the binding key everywhere else" — is a **core** problem, not a data one, and it outlives this PR: widgets bind by signal name, so a colliding name is an ambiguous binding no table key can fix. Filed as CANShift/canshift-core#96. This PR fixes the renderer half only, which is the half that misleads the user today.

## Test plan

- `npm run typecheck`, `lint`, `format:check`, `test` (54 files, 338 tests), `build` — all green
- 3 new tests on `signalRowKey`, including the eight-way `channel_placeholder` collision
- The profile-switch sequence above driven in Helium against both branches; console clean on this branch, 2 React key errors on `main`
