### PR TITLE
refactor(tuner): route shells to Tailwind

### DIFF
--- a/eslint-inline-style-baseline.mjs
+++ b/eslint-inline-style-baseline.mjs
@@ -44,12 +44,8 @@ export const INLINE_STYLE_BASELINE = [
   'src/components/editor/WidgetBox.tsx',
   'src/components/editor/WidgetListPanel.tsx',
   'src/components/editor/WidgetPalette.tsx',
-  'src/routes/AboutRoute.tsx',
-  'src/routes/CanBusRoute.tsx',
   'src/routes/EditorRoute.tsx',
-  'src/routes/LiveDataRoute.tsx',
   'src/routes/PageContextMenu.tsx',
   'src/routes/PageThumbnail.tsx',
   'src/routes/RightSidebar.tsx',
-  'src/routes/WelcomeRoute.tsx',
 ]

--- a/src/routes/AboutRoute.tsx
+++ b/src/routes/AboutRoute.tsx
@@ -1,22 +1,64 @@
-import type { CSSProperties, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { SCREEN_PROFILES } from '@canshift/core'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
 import { useDeviceStore } from '../stores/device.store'
 import { useObservabilityStore } from '../stores/observability.store'
 import { useConnectionStore } from '../stores/connection.store'
 import { BrandLockup } from '../components/brand/BrandLockup'
 import { Checkbox } from '../components/ui/checkbox'
 import { HeapStatsPanel } from '../components/about/HeapStatsPanel'
-import { MONO_FONT } from '../lib/typography'
+import { RouteBody } from '../components/ui/route-shell'
 
 const REPO_URL = 'https://github.com/CANShift/canshift-tuner'
 const DOCS_URL = 'https://canshift.app'
 const ISSUES_URL = 'https://github.com/CANShift/canshift-tuner/issues'
 
+type ConnectionStatus = ReturnType<typeof useConnectionStore.getState>['status']
+
+const STATUS_LABELS: Record<ConnectionStatus, string> = {
+  connected: 'Connected',
+  connecting: 'Connecting…',
+  reconnecting: 'Reconnecting…',
+  disconnected: 'Disconnected',
+}
+
+const MAIN_COLUMN = 'flex min-w-0 flex-1 flex-col gap-7 overflow-y-auto p-11 text-brand-text'
+
+const TABLE = 'max-w-[620px] border-t-2 border-solid border-brand-divider'
+
+const factRow = cva('flex justify-between gap-4 py-[13px] text-[14px]', {
+  variants: {
+    last: { true: '', false: 'border-b border-solid border-brand-neutral-300' },
+  },
+  defaultVariants: { last: false },
+})
+
+const LINK_BUTTON = [
+  'border border-solid border-brand-neutral-400 px-[22px] py-3',
+  'text-[12px] font-extrabold tracking-[0.08em] text-brand-text no-underline',
+].join(' ')
+
+const SIDE_PANEL = [
+  'w-[360px] shrink-0 overflow-y-auto',
+  'border-l-2 border-solid border-brand-divider bg-brand-neutral-100',
+].join(' ')
+
+const SIDE_HEADER = [
+  'border-b-2 border-solid border-brand-divider px-5 py-3.5',
+  'text-[10px] font-extrabold tracking-[0.2em] text-brand-neutral-600',
+].join(' ')
+
+const DIAGNOSTICS_ROW = [
+  'flex max-w-[520px] cursor-pointer items-start gap-2.5',
+  'text-[12px] leading-[1.5] text-brand-neutral-600',
+].join(' ')
+
 const DiagnosticsToggle = () => {
   const enabled = useObservabilityStore((s) => s.enabled)
   const setEnabled = useObservabilityStore((s) => s.setEnabled)
   return (
-    <label style={diagnosticsRowStyle}>
+    <label className={DIAGNOSTICS_ROW}>
       <Checkbox
         checked={enabled}
         onCheckedChange={(checked) => {
@@ -48,11 +90,11 @@ const AboutRoute = () => {
   const panels = SCREEN_PROFILES.map((p) => p.name).join(' · ')
 
   return (
-    <div style={containerStyle}>
-      <div style={mainColumnStyle}>
+    <RouteBody className="overflow-hidden">
+      <div className={MAIN_COLUMN}>
         <BrandLockup height={72} withBaseline />
 
-        <div style={tableStyle}>
+        <div className={TABLE}>
           <FactRow label="Tuner" value={`${tunerVersion} — web`} />
           <FactRow label="Firmware on device" value={firmwareVersion ?? '—'} />
           <FactRow label="Status" value={prettyStatus(status, simulationMode)} />
@@ -61,7 +103,7 @@ const AboutRoute = () => {
           <FactRow label="Licence" value="MIT · github.com/CANShift" last />
         </div>
 
-        <div style={{ display: 'flex', gap: 12 }}>
+        <div className="flex gap-3">
           <LinkButton href={DOCS_URL} label="DOCUMENTATION" />
           <LinkButton href={REPO_URL} label="GITHUB" />
           <LinkButton href={ISSUES_URL} label="REPORT A BUG" />
@@ -70,13 +112,13 @@ const AboutRoute = () => {
         <DiagnosticsToggle />
       </div>
 
-      <aside style={sidePanelStyle}>
-        <div style={sideHeaderStyle}>DEVICE HEAP — LIVE</div>
-        <div style={{ padding: '16px 20px' }}>
+      <aside className={SIDE_PANEL}>
+        <div className={SIDE_HEADER}>DEVICE HEAP — LIVE</div>
+        <div className="px-5 py-4">
           <HeapStatsPanel history={heapStats} />
         </div>
       </aside>
-    </div>
+    </RouteBody>
   )
 }
 
@@ -87,9 +129,9 @@ interface FactRowProps {
 }
 
 const FactRow = ({ label, value, last = false }: FactRowProps) => (
-  <div style={factRowStyle(last)}>
-    <span style={{ color: 'hsl(var(--brand-neutral-600))' }}>{label}</span>
-    <span style={{ fontFamily: MONO_FONT, fontSize: 13 }}>{value}</span>
+  <div className={cn(factRow({ last }))}>
+    <span className="text-brand-neutral-600">{label}</span>
+    <span className="font-mono text-[13px]">{value}</span>
   </div>
 )
 
@@ -99,104 +141,14 @@ interface LinkButtonProps {
 }
 
 const LinkButton = ({ href, label }: LinkButtonProps) => (
-  <a
-    href={href}
-    target="_blank"
-    rel="noreferrer"
-    className="shell-link-button"
-    style={linkButtonStyle}
-  >
+  <a href={href} target="_blank" rel="noreferrer" className={cn('shell-link-button', LINK_BUTTON)}>
     {label}
   </a>
 )
 
-const prettyStatus = (
-  status: ReturnType<typeof useConnectionStore.getState>['status'],
-  simulationMode: boolean
-): string => {
+const prettyStatus = (status: ConnectionStatus, simulationMode: boolean): string => {
   if (simulationMode) return 'Simulation mode'
-  switch (status) {
-    case 'connected':
-      return 'Connected'
-    case 'connecting':
-      return 'Connecting…'
-    case 'reconnecting':
-      return 'Reconnecting…'
-    case 'disconnected':
-      return 'Disconnected'
-    default:
-      return status
-  }
-}
-
-const containerStyle: CSSProperties = {
-  flex: 1,
-  display: 'flex',
-  minHeight: 0,
-  overflow: 'hidden',
-}
-
-const mainColumnStyle: CSSProperties = {
-  flex: 1,
-  minWidth: 0,
-  padding: 44,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 28,
-  overflowY: 'auto',
-  color: 'hsl(var(--brand-text))',
-}
-
-const tableStyle: CSSProperties = {
-  maxWidth: 620,
-  borderTop: '2px solid var(--brand-divider)',
-}
-
-const factRowStyle = (last: boolean): CSSProperties => ({
-  display: 'flex',
-  justifyContent: 'space-between',
-  gap: 16,
-  padding: '13px 0',
-  borderBottom: last ? 'none' : '1px solid hsl(var(--brand-neutral-300))',
-  fontSize: 14,
-})
-
-const linkButtonStyle: CSSProperties = {
-  padding: '12px 22px',
-  border: '1px solid hsl(var(--brand-neutral-400))',
-  fontWeight: 800,
-  fontSize: 12,
-  letterSpacing: '0.08em',
-  color: 'hsl(var(--brand-text))',
-  textDecoration: 'none',
-}
-
-const sidePanelStyle: CSSProperties = {
-  width: 360,
-  flexShrink: 0,
-  borderLeft: '2px solid var(--brand-divider)',
-  background: 'hsl(var(--brand-neutral-100))',
-  overflowY: 'auto',
-}
-
-const sideHeaderStyle: CSSProperties = {
-  padding: '14px 20px',
-  borderBottom: '2px solid var(--brand-divider)',
-  fontWeight: 800,
-  fontSize: 10,
-  letterSpacing: '0.2em',
-  color: 'hsl(var(--brand-neutral-600))',
+  return STATUS_LABELS[status]
 }
 
 export default AboutRoute
-
-const diagnosticsRowStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'flex-start',
-  gap: 10,
-  maxWidth: 520,
-  fontSize: 12,
-  lineHeight: 1.5,
-  color: 'hsl(var(--brand-neutral-600))',
-  cursor: 'pointer',
-}

--- a/src/routes/CanBusRoute.tsx
+++ b/src/routes/CanBusRoute.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState } from 'react'
-import type { CSSProperties } from 'react'
 import { useCanScanner } from '../hooks/useCanScanner'
 import { CanFrameTable } from '../components/can-bus/CanFrameTable'
 import { CanScanToolbar } from '../components/can-bus/CanScanToolbar'
@@ -9,6 +8,7 @@ import { useSignalStore } from '../stores/signal.store'
 import { useLogStore } from '../stores/log.store'
 import { formatFrameIdHex, parseHexFrameId } from '../utils/frame-id'
 import { buildDraftSignal, sortFrames } from '../utils/can-frames'
+import { RoutePage } from '../components/ui/route-shell'
 
 const CanBusRoute = () => {
   const connected = useDeviceStore((s) => s.connected)
@@ -52,7 +52,7 @@ const CanBusRoute = () => {
   const canControl = connected && !simulationMode
 
   return (
-    <div style={containerStyle}>
+    <RoutePage>
       <CanScanToolbar
         status={scanner.status}
         canControl={canControl}
@@ -82,16 +82,8 @@ const CanBusRoute = () => {
         learnScores={learn?.scores ?? null}
         onPromote={promote}
       />
-    </div>
+    </RoutePage>
   )
-}
-
-const containerStyle: CSSProperties = {
-  flex: 1,
-  display: 'flex',
-  flexDirection: 'column',
-  background: 'hsl(var(--brand-chrome-bg))',
-  overflow: 'hidden',
 }
 
 export default CanBusRoute

--- a/src/routes/LiveDataRoute.tsx
+++ b/src/routes/LiveDataRoute.tsx
@@ -1,14 +1,51 @@
 import { useMemo, useState } from 'react'
-import type { CSSProperties } from 'react'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
 import { SourceBadge, type SignalSource } from '../components/live-data/SourceBadge'
 import { RouteHeader } from '../components/shell/RouteHeader'
+import { RoutePage } from '../components/ui/route-shell'
 import { useLiveSignals } from '../hooks/useLiveSignals'
 import { useSignalStore } from '../stores/signal.store'
 import { useDeviceStore } from '../stores/device.store'
 import { Input } from '../components/ui/input'
-import { MONO_FONT } from '../lib/typography'
 
 const DANGER_FRACTION = 0.9
+
+const EXPORT_BUTTON = [
+  'border border-solid border-brand-neutral-400 bg-transparent px-3.5 py-1.5',
+  'text-[11px] font-extrabold tracking-[0.08em]',
+  'text-brand-text disabled:cursor-not-allowed disabled:text-brand-neutral-500',
+].join(' ')
+
+const EMPTY = 'px-6 py-16 text-center text-[13px] text-brand-neutral-500'
+
+const GRID = 'grid flex-1 grid-cols-4 overflow-y-auto [grid-auto-rows:minmax(150px,1fr)]'
+
+const CELL = [
+  'flex min-w-0 flex-col justify-center gap-[9px] px-5 py-[18px]',
+  'border-r border-b border-solid border-brand-neutral-300',
+].join(' ')
+
+const CELL_LABEL = [
+  'overflow-hidden text-ellipsis whitespace-nowrap',
+  'text-[10px] font-extrabold tracking-[0.18em] text-brand-neutral-600',
+].join(' ')
+
+const tinted = cva('', {
+  variants: {
+    danger: { true: 'text-brand-accent', false: 'text-brand-text' },
+  },
+  defaultVariants: { danger: false },
+})
+
+const barFill = cva('h-full', {
+  variants: {
+    danger: { true: 'bg-brand-accent', false: 'bg-brand-text' },
+  },
+  defaultVariants: { danger: false },
+})
+
+const CELL_VALUE = 'font-mono text-[44px] leading-[1.1] tabular-nums'
 
 const LiveDataRoute = () => {
   const signals = useSignalStore((s) => s.signals)
@@ -50,7 +87,7 @@ const LiveDataRoute = () => {
   }
 
   return (
-    <div style={containerStyle}>
+    <RoutePage>
       <RouteHeader
         title="Live data"
         subtitle={
@@ -72,10 +109,9 @@ const LiveDataRoute = () => {
             />
             <button
               type="button"
-              className="editor-ghost-accent"
+              className={cn('editor-ghost-accent', EXPORT_BUTTON)}
               onClick={handleExport}
               disabled={signals.length === 0}
-              style={exportButtonStyle(signals.length === 0)}
             >
               EXPORT CSV
             </button>
@@ -84,35 +120,32 @@ const LiveDataRoute = () => {
       />
 
       {filteredSignals.length === 0 ? (
-        <div style={emptyStyle}>
+        <div className={EMPTY}>
           {signals.length === 0
             ? 'No signals configured. Pick an ECU profile in the Editor to see live values here.'
             : 'No signals match the current filter.'}
         </div>
       ) : (
-        <div style={gridStyle}>
+        <div className={GRID}>
           {filteredSignals.map((sig) => {
             const raw = values[sig.name]
             const range = sig.max - sig.min || 1
             const pct = raw !== undefined ? Math.max(0, Math.min(1, (raw - sig.min) / range)) : 0
             const danger = pct >= DANGER_FRACTION
-            const tint = danger ? 'hsl(var(--brand-accent))' : 'hsl(var(--brand-text))'
             return (
-              <div key={sig.name} style={cellStyle}>
-                <span style={cellLabelStyle}>{sig.name.replace(/_/g, ' ').toUpperCase()}</span>
-                <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
-                  <span style={{ ...cellValueStyle, color: tint }}>
+              <div key={sig.name} className={CELL}>
+                <span className={CELL_LABEL}>{sig.name.replace(/_/g, ' ').toUpperCase()}</span>
+                <div className="flex items-baseline gap-1.5">
+                  <span className={cn(CELL_VALUE, tinted({ danger }))}>
                     {raw !== undefined ? formatValue(raw) : '—'}
                   </span>
-                  <span style={cellUnitStyle}>{sig.unit}</span>
+                  <span className="font-mono text-[13px] text-brand-neutral-600">{sig.unit}</span>
                 </div>
-                <div style={barTrackStyle}>
+                <div className="h-1 bg-brand-neutral-300">
                   <div
-                    style={{
-                      width: `${String(Math.round(pct * 100))}%`,
-                      height: '100%',
-                      background: tint,
-                    }}
+                    className={cn(barFill({ danger }))}
+                    // eslint-disable-next-line no-inline-style/no-inline-style
+                    style={{ width: `${String(Math.round(pct * 100))}%` }}
                   />
                 </div>
               </div>
@@ -120,7 +153,7 @@ const LiveDataRoute = () => {
           })}
         </div>
       )}
-    </div>
+    </RoutePage>
   )
 }
 
@@ -130,78 +163,6 @@ const formatValue = (value: number): string =>
 const escapeCsv = (value: string): string => {
   if (/[",\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`
   return value
-}
-
-const containerStyle: CSSProperties = {
-  flex: 1,
-  display: 'flex',
-  flexDirection: 'column',
-  overflow: 'hidden',
-}
-
-const exportButtonStyle = (disabled: boolean): CSSProperties => ({
-  padding: '6px 14px',
-  background: 'none',
-  border: `1px solid ${disabled ? 'hsl(var(--brand-neutral-400))' : 'hsl(var(--brand-neutral-400))'}`,
-  fontWeight: 800,
-  fontSize: 11,
-  letterSpacing: '0.08em',
-  color: disabled ? 'hsl(var(--brand-neutral-500))' : 'hsl(var(--brand-text))',
-  cursor: disabled ? 'not-allowed' : 'pointer',
-})
-
-const emptyStyle: CSSProperties = {
-  textAlign: 'center',
-  fontSize: 13,
-  color: 'hsl(var(--brand-neutral-500))',
-  padding: '64px 24px',
-}
-
-const gridStyle: CSSProperties = {
-  flex: 1,
-  overflowY: 'auto',
-  display: 'grid',
-  gridTemplateColumns: 'repeat(4, 1fr)',
-  gridAutoRows: 'minmax(150px, 1fr)',
-}
-
-const cellStyle: CSSProperties = {
-  borderRight: '1px solid hsl(var(--brand-neutral-300))',
-  borderBottom: '1px solid hsl(var(--brand-neutral-300))',
-  padding: '18px 20px',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  gap: 9,
-  minWidth: 0,
-}
-
-const cellLabelStyle: CSSProperties = {
-  fontWeight: 800,
-  fontSize: 10,
-  letterSpacing: '0.18em',
-  color: 'hsl(var(--brand-neutral-600))',
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-}
-
-const cellValueStyle: CSSProperties = {
-  fontFamily: MONO_FONT,
-  fontSize: 44,
-  lineHeight: 1.1,
-  fontVariantNumeric: 'tabular-nums',
-}
-
-const cellUnitStyle: CSSProperties = {
-  fontFamily: MONO_FONT,
-  fontSize: 13,
-  color: 'hsl(var(--brand-neutral-600))',
-}
-
-const barTrackStyle: CSSProperties = {
-  height: 4,
-  background: 'hsl(var(--brand-neutral-300))',
 }
 
 export default LiveDataRoute


### PR DESCRIPTION
Closes the route-shaped part of #144. Three files, 24 `style=` sites → **one**, and that one is a computed bar width carrying a scoped disable. Baseline 53 → 49.

## The issue's scope was stale

#144 lists 9 files and 56 sites. Two of those numbers no longer hold:

- **`CliRoute` is already at 0** and is not on the baseline — it was converted at some point without the issue being updated. Its 7 sites do not exist.
- **`WelcomeRoute` is at 0** since #163, but was **still on the baseline** — a dead allowlist entry that would have silently re-permitted inline styles in that file. Removed here along with `CliRoute`'s.

That leaves what the issue itself already identified as genuinely route-shaped — `AboutRoute` 12, `LiveDataRoute` 11, `CanBusRoute` 1 — and 20 sites across `EditorRoute` / `RightSidebar` / `PageThumbnail` / `PageContextMenu` that #144 says belong with the editor umbrella. Those stay for #146; this PR does not touch them, so **#144 stays open** until they land there.

## One dead ternary, one dead branch

`LiveDataRoute`'s export button:

```ts
border: `1px solid ${disabled ? 'hsl(var(--brand-neutral-400))' : 'hsl(var(--brand-neutral-400))'}`
```

Both arms are the same colour. It reads like a disabled state that was designed and then abandoned; as written the border never changed. Collapsed to one `border-brand-neutral-400`, with the parts that *did* differ — text colour and cursor — expressed as `disabled:` variants driven by the button's own `disabled` attribute rather than a duplicated boolean.

`AboutRoute`'s `prettyStatus` had a `default: return status` on a `switch` over `SerialStatus`, which is exactly `'disconnected' | 'connecting' | 'connected' | 'reconnecting'` — all four already handled, so the branch was unreachable. Now a `Record<ConnectionStatus, string>` with no fallback at all.

Worth noting against #154: that PR needed `?? DISCONNECTED_VISUAL` because `noUncheckedIndexedAccess` widened its lookup. It does **not** widen here — `noUncheckedIndexedAccess` applies to index *signatures*, not to a `Record` with a finite key union, so `STATUS_LABELS[status]` is `string`. Typecheck confirms with the fallback deleted.

## `tint` was a closed set wearing a runtime string

The live grid computed `const tint = danger ? 'hsl(var(--brand-accent))' : 'hsl(var(--brand-text))'` and threaded it into two `style` objects — the value colour and the bar fill. Two states, not a computed colour, so both are `cva` variants now and neither needs a `style` prop.

The genuinely computed thing is the bar **width** (`pct` of the signal's range), and it is the single surviving inline style, scoped per the #136 discipline: `// eslint-disable-next-line no-inline-style/no-inline-style` on that property alone, so the file comes off the baseline rather than keeping a blanket exemption.

## `AboutRoute` uses `RouteBody`, not `RoutePage`

#144 says both hand-rolled routes "should end up on `RoutePage` / `RouteHeader` / `RouteBody`". `LiveDataRoute` and `CanBusRoute` are exact `RoutePage` matches. `AboutRoute` is not: its root is a **row** (`display: flex` with no `flex-direction`) with `min-height: 0`, which is `RouteBody`'s definition, not `RoutePage`'s `flex-col`. It also has no header — the page opens on the brand lockup. Forcing `RoutePage` would mean overriding the primitive back to a row and inventing a `RouteHeader` the design does not have, so it uses `RouteBody` directly. Adding a header to About is a design decision, not a Tailwind conversion.

## Verification

Pixel diff vs `main`, 1440×900 in Helium:

| Surface | Diff |
| --- | --- |
| `/about` | **0 px** |
| `/can` | **0 px** |
| `/live` | **0 px** |
| `/live` filtered to no matches (empty state) | **0 px** |

`/live` renders continuously-updating simulated values, so a cross-branch diff is only meaningful if the capture is reproducible. Measured the noise floor first — two runs **on the same branch** — and it is 0 px on all four, so the cross-branch 0 px is a real result and not an averaging artefact.

**The danger band is not reachable in simulation.** No signal sits above 90 % of its range during capture (probed the DOM: 18 value cells, 0 in accent), so the pixel diff proves nothing about the `danger` variants — which is precisely the code that changed from a runtime string to a class. Checked those by mounting the new classes next to the **old inline style objects** and diffing `getComputedStyle`:

```
OK  live value — normal     OK  bar fill — normal   OK  bar track
OK  live value — danger     OK  bar fill — danger   OK  about table
OK  export button — enabled   OK  export button — disabled (real disabled attribute)
```

One reported difference is not one: the About side panel's `border-top-color`. Tailwind's `border-brand-divider` sets the colour on all four sides where the old object set only `borderLeft` — and the top border has zero width, which is why `/about` still diffs at 0 px.

The disabled export button is also unreachable in simulation (it needs zero configured signals, and the sim ships 18), so it is in the computed-style set rather than implied.

## Test plan

- `npm run typecheck`, `lint`, `format:check`, `test` (57 files, 359 tests), `build` — all green
- Baseline 53 → 49: three files converted, two stale entries deleted
- No console errors on any capture run, either branch