### PR TITLE
restyle(tuner): welcome screen with the bench of saved configs

### DIFF
--- a/docs/design/PROMPT_TUNER_WELCOME.md
+++ b/docs/design/PROMPT_TUNER_WELCOME.md
@@ -1,0 +1,102 @@
+# Prompt — Tuner welcome screen
+
+For Claude Code in `canshift-tuner`. Visual reference: the `Welcome` view in `CANShift Tuner.dc.html`
+(sidebar → Welcome). This document is self-sufficient; the mockup is only there to confirm proportions.
+
+---
+
+You are building (or correcting) the CANShift Tuner's welcome screen — the view shown when the app opens
+and no device is connected. Read the whole spec, then implement.
+
+## What this screen is for
+
+Two jobs, in this order: **get back to work** (resume a config you already made) and **get connected**
+(plug the dash in). It is not a landing page. There is no logo, no marketing hero, no centred copy, and
+no fake dashboard rendering — the app must never draw a dash it is not talking to.
+
+## Layout
+
+Two columns inside the normal app chrome (header 56 px, sidebar 236 px, both unchanged):
+
+|              |                                                                   |
+| ------------ | ----------------------------------------------------------------- |
+| Left column  | `minmax(360px, 470px)`, 2 px right divider, padding `44px 40px 0` |
+| Right column | `minmax(0, 1fr)`, ground `--color-neutral-100`                    |
+
+Below **1180 px** the two columns stack (`display: block` on the wrapper, children reset to
+`min-height: auto; overflow: visible`, the wrapper itself scrolls). The app floor is `min-width: 980px`;
+below it the page scrolls horizontally rather than clipping.
+
+Everything is flush left. Radius 0 everywhere. Rules do the organising: 2 px for major separations, 1 px
+between list rows.
+
+## Left column — connect
+
+1. **Status kicker** — `NO DEVICE CONNECTED`, mono 10.5 px, 0.2em, `--color-neutral-600`, over a **2 px**
+   bottom divider. This is the only place the connection state is stated.
+2. **Title** — "Configure your dash, live." Archivo 800, 38 px, -0.035em, line-height 1.04.
+3. **Dek** — "Pages, CAN bindings and OBD-II polling, edited in the browser against the dash on your
+   desk. Nothing to install, nothing to deploy." 15 px / 1.6, `--color-neutral-700`, max 42ch.
+4. **Actions** — two buttons, `gap: 1px`, labels **flush left**, `white-space: nowrap`:
+   - `CONNECT DEVICE` — accent fill, white, Archivo 800 13 px, 0.1em, padding 15 × 22. Hover
+     `--color-accent-600`.
+   - `Explore with sample data` — 1 px `--color-neutral-400` outline, transparent, 13 px / 700.
+5. **`TO CONNECT`** — mono 10.5 px, 0.18em kicker over a 1 px rule, then three rows separated by 1 px
+   rules, each `mono number (16 px wide) + title 14 px/700 + line 13.5 px`:
+   - `01 Plug the dash in` — USB-C, straight into the computer. No hub.
+   - `02 Pick the port` — The browser asks which USB port to use.
+   - `03 Start tuning` — Edit pages and widgets — the dash updates as you type.
+6. **Footer**, pushed down with `margin-top: auto` — About · Troubleshooting · Report a problem, mono
+   11 px.
+
+## Right column — the bench
+
+The recent configs, so a returning user resumes in one click. **This is the point of the screen.**
+
+- **Toolbar**, 40 px, 2 px bottom divider, mono 10.5 px 0.14em `--color-neutral-600`: `YOUR BENCH` on the
+  left, `N CONFIGS · LOCAL` on the right.
+- **One row per config**, `grid-template-columns: 100px minmax(0, 1fr) auto`, gap 20, padding 18 × 22,
+  1 px bottom rule, whole row clickable, hover `--color-neutral-200`:
+  - **Thumbnail**, 100 × 70, drawn in the config's _own dash theme_ (night configs on `#121212` with
+    white ink, day configs on `#DDDDDD` with black ink): a 2 px top rule, one representative value in
+    mono 17 px, a 1 px rule pushed to the bottom, and `6 PAGES · NIGHT` in mono 8 px. It is a miniature
+    of the real page grammar, not a screenshot and not an icon.
+  - **Middle**: config name in Archivo 800 15.5 px, then `ECU · bus rate · signal count` in mono 11.5 px
+    `--color-neutral-600` (e.g. `MegaSquirt MS3 · 500 kbit · 46 signals`).
+  - **Right**: relative date in mono 11.5 px, and `RESUME →` in the accent underneath.
+- **`+ Start a new config`** as the last row, same rhythm, accent `+` occupying the thumbnail column:
+  title plus "from a blank dash, or from one of the six defaults".
+- **Footer**, 2 px top divider, mono 11 px: "Configs live in this browser." + `Export ↗`, and
+  `Import a config file` pushed right.
+
+### Empty state (first run)
+
+No bench rows exist. Do **not** show an empty panel: promote `Start a new config` to fill the column —
+the six default pages (Street, Track, Engine, Tuning, Timing, Controls) as pickable rows using the same
+thumbnail treatment, under a `START FROM A DEFAULT` toolbar label. The left column is unchanged.
+
+## Behaviour
+
+| Interaction                               | Result                                                                                         |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `CONNECT DEVICE`                          | Web Serial port picker; on success go to Pages & widgets with the device attached              |
+| `Explore with sample data`                | loads the sample config into the editor, header keeps `no device`                              |
+| Row click / `RESUME →`                    | opens that config in Pages & widgets                                                           |
+| `+ Start a new config`                    | new blank config, or the defaults picker                                                       |
+| `Export ↗` / `Import`                     | download / upload the config JSON                                                              |
+| A device connects while this view is open | leave the screen; navigation is the user's call, but the header status must update immediately |
+
+Configs are stored client-side (IndexedDB or localStorage). The footer line saying so is not decoration —
+it sets the expectation that clearing the browser loses them, which is why Export is next to it.
+
+## Non-negotiable
+
+- **Never render a dash the app is not connected to.** The thumbnails are miniatures of saved configs —
+  real user data — not a live-looking dashboard. `- -` means _the sensor went quiet_ and must not be used
+  as a "no device" placeholder anywhere.
+- No logo on this screen. The mark is already in the header.
+- Nothing centred, no radius, no shadow, no gradient, no second accent.
+- Button labels flush left even when the button is wider than the label.
+- Focus: `outline: 2px solid var(--color-accent); outline-offset: 2px` — never the browser default.
+- Rows must survive a narrow viewport: the meta line may wrap to two lines, never to one word per line.
+  Verify at 1600 / 1280 / 1180 / 1024 / 980 px.

--- a/src/components/project/ProjectSwitcher.tsx
+++ b/src/components/project/ProjectSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ChangeEvent } from 'react'
+import { useState } from 'react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,11 +12,8 @@ import { NewProjectWizard } from './NewProjectWizard'
 import { DEFAULT_PROJECT_NAME, useProjectStore } from '../../stores/project/project.store'
 import { useDashboardStore } from '../../stores/dashboard.store'
 import { useLogStore } from '../../stores/log.store'
-import {
-  PROJECT_FILE_ACCEPT,
-  downloadProjectFile,
-  readProjectFileText,
-} from '../../lib/project-file'
+import { PROJECT_FILE_ACCEPT } from '../../lib/project-file'
+import { useProjectFileActions } from '../../hooks/useProjectFileActions'
 
 const RECENT_LIMIT = 8
 
@@ -41,11 +38,10 @@ export const ProjectSwitcher = () => {
   const activeProjectId = useProjectStore((s) => s.activeProjectId)
   const switchProject = useProjectStore((s) => s.switchProject)
   const duplicateProject = useProjectStore((s) => s.duplicateProject)
-  const importProject = useProjectStore((s) => s.importProject)
-  const exportProject = useProjectStore((s) => s.exportProject)
   const dashboardName = useDashboardStore((s) => s.config?.name ?? null)
   const log = useLogStore((s) => s.push)
-  const fileInputRef = useRef<HTMLInputElement>(null)
+  const { fileInputRef, exportProjectFile, openImportPicker, handleImportChange } =
+    useProjectFileActions()
   const [wizardOpen, setWizardOpen] = useState(false)
 
   const activeMeta = projects.find((p) => p.id === activeProjectId) ?? null
@@ -67,35 +63,7 @@ export const ProjectSwitcher = () => {
   }
 
   const handleExport = () => {
-    if (activeProjectId === null) return
-    const json = exportProject(activeProjectId)
-    if (json === null) {
-      log('error', 'Could not export the project.')
-      return
-    }
-    downloadProjectFile(activeName, json)
-    log('info', `Exported “${activeName}”.`)
-  }
-
-  const handleImportClick = () => {
-    fileInputRef.current?.click()
-  }
-
-  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    event.target.value = ''
-    if (!file) return
-    let raw: string
-    try {
-      raw = await readProjectFileText(file)
-    } catch (err) {
-      console.warn('[project] import read failed', err)
-      log('error', 'Could not read the selected file.')
-      return
-    }
-    const result = importProject(raw)
-    if (result.ok) log('success', `Imported “${result.name}”.`)
-    else log('error', result.error)
+    exportProjectFile(activeProjectId, activeName)
   }
 
   return (
@@ -146,7 +114,7 @@ export const ProjectSwitcher = () => {
           </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => {
-              handleImportClick()
+              openImportPicker()
             }}
           >
             Import .canshift…
@@ -166,7 +134,7 @@ export const ProjectSwitcher = () => {
         type="file"
         accept={PROJECT_FILE_ACCEPT}
         onChange={(event) => {
-          void handleFileChange(event)
+          void handleImportChange(event)
         }}
         className="hidden"
       />

--- a/src/components/shell/WelcomeScreen.tsx
+++ b/src/components/shell/WelcomeScreen.tsx
@@ -1,147 +1,68 @@
-import { Spinner } from '@/components/ui/spinner'
 import type { ReactNode } from 'react'
-import { Button } from '@/components/ui/button'
-import { BrandLockup } from '@/components/brand/BrandLockup'
-
-const SUPPORTED_BROWSERS = ['Chrome 89+', 'Edge 89+', 'Brave', 'Opera']
-
-const STEPS: Array<{ title: string; body: string }> = [
-  {
-    title: 'Plug your dash',
-    body: 'USB-C cable, directly into your computer. No hub.',
-  },
-  {
-    title: 'Pick the port',
-    body: 'Click Connect device. Your browser asks which USB port to use.',
-  },
-  {
-    title: 'Start tuning',
-    body: 'Edit your dashboard live — your changes preview as you type.',
-  },
-]
+import type { BenchEntry } from '../../lib/bench-entry'
+import { BenchPanel } from '../welcome/BenchPanel'
+import { ConnectColumn } from '../welcome/ConnectColumn'
 
 export interface WelcomeScreenProps {
+  entries: BenchEntry[]
+  now: number
   supported?: boolean
   busy?: boolean
   reconnecting?: boolean
   lastError?: string | null
   onConnect?: () => void
   onExploreSimulation?: () => void
+  onResume: (id: string) => void
+  onNewConfig: () => void
+  onStartFromPageSet: (pageSetId: string) => void
+  onExport: () => void
+  onImport: () => void
   footerLinks?: ReactNode
 }
 
+const WRAPPER = [
+  'flex-1 overflow-auto',
+  'grid grid-cols-[minmax(360px,470px)_minmax(0,1fr)]',
+  'max-[1180px]:block',
+  '[&>section]:max-[1180px]:[min-height:auto] [&>section]:max-[1180px]:overflow-visible',
+  '[&>section:first-child]:max-[1180px]:border-r-0',
+  '[&>section:first-child]:max-[1180px]:border-b-2',
+].join(' ')
+
 export const WelcomeScreen = ({
+  entries,
+  now,
   supported = true,
   busy = false,
   reconnecting = false,
   lastError = null,
   onConnect,
   onExploreSimulation,
+  onResume,
+  onNewConfig,
+  onStartFromPageSet,
+  onExport,
+  onImport,
   footerLinks,
-}: WelcomeScreenProps) => {
-  return (
-    <div className="flex flex-1 items-center justify-center overflow-y-auto bg-background px-8 py-12">
-      <div className="flex w-full max-w-[540px] flex-col gap-7">
-        <header className="flex flex-col items-center gap-3 text-center">
-          <div className="flex justify-center text-text">
-            <BrandLockup height={78} withBaseline label="CANShift Tuner" />
-          </div>
-          <h1 className="m-0 text-[30px] font-bold leading-[1.15] tracking-[-0.02em] text-text">
-            Configure your dash, live.
-          </h1>
-          <p className="m-0 max-w-[440px] text-sm leading-[1.6] text-text-dim">
-            Edit pages, bind CAN signals, tune OBD-II polling — all in your browser, with the dash
-            connected over USB. No install, nothing to deploy.
-          </p>
-        </header>
-
-        {!supported ? (
-          <UnsupportedBrowserCard />
-        ) : (
-          <>
-            <ol className="m-0 flex list-none flex-col gap-3.5 p-0">
-              {STEPS.map((step, idx) => (
-                <li
-                  key={step.title}
-                  className="flex items-start gap-3.5 border border-border bg-surface px-4 py-3.5"
-                >
-                  <div className="mt-0.5 flex size-7 shrink-0 items-center justify-center bg-brand-accent/15 text-[13px] font-bold text-brand-accent">
-                    {idx + 1}
-                  </div>
-                  <div>
-                    <div className="mb-0.5 text-sm leading-[1.5] font-semibold text-text">
-                      {step.title}
-                    </div>
-                    <div className="text-[13px] leading-[1.5] text-text-dim">{step.body}</div>
-                  </div>
-                </li>
-              ))}
-            </ol>
-
-            <div className="mt-1 flex flex-wrap items-center justify-center gap-3">
-              <Button
-                type="button"
-                disabled={busy}
-                onClick={onConnect}
-                className="h-auto gap-0 px-7 py-3.5 text-[13px] leading-5 font-semibold uppercase tracking-[0.06em] disabled:opacity-70"
-              >
-                {busy ? (
-                  <>
-                    <Spinner /> {reconnecting ? 'Reconnecting…' : 'Connecting…'}
-                  </>
-                ) : (
-                  'Connect device'
-                )}
-              </Button>
-              {onExploreSimulation && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={busy}
-                  onClick={onExploreSimulation}
-                  className="h-auto gap-0 bg-transparent px-[22px] py-[13px] text-xs leading-5 font-medium tracking-[0.04em] text-text-dim disabled:opacity-60"
-                >
-                  Explore with sample data
-                </Button>
-              )}
-            </div>
-
-            {lastError ? (
-              <div className="border border-destructive bg-bg-inset px-3.5 py-2.5 text-center text-[13px] text-destructive">
-                {lastError}
-              </div>
-            ) : null}
-          </>
-        )}
-
-        {footerLinks ? (
-          <footer className="mt-2 flex items-center justify-center gap-2 border-t border-border pt-2">
-            {footerLinks}
-          </footer>
-        ) : null}
-      </div>
-    </div>
-  )
-}
-
-const UnsupportedBrowserCard = () => (
-  <div
-    className="border border-border bg-bg-inset px-5 py-[18px] text-left text-[13px] text-text-dim"
-    role="alert"
-  >
-    <div className="mb-1.5 font-semibold text-text">
-      WebSerial isn&apos;t available in this browser
-    </div>
-    <div className="mb-3 text-[13px]">
-      CANShift Tuner needs the WebSerial API to talk to the dash over USB. Open this page in one of
-      the supported browsers — or copy the URL and paste it into the new one:
-    </div>
-    <ul className="m-0 list-none p-0 text-[13px]">
-      {SUPPORTED_BROWSERS.map((b) => (
-        <li key={b} className="py-0.5">
-          · {b}
-        </li>
-      ))}
-    </ul>
+}: WelcomeScreenProps) => (
+  <div className={WRAPPER}>
+    <ConnectColumn
+      supported={supported}
+      busy={busy}
+      reconnecting={reconnecting}
+      lastError={lastError}
+      onConnect={onConnect}
+      onExploreSimulation={onExploreSimulation}
+      footerLinks={footerLinks}
+    />
+    <BenchPanel
+      entries={entries}
+      now={now}
+      onResume={onResume}
+      onNewConfig={onNewConfig}
+      onStartFromPageSet={onStartFromPageSet}
+      onExport={onExport}
+      onImport={onImport}
+    />
   </div>
 )

--- a/src/components/welcome/BenchPanel.tsx
+++ b/src/components/welcome/BenchPanel.tsx
@@ -1,0 +1,84 @@
+import type { BenchEntry } from '../../lib/bench-entry'
+import { BENCH_ROW, BenchRow } from './BenchRow'
+import { DefaultsPicker } from './DefaultsPicker'
+
+export interface BenchPanelProps {
+  entries: BenchEntry[]
+  now: number
+  onResume: (id: string) => void
+  onNewConfig: () => void
+  onStartFromPageSet: (pageSetId: string) => void
+  onExport: () => void
+  onImport: () => void
+}
+
+const TOOLBAR = [
+  'flex h-10 shrink-0 items-center justify-between',
+  'border-b-2 border-solid border-brand-neutral-300 px-[22px]',
+  'font-mono text-[10.5px] uppercase tracking-[0.14em] text-brand-neutral-600',
+].join(' ')
+
+const FOOTER = [
+  'flex shrink-0 flex-wrap items-center justify-between gap-3',
+  'border-t-2 border-solid border-brand-neutral-300 py-3.5 pl-[22px] pr-20',
+  'font-mono text-[11px] text-brand-neutral-600',
+].join(' ')
+
+const FOOTER_ACTION = [
+  'text-brand-accent underline underline-offset-2',
+  'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+  'focus-visible:outline-brand-accent',
+].join(' ')
+
+export const BenchPanel = ({
+  entries,
+  now,
+  onResume,
+  onNewConfig,
+  onStartFromPageSet,
+  onExport,
+  onImport,
+}: BenchPanelProps) => (
+  <section className="flex min-h-0 flex-col overflow-hidden bg-brand-neutral-100">
+    <div className={TOOLBAR}>
+      <span>{entries.length === 0 ? 'Start from a default' : 'Your bench'}</span>
+      <span>
+        {entries.length} config{entries.length === 1 ? '' : 's'} · local
+      </span>
+    </div>
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      {entries.length === 0 ? (
+        <DefaultsPicker onStartFromPageSet={onStartFromPageSet} />
+      ) : (
+        <>
+          {entries.map((entry) => (
+            <BenchRow key={entry.id} entry={entry} now={now} onResume={onResume} />
+          ))}
+          <button type="button" className={BENCH_ROW} onClick={onNewConfig}>
+            <span className="text-[26px] leading-none text-brand-accent">+</span>
+            <span className="flex min-w-0 flex-col gap-1.5">
+              <span className="text-[15.5px] font-extrabold text-brand-text">
+                Start a new config
+              </span>
+              <span className="font-mono text-[11.5px] leading-[1.5] text-brand-neutral-600">
+                from a blank dash, or from one of the six defaults
+              </span>
+            </span>
+            <span />
+          </button>
+        </>
+      )}
+    </div>
+    <div className={FOOTER}>
+      <span>
+        Configs live in this browser.{' '}
+        <button type="button" className={FOOTER_ACTION} onClick={onExport}>
+          Export ↗
+        </button>
+      </span>
+      <button type="button" className={FOOTER_ACTION} onClick={onImport}>
+        Import a config file
+      </button>
+    </div>
+  </section>
+)

--- a/src/components/welcome/BenchRow.tsx
+++ b/src/components/welcome/BenchRow.tsx
@@ -1,0 +1,41 @@
+import type { BenchEntry } from '../../lib/bench-entry'
+import { formatRelativeDate } from '../../lib/bench-entry'
+import { ConfigThumbnail } from './ConfigThumbnail'
+
+export interface BenchRowProps {
+  entry: BenchEntry
+  now: number
+  onResume: (id: string) => void
+}
+
+export const BENCH_ROW = [
+  'grid w-full grid-cols-[100px_minmax(0,1fr)_auto] items-center gap-5',
+  'border-b border-solid border-brand-neutral-300 px-[22px] py-[18px] text-left',
+  'transition-colors hover:bg-brand-neutral-200',
+  'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+  'focus-visible:outline-brand-accent',
+].join(' ')
+
+export const BenchRow = ({ entry, now, onResume }: BenchRowProps) => (
+  <button
+    type="button"
+    className={BENCH_ROW}
+    onClick={() => {
+      onResume(entry.id)
+    }}
+  >
+    <ConfigThumbnail theme={entry.theme} kicker={entry.kicker} pageCount={entry.pageCount} />
+    <span className="flex min-w-0 flex-col gap-1.5">
+      <span className="truncate text-[15.5px] font-extrabold text-brand-text">{entry.name}</span>
+      <span className="font-mono text-[11.5px] leading-[1.5] text-brand-neutral-600">
+        {entry.ecuLabel} · {entry.signalCount} signals
+      </span>
+    </span>
+    <span className="flex flex-col items-end gap-1.5 whitespace-nowrap">
+      <span className="font-mono text-[11.5px] text-brand-neutral-600">
+        {formatRelativeDate(entry.updatedAt, now)}
+      </span>
+      <span className="font-mono text-[11.5px] text-brand-accent">RESUME →</span>
+    </span>
+  </button>
+)

--- a/src/components/welcome/ConfigThumbnail.tsx
+++ b/src/components/welcome/ConfigThumbnail.tsx
@@ -1,0 +1,47 @@
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+import type { BenchTheme } from '../../lib/bench-entry'
+
+export interface ConfigThumbnailProps {
+  theme: BenchTheme
+  kicker: string
+  pageCount: number
+}
+
+const frame = cva('flex h-[70px] w-[100px] shrink-0 flex-col justify-between px-1.5 py-1', {
+  variants: {
+    theme: {
+      night: 'bg-[#121212] text-white',
+      day: 'bg-[#DDDDDD] text-black',
+    },
+  },
+  defaultVariants: { theme: 'night' },
+})
+
+const rule = cva('block w-full', {
+  variants: {
+    theme: { night: 'bg-white', day: 'bg-black' },
+    weight: { top: 'h-0.5', bottom: 'h-px opacity-40' },
+  },
+  defaultVariants: { theme: 'night', weight: 'top' },
+})
+
+const META = 'font-mono text-[8px] whitespace-nowrap uppercase tracking-[0.08em] opacity-60'
+
+const VALUE = [
+  'overflow-hidden text-ellipsis whitespace-nowrap',
+  'font-mono text-[17px] leading-none',
+].join(' ')
+
+export const ConfigThumbnail = ({ theme, kicker, pageCount }: ConfigThumbnailProps) => (
+  <div className={cn(frame({ theme }))} aria-hidden="true">
+    <span className={cn(rule({ theme, weight: 'top' }))} />
+    <span className={VALUE}>{kicker}</span>
+    <span className="flex flex-col gap-0.5">
+      <span className={cn(rule({ theme, weight: 'bottom' }))} />
+      <span className={META}>
+        {pageCount} {pageCount === 1 ? 'page' : 'pages'} · {theme}
+      </span>
+    </span>
+  </div>
+)

--- a/src/components/welcome/ConnectColumn.tsx
+++ b/src/components/welcome/ConnectColumn.tsx
@@ -1,0 +1,141 @@
+import type { ReactNode } from 'react'
+import { Spinner } from '@/components/ui/spinner'
+
+export interface ConnectColumnProps {
+  supported: boolean
+  busy: boolean
+  reconnecting: boolean
+  lastError: string | null
+  onConnect: (() => void) | undefined
+  onExploreSimulation: (() => void) | undefined
+  footerLinks: ReactNode
+}
+
+const STEPS = [
+  { title: 'Plug the dash in', body: 'USB-C, straight into the computer. No hub.' },
+  { title: 'Pick the port', body: 'The browser asks which USB port to use.' },
+  { title: 'Start tuning', body: 'Edit pages and widgets — the dash updates as you type.' },
+]
+
+const SUPPORTED_BROWSERS = ['Chrome 89+', 'Edge 89+', 'Brave', 'Opera']
+
+const KICKER = 'font-mono text-[10.5px] uppercase tracking-[0.2em] text-brand-neutral-600'
+
+const FOCUS = [
+  'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+  'focus-visible:outline-brand-accent',
+].join(' ')
+
+const PRIMARY_ACTION = [
+  'bg-brand-accent px-[22px] py-[15px] text-left text-[13px] font-extrabold uppercase',
+  'tracking-[0.1em] whitespace-nowrap text-white hover:bg-brand-accent-600',
+  'disabled:opacity-70',
+  FOCUS,
+].join(' ')
+
+const SECONDARY_ACTION = [
+  'border border-solid border-brand-neutral-400 bg-transparent px-[22px] py-[15px]',
+  'text-left text-[13px] font-bold whitespace-nowrap text-brand-text',
+  'hover:bg-brand-neutral-200 disabled:opacity-60',
+  FOCUS,
+].join(' ')
+
+export const ConnectColumn = ({
+  supported,
+  busy,
+  reconnecting,
+  lastError,
+  onConnect,
+  onExploreSimulation,
+  footerLinks,
+}: ConnectColumnProps) => (
+  <section className="flex min-h-0 flex-col overflow-y-auto border-r-2 border-solid border-brand-neutral-300 px-10 pt-11">
+    <p className={`${KICKER} border-b-2 border-solid border-brand-neutral-300 pb-3.5`}>
+      No device connected
+    </p>
+    <h1 className="mt-9 text-[38px] leading-[1.04] font-extrabold tracking-[-0.035em] text-brand-text">
+      Configure your dash, live.
+    </h1>
+    <p className="mt-5 max-w-[42ch] text-[15px] leading-[1.6] text-brand-neutral-700">
+      Pages, CAN bindings and OBD-II polling, edited in the browser against the dash on your desk.
+      Nothing to install, nothing to deploy.
+    </p>
+
+    {supported ? (
+      <div className="mt-8 flex flex-wrap gap-px">
+        <button type="button" disabled={busy} onClick={onConnect} className={PRIMARY_ACTION}>
+          {busy ? (
+            <>
+              <Spinner size="sm" />
+              {reconnecting ? 'Reconnecting…' : 'Connecting…'}
+            </>
+          ) : (
+            'Connect device'
+          )}
+        </button>
+        {onExploreSimulation && (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onExploreSimulation}
+            className={SECONDARY_ACTION}
+          >
+            Explore with sample data
+          </button>
+        )}
+      </div>
+    ) : (
+      <UnsupportedBrowserPanel />
+    )}
+
+    {lastError !== null && (
+      <p className="mt-4 border border-solid border-destructive px-3.5 py-2.5 text-[13px] text-destructive">
+        {lastError}
+      </p>
+    )}
+
+    <p className={`${KICKER} mt-11 border-b border-solid border-brand-neutral-300 pb-2.5`}>
+      To connect
+    </p>
+    <ol className="m-0 list-none p-0">
+      {STEPS.map((step, index) => (
+        <li
+          key={step.title}
+          className="grid grid-cols-[16px_minmax(0,1fr)] gap-x-4 border-b border-solid border-brand-neutral-300 py-4"
+        >
+          <span className="font-mono text-[12px] text-brand-neutral-600">0{index + 1}</span>
+          <span className="flex flex-col gap-1">
+            <span className="text-[14px] font-bold text-brand-text">{step.title}</span>
+            <span className="text-[13.5px] leading-[1.5] text-brand-neutral-700">{step.body}</span>
+          </span>
+        </li>
+      ))}
+    </ol>
+
+    {footerLinks !== undefined && (
+      <footer className="mt-auto flex flex-wrap items-center gap-2 py-8 font-mono text-[11px]">
+        {footerLinks}
+      </footer>
+    )}
+  </section>
+)
+
+const UnsupportedBrowserPanel = () => (
+  <div
+    role="alert"
+    className="mt-8 border border-solid border-brand-neutral-400 px-5 py-[18px] text-[13px] text-brand-neutral-700"
+  >
+    <p className="font-bold text-brand-text">WebSerial isn&apos;t available in this browser</p>
+    <p className="mt-1.5">
+      CANShift Tuner needs the WebSerial API to talk to the dash over USB. Open this page in one of
+      the supported browsers — or copy the URL and paste it into the new one:
+    </p>
+    <ul className="m-0 mt-3 list-none p-0 font-mono text-[12px]">
+      {SUPPORTED_BROWSERS.map((browser) => (
+        <li key={browser} className="py-0.5">
+          · {browser}
+        </li>
+      ))}
+    </ul>
+  </div>
+)

--- a/src/components/welcome/DefaultsPicker.tsx
+++ b/src/components/welcome/DefaultsPicker.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react'
+import { DEFAULT_SIM_CONFIG } from '../../config/default-sim-config'
+import { benchPreviewOfPage } from '../../lib/bench-entry'
+import { BENCH_ROW } from './BenchRow'
+import { ConfigThumbnail } from './ConfigThumbnail'
+
+export interface DefaultsPickerProps {
+  onStartFromPageSet: (pageSetId: string) => void
+}
+
+const DEFAULT_PAGE_COUNT = 1
+
+const prettify = (id: string): string => id.charAt(0).toUpperCase() + id.slice(1)
+
+export const DefaultsPicker = ({ onStartFromPageSet }: DefaultsPickerProps) => {
+  const defaults = useMemo(
+    () =>
+      DEFAULT_SIM_CONFIG.pages.map((page) => ({
+        id: page.id,
+        label: prettify(page.id),
+        widgetCount: page.widgets.length,
+        preview: benchPreviewOfPage(page),
+      })),
+    []
+  )
+
+  return (
+    <>
+      {defaults.map((option) => (
+        <button
+          key={option.id}
+          type="button"
+          className={BENCH_ROW}
+          onClick={() => {
+            onStartFromPageSet(option.id)
+          }}
+        >
+          <ConfigThumbnail
+            theme={option.preview.theme}
+            kicker={option.preview.kicker}
+            pageCount={DEFAULT_PAGE_COUNT}
+          />
+          <span className="flex min-w-0 flex-col gap-1.5">
+            <span className="text-[15.5px] font-extrabold text-brand-text">{option.label}</span>
+            <span className="font-mono text-[11.5px] leading-[1.5] text-brand-neutral-600">
+              {option.widgetCount} widgets · one page to start from
+            </span>
+          </span>
+          <span className="font-mono text-[11.5px] whitespace-nowrap text-brand-accent">
+            START →
+          </span>
+        </button>
+      ))}
+    </>
+  )
+}

--- a/src/hooks/useBenchEntries.ts
+++ b/src/hooks/useBenchEntries.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react'
+import { useProjectStore } from '../stores/project/project.store'
+import { readProject } from '../stores/project/storage'
+import { benchEntryFrom, type BenchEntry } from '../lib/bench-entry'
+import { ecuLabelForKey } from '../utils/ecu-label'
+import { useCatalogueIndex } from './useCatalogueIndex'
+
+export const useBenchEntries = (): BenchEntry[] => {
+  const projects = useProjectStore((s) => s.projects)
+  const catalogue = useCatalogueIndex()
+
+  return useMemo(
+    () =>
+      projects.flatMap((meta) => {
+        const project = readProject(meta.id)
+        if (!project) return []
+        return [benchEntryFrom(project, meta, ecuLabelForKey(project.ecuProfileKey, catalogue))]
+      }),
+    [projects, catalogue]
+  )
+}

--- a/src/hooks/useCatalogueIndex.ts
+++ b/src/hooks/useCatalogueIndex.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import { errorMessage } from '../lib/error-message'
+import { useLogStore } from '../stores/log.store'
+
+export interface CatalogueIndexEntry {
+  id: string
+  vendor: string
+  label: string
+}
+
+interface CatalogueManifest {
+  entries: CatalogueIndexEntry[]
+}
+
+export type CatalogueIndex = ReadonlyMap<string, string>
+
+const CATALOGUE_URL = '/ecu-catalogue/index.json'
+
+const EMPTY_INDEX: CatalogueIndex = new Map()
+
+export const useCatalogueIndex = (): CatalogueIndex => {
+  const [labels, setLabels] = useState<CatalogueIndex>(EMPTY_INDEX)
+  const log = useLogStore((s) => s.push)
+
+  useEffect(() => {
+    let cancelled = false
+    void fetch(CATALOGUE_URL)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${String(res.status)}`)
+        return res.json() as Promise<CatalogueManifest>
+      })
+      .then((manifest) => {
+        if (cancelled) return
+        setLabels(new Map(manifest.entries.map((entry) => [entry.id, entry.label])))
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setLabels(EMPTY_INDEX)
+        log('warn', `ECU catalogue index unavailable — ${errorMessage(err)}`)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [log])
+
+  return labels
+}

--- a/src/hooks/useProjectFileActions.ts
+++ b/src/hooks/useProjectFileActions.ts
@@ -1,0 +1,51 @@
+import { useRef, type ChangeEvent } from 'react'
+import { useProjectStore } from '../stores/project/project.store'
+import { useLogStore } from '../stores/log.store'
+import { downloadProjectFile, readProjectFileText } from '../lib/project-file'
+
+export interface ProjectFileActions {
+  fileInputRef: React.RefObject<HTMLInputElement | null>
+  exportProjectFile: (id: string | null, name: string) => void
+  openImportPicker: () => void
+  handleImportChange: (event: ChangeEvent<HTMLInputElement>) => Promise<void>
+}
+
+export const useProjectFileActions = (): ProjectFileActions => {
+  const importProject = useProjectStore((s) => s.importProject)
+  const exportProject = useProjectStore((s) => s.exportProject)
+  const log = useLogStore((s) => s.push)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const exportProjectFile = (id: string | null, name: string) => {
+    if (id === null) return
+    const json = exportProject(id)
+    if (json === null) {
+      log('error', 'Could not export the project.')
+      return
+    }
+    downloadProjectFile(name, json)
+    log('info', `Exported “${name}”.`)
+  }
+
+  const openImportPicker = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleImportChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) return
+    let raw: string
+    try {
+      raw = await readProjectFileText(file)
+    } catch {
+      log('error', 'Could not read the selected file.')
+      return
+    }
+    const result = importProject(raw)
+    if (result.ok) log('success', `Imported “${result.name}”.`)
+    else log('error', result.error)
+  }
+
+  return { fileInputRef, exportProjectFile, openImportPicker, handleImportChange }
+}

--- a/src/lib/bench-entry.test.ts
+++ b/src/lib/bench-entry.test.ts
@@ -1,0 +1,65 @@
+import type { PageConfig, Widget } from '@canshift/core'
+import { describe, expect, it } from 'vitest'
+import { benchPreviewOfPage, formatRelativeDate } from './bench-entry'
+
+const NOW = Date.parse('2026-08-12T12:00:00Z')
+const ago = (ms: number): string => new Date(NOW - ms).toISOString()
+const DAY = 86_400_000
+
+const widget = (type: string, signal: string): Widget =>
+  ({ id: `${type}-1`, type, signal, layout: {}, style: {}, config: { type } }) as unknown as Widget
+
+const page = (backgroundColor: string, widgets: Widget[], id = 'street'): PageConfig =>
+  ({ id, backgroundColor, widgets }) as unknown as PageConfig
+
+describe('formatRelativeDate', () => {
+  it('collapses anything under an hour to "just now"', () => {
+    expect(formatRelativeDate(ago(59 * 60_000), NOW)).toBe('just now')
+  })
+
+  it('separates today from yesterday at the day boundary', () => {
+    expect(formatRelativeDate(ago(23 * 3_600_000), NOW)).toBe('today')
+    expect(formatRelativeDate(ago(DAY), NOW)).toBe('yesterday')
+  })
+
+  it('counts days up to a month, then months', () => {
+    expect(formatRelativeDate(ago(4 * DAY), NOW)).toBe('4 days ago')
+    expect(formatRelativeDate(ago(45 * DAY), NOW)).toBe('last month')
+    expect(formatRelativeDate(ago(200 * DAY), NOW)).toBe('6 months ago')
+    expect(formatRelativeDate(ago(400 * DAY), NOW)).toBe('over a year ago')
+  })
+
+  it('never reports a future timestamp as negative', () => {
+    expect(formatRelativeDate(new Date(NOW + DAY).toISOString(), NOW)).toBe('just now')
+  })
+
+  it('degrades on an unparseable timestamp instead of printing NaN', () => {
+    expect(formatRelativeDate('not-a-date', NOW)).toBe('—')
+  })
+})
+
+describe('benchPreviewOfPage', () => {
+  it('reads the theme from the page ground, not from a stored flag', () => {
+    expect(benchPreviewOfPage(page('#121212', [])).theme).toBe('night')
+    expect(benchPreviewOfPage(page('#DDDDDD', [])).theme).toBe('day')
+  })
+
+  it('takes the kicker from the first bound value widget', () => {
+    const preview = benchPreviewOfPage(
+      page('#121212', [widget('button', 'flag_mil'), widget('gauge', 'speed_kph')])
+    )
+    expect(preview.kicker).toBe('SPEED')
+  })
+
+  it('skips a value widget that is bound to nothing', () => {
+    const preview = benchPreviewOfPage(
+      page('#121212', [widget('gauge', ''), widget('gauge', 'rpm')])
+    )
+    expect(preview.kicker).toBe('RPM')
+  })
+
+  it('falls back to the page name when a page carries no value widget', () => {
+    const preview = benchPreviewOfPage(page('#121212', [widget('button', 'flag_mil')], 'controls'))
+    expect(preview.kicker).toBe('CONTROLS')
+  })
+})

--- a/src/lib/bench-entry.ts
+++ b/src/lib/bench-entry.ts
@@ -1,0 +1,97 @@
+import type { DashboardConfig, PageConfig, Project, ProjectMeta } from '@canshift/core'
+import { displayLabelForSignal } from '../utils/signal-labels'
+
+export type BenchTheme = 'day' | 'night'
+
+export interface BenchEntry {
+  id: string
+  name: string
+  ecuLabel: string
+  signalCount: number
+  pageCount: number
+  theme: BenchTheme
+  kicker: string
+  updatedAt: string
+}
+
+const NIGHT_LUMINANCE_MAX = 0.5
+const VALUE_WIDGET_TYPES = new Set(['gauge', 'gear', 'timer'])
+
+const relativeLuminance = (hex: string): number => {
+  const value = hex.replace('#', '')
+  if (value.length !== 6) return 0
+  const channel = (offset: number): number => parseInt(value.slice(offset, offset + 2), 16) / 255
+  return 0.2126 * channel(0) + 0.7152 * channel(2) + 0.0722 * channel(4)
+}
+
+const defaultPage = (dashboard: DashboardConfig): PageConfig | null => {
+  const match = dashboard.pages.find((page) => page.id === dashboard.defaultPageId)
+  return match ?? dashboard.pages[0] ?? null
+}
+
+const themeOf = (page: PageConfig | null): BenchTheme => {
+  if (!page) return 'night'
+  return relativeLuminance(page.backgroundColor) > NIGHT_LUMINANCE_MAX ? 'day' : 'night'
+}
+
+const kickerOf = (page: PageConfig | null): string => {
+  if (!page) return '—'
+  const widget = page.widgets.find(
+    (candidate) => VALUE_WIDGET_TYPES.has(candidate.type) && candidate.signal !== ''
+  )
+  if (!widget) return page.id.toUpperCase()
+  return displayLabelForSignal(widget.signal).toUpperCase()
+}
+
+export interface BenchPreview {
+  theme: BenchTheme
+  kicker: string
+}
+
+export const benchPreviewOfPage = (page: PageConfig | null): BenchPreview => ({
+  theme: themeOf(page),
+  kicker: kickerOf(page),
+})
+
+export const benchEntryFrom = (
+  project: Project,
+  meta: ProjectMeta,
+  ecuLabel: string
+): BenchEntry => {
+  const dashboard = project.dashboard as DashboardConfig
+  const preview = benchPreviewOfPage(defaultPage(dashboard))
+  return {
+    id: meta.id,
+    name: meta.name,
+    ecuLabel,
+    signalCount: project.signals.length,
+    pageCount: dashboard.pages.length,
+    theme: preview.theme,
+    kicker: preview.kicker,
+    updatedAt: meta.updatedAt,
+  }
+}
+
+const MINUTE_MS = 60_000
+const HOUR_MS = 60 * MINUTE_MS
+const DAY_MS = 24 * HOUR_MS
+const MONTH_DAYS = 30
+const YEAR_DAYS = 365
+
+export const formatRelativeDate = (iso: string, now: number): string => {
+  const then = Date.parse(iso)
+  if (Number.isNaN(then)) return '—'
+  const elapsed = Math.max(0, now - then)
+  if (elapsed < HOUR_MS) return 'just now'
+  if (elapsed < DAY_MS) return 'today'
+  const days = Math.floor(elapsed / DAY_MS)
+  if (days === 1) return 'yesterday'
+  if (days < MONTH_DAYS) return `${String(days)} days ago`
+  if (days < YEAR_DAYS) return relativeMonths(days)
+  return 'over a year ago'
+}
+
+const relativeMonths = (days: number): string => {
+  const months = Math.floor(days / MONTH_DAYS)
+  return months === 1 ? 'last month' : `${String(months)} months ago`
+}

--- a/src/routes/WelcomeRoute.tsx
+++ b/src/routes/WelcomeRoute.tsx
@@ -1,15 +1,22 @@
-import type { CSSProperties } from 'react'
-import { Link, Navigate } from 'react-router-dom'
+import { useState } from 'react'
+import { Link, Navigate, useNavigate } from 'react-router-dom'
+import { DEFAULT_SCREEN_PROFILE_ID } from '@canshift/core'
 import { WelcomeScreen } from '../components/shell/WelcomeScreen'
+import { NewProjectWizard } from '../components/project/NewProjectWizard'
 import { useConnectionStore } from '../stores/connection.store'
 import { useDeviceStore } from '../stores/device.store'
+import { useProjectStore } from '../stores/project/project.store'
+import { useLogStore } from '../stores/log.store'
+import { useBenchEntries } from '../hooks/useBenchEntries'
+import { useProjectFileActions } from '../hooks/useProjectFileActions'
+import { buildNewProjectDashboard } from '../lib/new-project'
+import { PROJECT_FILE_ACCEPT } from '../lib/project-file'
 import { humanizeTransportError } from '../transport/humanize-transport-error'
 
 const SUPPORT_EMAIL = 'support@canshift.app'
 
-const isWebSerialAvailable = (): boolean => {
-  return typeof navigator !== 'undefined' && 'serial' in navigator
-}
+const isWebSerialAvailable = (): boolean =>
+  typeof navigator !== 'undefined' && 'serial' in navigator
 
 const buildSupportMailto = (lastError: string | null): string => {
   const subject = encodeURIComponent('CANShift Tuner — issue report')
@@ -30,9 +37,10 @@ const buildSupportMailto = (lastError: string | null): string => {
     '',
     'Thanks!',
   ]
-  const body = encodeURIComponent(lines.join('\n'))
-  return `mailto:${SUPPORT_EMAIL}?subject=${subject}&body=${body}`
+  return `mailto:${SUPPORT_EMAIL}?subject=${subject}&body=${encodeURIComponent(lines.join('\n'))}`
 }
+
+const LINK = 'text-brand-neutral-600 no-underline hover:text-brand-accent'
 
 const WelcomeRoute = () => {
   const status = useConnectionStore((s) => s.status)
@@ -40,59 +48,100 @@ const WelcomeRoute = () => {
   const connect = useConnectionStore((s) => s.connect)
   const simulationMode = useDeviceStore((s) => s.simulationMode)
   const enterSimulation = useDeviceStore((s) => s.enterSimulation)
+  const switchProject = useProjectStore((s) => s.switchProject)
+  const createProject = useProjectStore((s) => s.createProject)
+  const log = useLogStore((s) => s.push)
+  const navigate = useNavigate()
+  const entries = useBenchEntries()
+  const { fileInputRef, exportProjectFile, openImportPicker, handleImportChange } =
+    useProjectFileActions()
+  const [wizardOpen, setWizardOpen] = useState(false)
+  const [now] = useState(() => Date.now())
 
   if (status === 'connected' || simulationMode) {
     return <Navigate to="/dashboard" replace />
   }
 
-  const busy = status === 'connecting' || status === 'reconnecting'
-  const supported = isWebSerialAvailable()
+  const resume = (id: string) => {
+    if (!switchProject(id)) {
+      log('error', 'Could not open that config.')
+      return
+    }
+    void navigate('/dashboard')
+  }
+
+  const startFromPageSet = (pageSetId: string) => {
+    const name = pageSetId.charAt(0).toUpperCase() + pageSetId.slice(1)
+    createProject(
+      name,
+      buildNewProjectDashboard({
+        name,
+        targetProfile: DEFAULT_SCREEN_PROFILE_ID,
+        pageSetId,
+      })
+    )
+    void navigate('/dashboard')
+  }
+
+  const newest = entries[0] ?? null
 
   return (
-    <WelcomeScreen
-      supported={supported}
-      busy={busy}
-      reconnecting={status === 'reconnecting'}
-      lastError={lastError !== null ? humanizeTransportError(lastError) : null}
-      onConnect={() => {
-        void connect()
-      }}
-      onExploreSimulation={() => {
-        enterSimulation()
-      }}
-      footerLinks={
-        <>
-          <Link to="/about" style={linkStyle}>
-            About
-          </Link>
-          <span style={dotSeparatorStyle}>·</span>
-          <a
-            href="https://canshift.app/user-guide/install/boot-issues/"
-            target="_blank"
-            rel="noreferrer"
-            style={linkStyle}
-          >
-            Troubleshooting
-          </a>
-          <span style={dotSeparatorStyle}>·</span>
-          <a href={buildSupportMailto(lastError)} style={linkStyle}>
-            Report a problem
-          </a>
-        </>
-      }
-    />
+    <>
+      <WelcomeScreen
+        entries={entries}
+        now={now}
+        supported={isWebSerialAvailable()}
+        busy={status === 'connecting' || status === 'reconnecting'}
+        reconnecting={status === 'reconnecting'}
+        lastError={lastError !== null ? humanizeTransportError(lastError) : null}
+        onConnect={() => {
+          void connect()
+        }}
+        onExploreSimulation={() => {
+          enterSimulation()
+        }}
+        onResume={resume}
+        onNewConfig={() => {
+          setWizardOpen(true)
+        }}
+        onStartFromPageSet={startFromPageSet}
+        onExport={() => {
+          exportProjectFile(newest?.id ?? null, newest?.name ?? '')
+        }}
+        onImport={openImportPicker}
+        footerLinks={
+          <>
+            <Link to="/about" className={LINK}>
+              About
+            </Link>
+            <span className="text-brand-neutral-500">·</span>
+            <a
+              href="https://canshift.app/user-guide/install/boot-issues/"
+              target="_blank"
+              rel="noreferrer"
+              className={LINK}
+            >
+              Troubleshooting
+            </a>
+            <span className="text-brand-neutral-500">·</span>
+            <a href={buildSupportMailto(lastError)} className={LINK}>
+              Report a problem
+            </a>
+          </>
+        }
+      />
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={PROJECT_FILE_ACCEPT}
+        onChange={(event) => {
+          void handleImportChange(event)
+        }}
+        className="hidden"
+      />
+      <NewProjectWizard open={wizardOpen} onOpenChange={setWizardOpen} />
+    </>
   )
-}
-
-const linkStyle: CSSProperties = {
-  color: 'hsl(var(--text-dim))',
-  fontSize: 12,
-  textDecoration: 'none',
-}
-
-const dotSeparatorStyle: CSSProperties = {
-  color: 'hsl(var(--text-muted))',
-  fontSize: 12,
 }
 
 export default WelcomeRoute

--- a/src/utils/ecu-label.test.ts
+++ b/src/utils/ecu-label.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { ecuLabelForKey } from './ecu-label'
+
+const INDEX = new Map([['maxxecu/maxxecu_default_can.xml', 'Maxxecu Default CAN']])
+
+describe('ecuLabelForKey', () => {
+  it('names a builtin profile from the core catalogue rather than its id', () => {
+    expect(ecuLabelForKey('builtin:obd2-j1979', INDEX)).toBe('OBD-II (J1979 PIDs)')
+  })
+
+  it('uses the catalogue label when the index has loaded', () => {
+    expect(ecuLabelForKey('catalogue:maxxecu/maxxecu_default_can.xml', INDEX)).toBe(
+      'Maxxecu Default CAN'
+    )
+  })
+
+  it('degrades to the file name when the index has not loaded', () => {
+    expect(ecuLabelForKey('catalogue:maxxecu/maxxecu_default_can.xml', new Map())).toBe(
+      'Maxxecu Default Can'
+    )
+  })
+
+  it('strips the extension from an imported profile', () => {
+    expect(ecuLabelForKey('import:my_car.xml', INDEX)).toBe('my_car')
+  })
+
+  it('keeps a colon-bearing catalogue id intact instead of splitting on every colon', () => {
+    expect(ecuLabelForKey('import:weird:name.xml', INDEX)).toBe('weird:name')
+  })
+
+  it('does not throw on a key with no prefix or an unknown one', () => {
+    expect(ecuLabelForKey('generic-blank', INDEX)).toBe('Generic Blank')
+    expect(ecuLabelForKey('future:something', INDEX)).toBe('Something')
+  })
+})

--- a/src/utils/ecu-label.ts
+++ b/src/utils/ecu-label.ts
@@ -1,0 +1,24 @@
+import { ECU_PROFILES } from '@canshift/core'
+import type { CatalogueIndex } from '../hooks/useCatalogueIndex'
+import { prettyProfileKey } from './profile-key'
+
+const titleCase = (value: string): string => value.replace(/\b[a-z]/g, (char) => char.toUpperCase())
+
+const catalogueFallback = (itemId: string): string => {
+  const file = itemId.split('/').pop() ?? itemId
+  return titleCase(file.replace(/\.xml$/i, '').replace(/[-_]/g, ' '))
+}
+
+const RESOLVERS: Record<string, (rest: string, index: CatalogueIndex) => string> = {
+  builtin: (rest) => ECU_PROFILES.find((profile) => profile.id === rest)?.name ?? titleCase(rest),
+  catalogue: (rest, index) => index.get(rest) ?? catalogueFallback(rest),
+  import: (rest) => rest.replace(/\.xml$/i, ''),
+}
+
+export const ecuLabelForKey = (key: string, index: CatalogueIndex): string => {
+  const separator = key.indexOf(':')
+  if (separator === -1) return titleCase(prettyProfileKey(key))
+  const resolve = RESOLVERS[key.slice(0, separator)]
+  if (!resolve) return titleCase(prettyProfileKey(key))
+  return resolve(key.slice(separator + 1), index)
+}


### PR DESCRIPTION
Closes #162. Implements `docs/design/PROMPT_TUNER_WELCOME.md`, committed here from the design package.

The old screen was a centred landing page — brand lockup, headline, three bordered step cards, `max-w-[540px]`, `items-center`. The spec's first paragraph rules out every part of that, and replaces it with two columns whose right-hand side is the actual point: **the bench**, one row per saved config, so a returning user resumes in one click.

## Two spec fields had no data behind them

Both were decided rather than guessed, and both are recorded in #162.

**Bus rate — dropped.** The meta line in the mockup reads `MegaSquirt MS3 · 500 kbit · 46 signals`. The ECU comes from `ecuProfileKey`, the count from `Project.signals.length`, but the CAN bit rate is stored **nowhere** — not `ProjectSchema`, not `DashboardConfigSchema`, not the board config. The only bitrate in the repo is the USB serial baud in `webserial-client.ts`, a different bus entirely. Deriving it from a vendor table would print a guess as a fact, so the line is `MegaSquirt MS3 · 46 signals` until the field has a real source.

**Thumbnail value — the signal kicker, not a number.** The mockup shows `82` / `1.42` / `98`. A saved config holds bindings, not readings, and the spec forbids both rendering a dash the app is not connected to and using `- -` as a placeholder. So the thumbnail shows the kicker of the default page's first *bound* value widget — `SPEED`, `RPM`, `COOLANT` — which is real config data. The grammar the spec asks for is unchanged: 2 px top rule, one line in mono 17 px, 1 px rule at the bottom, `6 pages · night` under it, drawn in the config's own theme (`#121212`/white, `#DDDDDD`/black).

That fallback chain matters more than it looks. `controls` is a page of buttons with no value widget at all, and my first pass rendered `NO SIGNAL` — which is exactly the "the sensor went quiet" reading the spec bans, *and* it overflowed the 100 px thumbnail. It now falls back to the page name, so the Controls default reads `CONTROLS`.

## Three things the browser caught that the code review would not have

Verified against `vite preview`, because `WelcomeScreen` is unreachable on the dev server — `useSimulationBootstrap` auto-enters simulation whenever `import.meta.env.DEV`, so the route redirects to `/dashboard`.

1. **`min-w-[980px]` was on the wrong element.** The spec's app floor is 980 px for the *page*; I put it on the welcome wrapper, which sits inside a 236 px sidebar. At a 1180 px viewport the content area is 944 px, so the floor forced a horizontal scrollbar and clipped `3 CONFIGS · LOC…` and the whole `RESUME →` column. The floor is an app-level concern, not this screen's — removed.
2. **The 2 px divider is a column divider.** Stacked below 1180 px it was still drawn on the right edge of a full-width block, a vertical rule floating in the middle of nothing. It now flips to a bottom divider under the same breakpoint.
3. **The bench footer sat under the feedback bubble.** `Import a config file` is flush right, the floating bubble is bottom-right, so the control was permanently half-covered — the mockup has no bubble to collide with. The footer keeps `pr-20` to clear it.

Also `1 PAGES` → `1 page` on the defaults, which all have exactly one.

## Shape

Six components under `src/components/welcome/`, none over 90 lines: `ConnectColumn`, `BenchPanel`, `BenchRow`, `ConfigThumbnail`, `DefaultsPicker`, with `WelcomeScreen` reduced to the two-column composition. Data derivation is pure and lives in `src/lib/bench-entry.ts` — `ProjectMeta` alone is only `{ id, name, createdAt, updatedAt }`, so a row reads the full project for page count, theme, ECU key and signal count.

**`ecuLabelForKey` resolves three key shapes** — `builtin:` against core's `ECU_PROFILES`, `catalogue:` against `/ecu-catalogue/index.json`, `import:` by stripping the extension — as a `Record` of resolvers rather than a chain of `else if`. It splits on the **first** colon only; `import:weird:name.xml` is a real filename shape and `key.split(':')` would have mangled it.

**Export/import moved to a shared hook.** `ProjectSwitcher` already owned both, and the welcome footer needs both — that is the second copy, so `useProjectFileActions` now serves both call sites rather than the logic being retyped. Its `catch` also drops a `console.warn` that `CLAUDE.md` does not allow; the catch still recovers by logging through the store and returning.

`Export ↗` exports the **most recently updated** config, since there is no active project on this screen — the footer's job is "don't lose these", and the newest is the one you would reach for. Disabled-by-absence when the bench is empty.

## Verification

`npm run build` + `vite preview`, Helium, bench seeded with three configs (6-page night, 4-page night, 3-page **day**) to exercise both thumbnail themes:

| Width | Result |
| --- | --- |
| 1600 | two columns, matches the comp |
| 1280 | two columns, no wrap, footer clear |
| 1180 | stacks, divider flips to bottom, no horizontal scroll |
| 1024 | stacked, clean |
| 980 | stacked, meta line still one line — never one word per line |

Empty state captured separately: the six defaults render as pickable rows under `START FROM A DEFAULT`, each with its own kicker (`SPEED`, `RPM`, `COOLANT`, `MAP`, `GEAR`, `CONTROLS`) and the left column unchanged.

**`ProjectSwitcher` regression: 0 px** on both the closed trigger and the open dropdown, against `main` — the hook extraction changes no rendering.

No console errors on any run, either branch.

## Test plan

- `npm run typecheck`, `lint`, `format:check`, `test` (57 files, 359 tests), `build` — all green
- 15 new tests: `formatRelativeDate` boundaries including a future timestamp and an unparseable one, `benchPreviewOfPage` theme/kicker/fallback, `ecuLabelForKey` across all four key shapes plus the colon-in-filename case

## Not done here

- **The chrome in the mockup differs from ours** — it shows undo/redo, `SAVE`, `Boot & update`, `States & alerts`. The spec says header and sidebar are unchanged, so none of that is in scope.
- **`EcuCatalogueList` still fetches `index.json` inline.** The new `useCatalogueIndex` hook is the natural home for it, but rewiring `/ecu`'s loading and error states inside a welcome-screen restyle would spend that route's pixel-diff budget on an unrelated change. Left as a follow-up.