### PR TITLE
refactor(tuner): collapse ThemeStatusCard branches to a lookup

### DIFF
--- a/src/components/themes/ThemeStatusCard.test.ts
+++ b/src/components/themes/ThemeStatusCard.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { THEME_STATUS, resolveThemeStatus } from './ThemeStatusCard'
+
+describe('resolveThemeStatus', () => {
+  it('reports simulation even while a device is connected and reporting a mode', () => {
+    expect(resolveThemeStatus({ isDayMode: true, connected: true, simulationMode: true })).toBe(
+      'simulation'
+    )
+  })
+
+  it('reports disconnected before waiting on a handshake', () => {
+    expect(resolveThemeStatus({ isDayMode: null, connected: false, simulationMode: false })).toBe(
+      'disconnected'
+    )
+  })
+
+  it('waits on the handshake once connected with no mode yet', () => {
+    expect(resolveThemeStatus({ isDayMode: null, connected: true, simulationMode: false })).toBe(
+      'reading'
+    )
+  })
+
+  it('resolves the device mode once the firmware reports one', () => {
+    expect(resolveThemeStatus({ isDayMode: true, connected: true, simulationMode: false })).toBe(
+      'day'
+    )
+    expect(resolveThemeStatus({ isDayMode: false, connected: true, simulationMode: false })).toBe(
+      'night'
+    )
+  })
+})
+
+describe('THEME_STATUS', () => {
+  it('only paints the day palette for a device actually reporting day', () => {
+    const dayVariants = Object.entries(THEME_STATUS)
+      .filter(([, visual]) => visual.variant === 'day')
+      .map(([status]) => status)
+
+    expect(dayVariants).toEqual(['day'])
+  })
+
+  it('labels the unresolved states "Theme" and the resolved ones "Current theme"', () => {
+    expect(THEME_STATUS.simulation.label).toBe('Theme')
+    expect(THEME_STATUS.disconnected.label).toBe('Theme')
+    expect(THEME_STATUS.reading.label).toBe('Theme')
+    expect(THEME_STATUS.day.label).toBe('Current theme')
+    expect(THEME_STATUS.night.label).toBe('Current theme')
+  })
+})

--- a/src/components/themes/ThemeStatusCard.tsx
+++ b/src/components/themes/ThemeStatusCard.tsx
@@ -7,57 +7,75 @@ export interface ThemeStatusCardProps {
   simulationMode: boolean
 }
 
-export const ThemeStatusCard = ({ isDayMode, connected, simulationMode }: ThemeStatusCardProps) => {
-  if (simulationMode) {
-    return (
-      <div className={cn(card({ variant: 'night' }))}>
-        <div className={ICON}>◐</div>
-        <div className="flex flex-col gap-1">
-          <div className={LABEL}>Theme</div>
-          <div className={VALUE}>Simulation</div>
-          <div className={HINT}>Connect a real device to control its theme.</div>
-        </div>
-      </div>
-    )
-  }
+type ThemeStatus = 'simulation' | 'disconnected' | 'reading' | 'day' | 'night'
 
-  if (!connected) {
-    return (
-      <div className={cn(card({ variant: 'night' }))}>
-        <div className={ICON}>◐</div>
-        <div className="flex flex-col gap-1">
-          <div className={LABEL}>Theme</div>
-          <div className={VALUE}>Disconnected</div>
-          <div className={HINT}>Plug the device in to read its current theme.</div>
-        </div>
-      </div>
-    )
-  }
+interface ThemeStatusVisual {
+  variant: 'day' | 'night'
+  icon: string
+  label: string
+  value: string
+  hint: string
+}
 
-  if (isDayMode === null) {
-    return (
-      <div className={cn(card({ variant: 'night' }))}>
-        <div className={ICON}>◐</div>
-        <div className="flex flex-col gap-1">
-          <div className={LABEL}>Theme</div>
-          <div className={VALUE}>Reading…</div>
-          <div className={HINT}>Waiting for the firmware handshake.</div>
-        </div>
-      </div>
-    )
-  }
+export const resolveThemeStatus = ({
+  isDayMode,
+  connected,
+  simulationMode,
+}: ThemeStatusCardProps): ThemeStatus => {
+  if (simulationMode) return 'simulation'
+  if (!connected) return 'disconnected'
+  if (isDayMode === null) return 'reading'
+  return isDayMode ? 'day' : 'night'
+}
+
+export const THEME_STATUS: Record<ThemeStatus, ThemeStatusVisual> = {
+  simulation: {
+    variant: 'night',
+    icon: '◐',
+    label: 'Theme',
+    value: 'Simulation',
+    hint: 'Connect a real device to control its theme.',
+  },
+  disconnected: {
+    variant: 'night',
+    icon: '◐',
+    label: 'Theme',
+    value: 'Disconnected',
+    hint: 'Plug the device in to read its current theme.',
+  },
+  reading: {
+    variant: 'night',
+    icon: '◐',
+    label: 'Theme',
+    value: 'Reading…',
+    hint: 'Waiting for the firmware handshake.',
+  },
+  day: {
+    variant: 'day',
+    icon: '☀',
+    label: 'Current theme',
+    value: 'Day',
+    hint: 'Bright palette: light background, dark text.',
+  },
+  night: {
+    variant: 'night',
+    icon: '☾',
+    label: 'Current theme',
+    value: 'Night',
+    hint: 'Dark palette: black background, white text.',
+  },
+}
+
+export const ThemeStatusCard = (props: ThemeStatusCardProps) => {
+  const visual = THEME_STATUS[resolveThemeStatus(props)]
 
   return (
-    <div className={cn(card({ variant: isDayMode ? 'day' : 'night' }))}>
-      <div className={ICON}>{isDayMode ? '☀' : '☾'}</div>
+    <div className={cn(card({ variant: visual.variant }))}>
+      <div className={ICON}>{visual.icon}</div>
       <div className="flex flex-col gap-1">
-        <div className={LABEL}>Current theme</div>
-        <div className={VALUE}>{isDayMode ? 'Day' : 'Night'}</div>
-        <div className={HINT}>
-          {isDayMode
-            ? 'Bright palette: light background, dark text.'
-            : 'Dark palette: black background, white text.'}
-        </div>
+        <div className={LABEL}>{visual.label}</div>
+        <div className={VALUE}>{visual.value}</div>
+        <div className={HINT}>{visual.hint}</div>
       </div>
     </div>
   )


### PR DESCRIPTION
Closes #151.

Four `return` blocks rendering the same five-element structure become one, behind `Record<ThemeStatus, ThemeStatusVisual>`. `CLAUDE.md` names this shape directly — stacked mutually-exclusive branches are a union that lost its type — and `WidgetPreview.tsx` is the reference.

The branch structure was left in place deliberately by #141, which was a pure Tailwind conversion proven by a pixel diff and had no business also changing control flow. The class constants it extracted are what makes this cheap now.

## What the collapse exposed

The four branches were **five** states, not four. The last block was `isDayMode ? … : …` on every one of its five values — variant, icon, label, value, hint — so `day` and `night` were already separate states wearing one `return`. Naming them separates the one thing that genuinely differs between them from the three states that only *look* similar:

```ts
type ThemeStatus = 'simulation' | 'disconnected' | 'reading' | 'day' | 'night'
```

`simulation`, `disconnected` and `reading` share `variant: 'night'` and the `◐` glyph, but they share it as data now rather than as three copies of the same JSX. The precedence that was implicit in the order of the early returns is now one readable function:

```ts
export const resolveThemeStatus = ({ isDayMode, connected, simulationMode }) => {
  if (simulationMode) return 'simulation'
  if (!connected) return 'disconnected'
  if (isDayMode === null) return 'reading'
  return isDayMode ? 'day' : 'night'
}
```

No `?? FALLBACK` was needed, unlike `HeaderView` in #154: a `Record` with a finite key union returns `T`, not `T | undefined` — `noUncheckedIndexedAccess` only widens index *signatures*.

## Why there are tests on a refactor

Only one of the five states is reachable in the browser. The dev server auto-enters simulation, so `/themes` always renders `simulation`; `disconnected`, `reading`, `day` and `night` all need hardware, and there is no board to plug in. A pixel diff can therefore only prove one fifth of this change, which is not enough for a change that rewrites the state precedence.

So `resolveThemeStatus` and `THEME_STATUS` are exported and covered directly — six tests over all five states, including the two precedence rules that were previously only expressible as "the early returns happen to be in this order":

- simulation wins even when a device is connected **and** reporting a mode
- disconnected wins over reading when there is no mode yet

Plus two on the table itself: only `day` paints the day palette, and the label is `Theme` in the three unresolved states against `Current theme` in the two resolved ones. That label split was easy to lose in the collapse — it is the one string the old branches did not share.

## Verification

- **`/themes` pixel diff vs `main`: 0 px.** Simulation state, 1440×900, no console errors on either run.
- The other four states: unreachable without a board, covered by the tests above rather than implied.
- `npm run typecheck`, `lint`, `format:check`, `test` (54 files, 341 tests), `build` — all green