### PR TITLE
refactor(tuner): widget previews, palette and widget list to Tailwind

### DIFF
--- a/eslint-inline-style-baseline.mjs
+++ b/eslint-inline-style-baseline.mjs
@@ -1,6 +1,5 @@
 export const INLINE_STYLE_BASELINE = [
   'src/components/editor/CruiseControlOverCapDialog.tsx',
-  'src/components/editor/CruiseControlPreview.tsx',
   'src/components/editor/NewPageMenu.tsx',
   'src/components/editor/property-panel/button-fields.tsx',
   'src/components/editor/property-panel/button/action-editor.tsx',
@@ -22,14 +21,4 @@ export const INLINE_STYLE_BASELINE = [
   'src/components/editor/ScreenSettingsPanel.tsx',
   'src/components/editor/ShortcutsDialog.tsx',
   'src/components/editor/UndoToast.tsx',
-  'src/components/editor/widget-previews/Button.tsx',
-  'src/components/editor/widget-previews/GaugeArc.tsx',
-  'src/components/editor/widget-previews/GaugeNumeric.tsx',
-  'src/components/editor/widget-previews/Gear.tsx',
-  'src/components/editor/widget-previews/Image.tsx',
-  'src/components/editor/widget-previews/ShiftLight.tsx',
-  'src/components/editor/widget-previews/Timer.tsx',
-  'src/components/editor/widget-previews/Warning.tsx',
-  'src/components/editor/WidgetListPanel.tsx',
-  'src/components/editor/WidgetPalette.tsx',
 ]

--- a/src/components/editor/CruiseControlPreview.tsx
+++ b/src/components/editor/CruiseControlPreview.tsx
@@ -1,5 +1,5 @@
 import type { PagePalette } from '@canshift/core'
-import { MONO_FONT, UI_FONT, UI_LABEL_TRACKING, UI_LABEL_WEIGHT } from '../../lib/typography'
+import { UI_FONT, UI_LABEL_TRACKING, UI_LABEL_WEIGHT } from '../../lib/typography'
 
 const OUTER_PAD = 6
 const CENTER_W = 100
@@ -9,6 +9,16 @@ const CORNER_R = 8
 const INNER_R = 5
 const LABEL_PAD = 10
 const STROKE_W = 2
+
+const CENTER = 'absolute box-border flex flex-col items-center justify-center'
+
+const CENTER_LABEL = [
+  'text-center font-sans font-extrabold leading-none tracking-[0.18em] text-[#888888]',
+].join(' ')
+
+const CENTER_VALUE = [
+  'whitespace-nowrap text-center font-mono font-extrabold leading-none tracking-[0.02em]',
+].join(' ')
 
 const DEMO_SET_SPEED = 0
 const SPEED_UNIT = 'km/h'
@@ -157,10 +167,7 @@ export const CruiseControlPreview = ({
   const notchH = Math.round(CENTER_H / 2 + NOTCH_MARGIN)
 
   return (
-    <div
-      style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}
-      data-testid="cruise-control-preview"
-    >
+    <div className="pointer-events-none absolute inset-0" data-testid="cruise-control-preview">
       {BUTTONS.map((btn) => {
         const box = layout[btn.corner]
         const w = box.w
@@ -178,13 +185,9 @@ export const CruiseControlPreview = ({
             width={w * scale}
             height={h * scale}
             viewBox={`0 0 ${String(w)} ${String(h)}`}
-            style={{
-              position: 'absolute',
-              left: box.x * scale,
-              top: box.y * scale,
-              overflow: 'visible',
-              opacity: 0.92,
-            }}
+            className="absolute overflow-visible opacity-[0.92]"
+            // eslint-disable-next-line no-inline-style/no-inline-style
+            style={{ left: box.x * scale, top: box.y * scale }}
             aria-label={`${btn.label} — ${btn.hint}`}
           >
             <title>{`${btn.label} — ${btn.hint}`}</title>
@@ -213,58 +216,35 @@ export const CruiseControlPreview = ({
       })}
 
       <div
+        className={CENTER}
+        // eslint-disable-next-line no-inline-style/no-inline-style
         style={{
-          position: 'absolute',
           left: layout.center.x * scale,
           top: layout.center.y * scale,
           width: layout.center.w * scale,
           height: layout.center.h * scale,
-          boxSizing: 'border-box',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
           gap: 2 * scale,
           color: palette.text,
         }}
       >
         <span
-          style={{
-            fontFamily: UI_FONT,
-            fontWeight: UI_LABEL_WEIGHT,
-            fontSize: 10 * scale,
-            color: '#888888',
-            lineHeight: 1,
-            letterSpacing: UI_LABEL_TRACKING,
-            textAlign: 'center',
-          }}
+          className={CENTER_LABEL}
+          // eslint-disable-next-line no-inline-style/no-inline-style
+          style={{ fontSize: 10 * scale }}
         >
           SET
         </span>
         <span
-          style={{
-            color: palette.text,
-            fontFamily: MONO_FONT,
-            fontWeight: 800,
-            fontSize: Math.round(40 * scale),
-            lineHeight: 1,
-            letterSpacing: '0.02em',
-            whiteSpace: 'nowrap',
-            textAlign: 'center',
-          }}
+          className={CENTER_VALUE}
+          // eslint-disable-next-line no-inline-style/no-inline-style
+          style={{ color: palette.text, fontSize: Math.round(40 * scale) }}
         >
           {DEMO_SET_SPEED}
         </span>
         <span
-          style={{
-            color: '#888888',
-            fontFamily: UI_FONT,
-            fontWeight: UI_LABEL_WEIGHT,
-            fontSize: Math.max(8, Math.round(10 * scale)),
-            lineHeight: 1,
-            letterSpacing: UI_LABEL_TRACKING,
-            textAlign: 'center',
-          }}
+          className={CENTER_LABEL}
+          // eslint-disable-next-line no-inline-style/no-inline-style
+          style={{ fontSize: Math.max(8, Math.round(10 * scale)) }}
         >
           {SPEED_UNIT}
         </span>

--- a/src/components/editor/WidgetListPanel.tsx
+++ b/src/components/editor/WidgetListPanel.tsx
@@ -1,6 +1,7 @@
-import type { CSSProperties } from 'react'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+import { ActiveBar } from '@/components/ui/active-bar'
 import { useDashboardStore } from '../../stores/dashboard.store'
-import { MONO_FONT } from '../../lib/typography'
 
 interface WidgetListPanelProps {
   pageId: string
@@ -16,30 +17,29 @@ const WidgetListPanel = ({ pageId }: WidgetListPanelProps) => {
   if (!page) return null
 
   return (
-    <div style={panelStyle}>
-      <div style={headerStyle}>
+    <div className={PANEL}>
+      <div className={HEADER}>
         <span>PAGE {pageIndex + 1}</span>
         <span>
           {page.widgets.length} widget{page.widgets.length === 1 ? '' : 's'}
         </span>
       </div>
-      {page.widgets.length === 0 && <div style={emptyStyle}>No widgets on this page yet.</div>}
+      {page.widgets.length === 0 && <div className={EMPTY}>No widgets on this page yet.</div>}
       {page.widgets.map((widget, index) => {
         const selected = widget.id === selectedWidgetId
         return (
           <button
             key={widget.id}
             type="button"
-            className={selected ? undefined : 'shell-nav-item'}
+            className={cn(!selected && 'shell-nav-item', row({ selected }))}
             onClick={() => {
               selectWidget(widget.id)
             }}
-            style={rowStyle(selected)}
           >
-            {selected && <span aria-hidden="true" style={selectedBarStyle} />}
-            <span style={indexStyle}>{String(index + 1).padStart(2, '0')}</span>
-            <span style={nameStyle}>{widget.type}</span>
-            <span style={signalStyle}>{widget.signal || '—'}</span>
+            {selected && <ActiveBar />}
+            <span className={INDEX}>{String(index + 1).padStart(2, '0')}</span>
+            <span className="text-[13px]">{widget.type}</span>
+            <span className={SIGNAL}>{widget.signal || '—'}</span>
           </button>
         )
       })}
@@ -47,69 +47,34 @@ const WidgetListPanel = ({ pageId }: WidgetListPanelProps) => {
   )
 }
 
-const panelStyle: CSSProperties = {
-  flex: 1,
-  overflowY: 'auto',
-}
+const PANEL = 'flex-1 overflow-y-auto'
 
-const headerStyle: CSSProperties = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  padding: '12px 16px',
-  borderBottom: '2px solid var(--brand-divider)',
-  fontWeight: 800,
-  fontSize: 10,
-  letterSpacing: '0.18em',
-  color: 'hsl(var(--brand-neutral-600))',
-}
+const HEADER = [
+  'flex justify-between px-4 py-3',
+  'border-b-2 border-solid border-brand-divider',
+  'text-[10px] font-extrabold tracking-[0.18em] text-brand-neutral-600',
+].join(' ')
 
-const emptyStyle: CSSProperties = {
-  padding: '14px 16px',
-  fontSize: 12,
-  color: 'hsl(var(--brand-neutral-500))',
-}
+const EMPTY = 'px-4 py-3.5 text-[12px] text-brand-neutral-500'
 
-const rowStyle = (selected: boolean): CSSProperties => ({
-  position: 'relative',
-  width: '100%',
-  display: 'flex',
-  alignItems: 'center',
-  gap: 9,
-  padding: '9px 16px 9px 19px',
-  background: selected ? 'hsl(var(--brand-neutral-200))' : 'none',
-  border: 0,
-  borderBottom: '1px solid hsl(var(--brand-neutral-200))',
-  cursor: 'pointer',
-  textAlign: 'left',
-  color: selected ? 'hsl(var(--brand-text))' : 'hsl(var(--brand-neutral-700))',
-})
+const row = cva(
+  [
+    'relative flex w-full cursor-pointer items-center gap-[9px] py-[9px] pl-[19px] pr-4',
+    'border-0 border-b border-solid border-brand-neutral-200 text-left',
+  ].join(' '),
+  {
+    variants: {
+      selected: {
+        true: 'bg-brand-neutral-200 text-brand-text',
+        false: 'bg-transparent text-brand-neutral-700',
+      },
+    },
+    defaultVariants: { selected: false },
+  }
+)
 
-const selectedBarStyle: CSSProperties = {
-  position: 'absolute',
-  left: 0,
-  top: 0,
-  bottom: 0,
-  width: 3,
-  background: 'hsl(var(--brand-accent))',
-}
+const INDEX = 'w-5 shrink-0 font-mono text-[10px] text-brand-neutral-600'
 
-const indexStyle: CSSProperties = {
-  width: 20,
-  flexShrink: 0,
-  fontFamily: MONO_FONT,
-  fontSize: 10,
-  color: 'hsl(var(--brand-neutral-600))',
-}
-
-const nameStyle: CSSProperties = {
-  fontSize: 13,
-}
-
-const signalStyle: CSSProperties = {
-  marginLeft: 'auto',
-  fontFamily: MONO_FONT,
-  fontSize: 10,
-  color: 'hsl(var(--brand-neutral-600))',
-}
+const SIGNAL = 'ml-auto font-mono text-[10px] text-brand-neutral-600'
 
 export default WidgetListPanel

--- a/src/components/editor/WidgetPalette.tsx
+++ b/src/components/editor/WidgetPalette.tsx
@@ -1,11 +1,11 @@
-import type { CSSProperties } from 'react'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
 import type { WidgetType, SensorIconName } from '@canshift/core'
 import { useDashboardStore } from '../../stores/dashboard.store'
 import { SensorIcon } from '../icons/SensorIcons'
 import { SIZE_TOKENS } from '../../utils/size-tokens'
 import { createId } from '../../utils/id'
 import { DEFAULT_WIDGET_STYLE, WIDGET_TYPE_DRAG_MIME } from '../../utils/default-widget'
-import { MONO_FONT } from '../../lib/typography'
 
 type PaletteWidgetType = Extract<WidgetType, 'gauge' | 'button' | 'gear' | 'shift_light'>
 
@@ -113,13 +113,13 @@ const WidgetPalette = ({ pageId }: WidgetPaletteProps) => {
   }
 
   return (
-    <div style={{ flex: 1, overflowY: 'auto', opacity: templateLocked ? 0.5 : 1 }}>
-      <div style={libraryHeaderStyle}>
+    <div className={cn(panel({ locked: templateLocked }))}>
+      <div className={HEADER}>
         <span>WIDGET LIBRARY</span>
         <span>{PALETTE_ITEMS.length}</span>
       </div>
       {templateLocked && (
-        <div style={lockedNoteStyle}>
+        <div className={LOCKED_NOTE}>
           This page uses a built-in template — widget edits are ignored. Switch the page template
           back to <em>Custom layout</em> to add widgets.
         </div>
@@ -128,7 +128,11 @@ const WidgetPalette = ({ pageId }: WidgetPaletteProps) => {
         <button
           key={item.label}
           type="button"
-          className={templateLocked ? undefined : 'shell-nav-item'}
+          className={cn(
+            !templateLocked && 'shell-nav-item',
+            ROW,
+            templateLocked && 'cursor-not-allowed'
+          )}
           onClick={() => {
             handleAdd(item)
           }}
@@ -139,13 +143,12 @@ const WidgetPalette = ({ pageId }: WidgetPaletteProps) => {
           }}
           disabled={templateLocked}
           title={templateLocked ? 'Disabled — page uses a template' : `Add ${item.label}`}
-          style={libraryRowStyle(templateLocked)}
         >
-          <span style={rowIconStyle}>
+          <span className={ROW_ICON}>
             <SensorIcon name={item.icon} size={13} color="currentColor" />
           </span>
-          <span style={{ fontSize: 13 }}>{item.label}</span>
-          <span style={rowSizeStyle}>
+          <span className="text-[13px]">{item.label}</span>
+          <span className={ROW_SIZE}>
             {item.defaultColSpan}×{item.defaultRowSpan}
           </span>
         </button>
@@ -154,51 +157,30 @@ const WidgetPalette = ({ pageId }: WidgetPaletteProps) => {
   )
 }
 
-const libraryHeaderStyle: CSSProperties = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  padding: '12px 16px',
-  borderBottom: '2px solid var(--brand-divider)',
-  fontWeight: 800,
-  fontSize: 10,
-  letterSpacing: '0.18em',
-  color: 'hsl(var(--brand-neutral-600))',
-}
-
-const lockedNoteStyle: CSSProperties = {
-  padding: '10px 16px',
-  fontSize: 11,
-  lineHeight: 1.4,
-  color: 'hsl(var(--brand-neutral-600))',
-  borderBottom: '1px solid hsl(var(--brand-neutral-200))',
-}
-
-const libraryRowStyle = (locked: boolean): CSSProperties => ({
-  width: '100%',
-  display: 'flex',
-  alignItems: 'center',
-  gap: 9,
-  padding: '9px 16px',
-  background: 'none',
-  border: 0,
-  borderBottom: '1px solid hsl(var(--brand-neutral-200))',
-  color: 'hsl(var(--brand-neutral-700))',
-  cursor: locked ? 'not-allowed' : 'pointer',
-  textAlign: 'left',
+const panel = cva('flex-1 overflow-y-auto', {
+  variants: { locked: { true: 'opacity-50', false: 'opacity-100' } },
+  defaultVariants: { locked: false },
 })
 
-const rowIconStyle: CSSProperties = {
-  width: 20,
-  flexShrink: 0,
-  display: 'inline-flex',
-  color: 'hsl(var(--brand-accent))',
-}
+const HEADER = [
+  'flex justify-between px-4 py-3',
+  'border-b-2 border-solid border-brand-divider',
+  'text-[10px] font-extrabold tracking-[0.18em] text-brand-neutral-600',
+].join(' ')
 
-const rowSizeStyle: CSSProperties = {
-  marginLeft: 'auto',
-  fontFamily: MONO_FONT,
-  fontSize: 10,
-  color: 'hsl(var(--brand-neutral-600))',
-}
+const LOCKED_NOTE = [
+  'border-b border-solid border-brand-neutral-200 px-4 py-2.5',
+  'text-[11px] leading-[1.4] text-brand-neutral-600',
+].join(' ')
+
+const ROW = [
+  'flex w-full cursor-pointer items-center gap-[9px] px-4 py-[9px]',
+  'border-0 border-b border-solid border-brand-neutral-200',
+  'bg-transparent text-left text-brand-neutral-700',
+].join(' ')
+
+const ROW_ICON = 'inline-flex w-5 shrink-0 text-brand-accent'
+
+const ROW_SIZE = 'ml-auto font-mono text-[10px] text-brand-neutral-600'
 
 export default WidgetPalette

--- a/src/components/editor/widget-preview.styles.ts
+++ b/src/components/editor/widget-preview.styles.ts
@@ -1,39 +1,27 @@
-import type { CSSProperties } from 'react'
-import { uiLabelAtSize } from '../../lib/typography'
+import { cva } from 'class-variance-authority'
+import { WIDGET_TOP_RULE } from '@canshift/core'
 
-export const BLINK_ANIM = 'canshift-blink 0.7s step-end infinite'
+export const BLINK = '[animation:canshift-blink_0.7s_step-end_infinite]'
 
 export const WIDGET_DIM_COLOR = '#888888'
 
-const KICKER_FONT_PX = 10
-const KICKER_INSET_PX = 4
+export const WIDGET_KICKER = [
+  'absolute left-1 top-1 max-w-[calc(100%-8px)]',
+  'overflow-hidden text-ellipsis whitespace-nowrap',
+  'font-sans text-[10px] font-extrabold uppercase leading-none tracking-[0.18em]',
+  'text-[#888888]',
+].join(' ')
 
-export const widgetKickerStyle: CSSProperties = {
-  ...uiLabelAtSize(KICKER_FONT_PX),
-  position: 'absolute',
-  top: KICKER_INSET_PX,
-  left: KICKER_INSET_PX,
-  color: WIDGET_DIM_COLOR,
-  lineHeight: 1,
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  maxWidth: `calc(100% - ${String(KICKER_INSET_PX * 2)}px)`,
-}
-
-export const widgetTopRuleStyle = (
-  rulePx: number,
-  color: string,
-  blink: boolean
-): CSSProperties => ({
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  right: 0,
-  height: rulePx,
-  background: color,
-  animation: blink ? BLINK_ANIM : undefined,
+export const widgetTopRule = cva('absolute left-0 right-0 top-0', {
+  variants: {
+    tier: { primary: 'h-0.5', secondary: 'h-px' },
+    blink: { true: BLINK, false: '' },
+  },
+  defaultVariants: { tier: 'secondary', blink: false },
 })
+
+export const ruleTier = (rulePx: number): 'primary' | 'secondary' =>
+  rulePx === WIDGET_TOP_RULE.primaryPx ? 'primary' : 'secondary'
 
 export const thresholdPct = (level: number, min: number, max: number): number => {
   const range = max - min || 1

--- a/src/components/editor/widget-previews/Button.tsx
+++ b/src/components/editor/widget-previews/Button.tsx
@@ -1,7 +1,19 @@
 import { memo } from 'react'
 import { WIDGET_ACCENT_COLOR, WIDGET_MUTED_COLOR } from '@canshift/core'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
-import { UI_FONT, UI_LABEL_TRACKING, UI_LABEL_WEIGHT } from '../../../lib/typography'
+
+const FRAME = [
+  'box-border flex flex-col items-start justify-center gap-0.5 overflow-visible',
+  'rounded-none border-2 border-solid px-[7px] py-1',
+  '[transition:background_0.1s,border-color_0.1s]',
+].join(' ')
+
+const KICKER = 'font-sans text-[10px] font-extrabold uppercase leading-none tracking-[0.18em]'
+
+const LABEL = [
+  'min-w-0 overflow-visible whitespace-normal break-words',
+  'text-left font-sans font-extrabold leading-none',
+].join(' ')
 
 export interface ButtonRendererProps extends BaseRendererProps {
   active: boolean
@@ -90,52 +102,24 @@ export const ButtonPreview = memo(function ButtonPreview({
 
   return (
     <div
-      style={{
-        width: w,
-        height: h,
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        justifyContent: 'center',
-        gap: 2,
-        padding: '4px 7px',
-        boxSizing: 'border-box',
-        background: bgColor,
-        border: `2px solid ${borderColor}`,
-        borderRadius: 0,
-        overflow: 'visible',
-        transition: 'background 0.1s, border-color 0.1s',
-      }}
+      className={FRAME}
+      // eslint-disable-next-line no-inline-style/no-inline-style
+      style={{ width: w, height: h, background: bgColor, borderColor }}
     >
       {showLabel && kicker !== '' && (
         <span
-          style={{
-            color: kickerColor,
-            fontSize: 10,
-            fontFamily: UI_FONT,
-            fontWeight: UI_LABEL_WEIGHT,
-            letterSpacing: UI_LABEL_TRACKING,
-            textTransform: 'uppercase',
-            lineHeight: 1,
-          }}
+          className={KICKER}
+          // eslint-disable-next-line no-inline-style/no-inline-style
+          style={{ color: kickerColor }}
         >
           {kicker}
         </span>
       )}
       {showLabel && (
         <span
-          style={{
-            color: textColor,
-            fontSize,
-            fontFamily: UI_FONT,
-            fontWeight: 800,
-            whiteSpace: 'normal',
-            wordBreak: 'break-word',
-            overflow: 'visible',
-            minWidth: 0,
-            textAlign: 'left',
-            lineHeight: 1,
-          }}
+          className={LABEL}
+          // eslint-disable-next-line no-inline-style/no-inline-style
+          style={{ color: textColor, fontSize }}
         >
           {displayText}
         </span>

--- a/src/components/editor/widget-previews/GaugeArc.tsx
+++ b/src/components/editor/widget-previews/GaugeArc.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react'
 import { GAUGE_ARC, GAUGE_TRACK_COLORS, STALE_PLACEHOLDER, deviceValueFontPx } from '@canshift/core'
-import { BLINK_ANIM, thresholdPct } from '../widget-preview.styles'
+import { cn } from '@/lib/utils'
+import { thresholdPct } from '../widget-preview.styles'
 import { effectiveValue, gaugeArcD } from './gauge-math'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
 import { MONO_FONT, UI_FONT, UI_LABEL_TRACKING, UI_LABEL_WEIGHT } from '../../../lib/typography'
@@ -13,6 +14,8 @@ export interface GaugeArcRendererProps extends BaseRendererProps {
 }
 
 const SIGNAL_LABEL_FONT_SIZE = 9
+
+const BLINK = '[animation:canshift-blink_0.7s_step-end_infinite]'
 
 export const GaugeArcPreview = memo(function GaugeArcPreview({
   widget,
@@ -51,7 +54,7 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
   const valueFontSize = cfg.big !== undefined ? deviceValueFontPx(cfg.big) : autoValueSize
 
   return (
-    <svg width={w} height={h} style={{ display: 'block', overflow: 'hidden' }} aria-hidden="true">
+    <svg width={w} height={h} className="block overflow-hidden" aria-hidden="true">
       {showRevFlash && <rect x={0} y={0} width={w} height={h} fill="#FF000022" />}
       {revFlash && (
         <circle
@@ -78,7 +81,7 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
         stroke={inkColor}
         strokeWidth={strokeW}
         strokeLinecap="butt"
-        style={{ animation: danger ? BLINK_ANIM : undefined }}
+        className={cn(danger && BLINK)}
       />
       <text
         x={cx}
@@ -89,7 +92,7 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
         fontSize={valueFontSize}
         fontWeight="900"
         fontFamily={MONO_FONT}
-        style={{ animation: danger ? BLINK_ANIM : undefined }}
+        className={cn(danger && BLINK)}
       >
         {valueStr}
       </text>
@@ -103,7 +106,7 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
         fontFamily={UI_FONT}
         fontWeight={UI_LABEL_WEIGHT}
         letterSpacing={UI_LABEL_TRACKING}
-        style={{ textTransform: 'uppercase' }}
+        className="uppercase"
       >
         {formatSignalLabel(widget.signal).toUpperCase()}
       </text>

--- a/src/components/editor/widget-previews/GaugeNumeric.tsx
+++ b/src/components/editor/widget-previews/GaugeNumeric.tsx
@@ -7,15 +7,31 @@ import {
   valueUnitFontSize,
   widgetTopRulePx,
 } from '@canshift/core'
+import { cn } from '@/lib/utils'
 import {
-  BLINK_ANIM,
+  BLINK,
   WIDGET_DIM_COLOR,
-  widgetKickerStyle,
-  widgetTopRuleStyle,
+  WIDGET_KICKER,
+  ruleTier,
+  widgetTopRule,
 } from '../widget-preview.styles'
 import { effectiveValue } from './gauge-math'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
-import { MONO_FONT } from '../../../lib/typography'
+
+const FRAME = 'relative box-border flex flex-col items-center justify-center gap-0 overflow-hidden'
+
+const BAR_TRACK = 'absolute bottom-0 left-1 right-1'
+
+const BAR_FILL = 'block h-full'
+
+const VALUE_ROW = 'flex w-full shrink-0 flex-row items-baseline justify-center gap-1'
+
+const VALUE = [
+  'overflow-hidden whitespace-nowrap text-left [text-overflow:clip]',
+  'font-mono font-extrabold leading-none',
+].join(' ')
+
+const UNIT = 'pointer-events-none whitespace-nowrap font-mono font-medium leading-none'
 
 export interface GaugeNumericRendererProps extends BaseRendererProps {
   danger: boolean
@@ -62,82 +78,47 @@ export const GaugeNumericPreview = memo(function GaugeNumericPreview({
 
   return (
     <div
-      style={{
-        width: w,
-        height: h,
-        position: 'relative',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: `${String(sigHeaderH + 2)}px 4px 2px`,
-        boxSizing: 'border-box',
-        overflow: 'hidden',
-        gap: 0,
-      }}
+      className={FRAME}
+      // eslint-disable-next-line no-inline-style/no-inline-style
+      style={{ width: w, height: h, padding: `${String(sigHeaderH + 2)}px 4px 2px` }}
     >
-      <span aria-hidden="true" style={widgetTopRuleStyle(rulePx, ruleColor, danger)} />
+      <span
+        aria-hidden="true"
+        className={cn(widgetTopRule({ tier: ruleTier(rulePx), blink: danger }))}
+        // eslint-disable-next-line no-inline-style/no-inline-style
+        style={{ background: ruleColor }}
+      />
       {showBar && (
         <span
           aria-hidden="true"
-          style={{
-            position: 'absolute',
-            bottom: 0,
-            left: 4,
-            right: 4,
-            height: SECONDARY_BAR.heightPx,
-            background: WIDGET_TOP_RULE.trackColor,
-          }}
+          className={BAR_TRACK}
+          // eslint-disable-next-line no-inline-style/no-inline-style
+          style={{ height: SECONDARY_BAR.heightPx, background: WIDGET_TOP_RULE.trackColor }}
         >
           <span
+            className={BAR_FILL}
+            // eslint-disable-next-line no-inline-style/no-inline-style
             style={{
-              display: 'block',
               width: `${String(Math.round(Math.max(0, Math.min(1, valuePct)) * 100))}%`,
-              height: '100%',
               background: valueColor,
             }}
           />
         </span>
       )}
-      <span style={widgetKickerStyle}>{signalLabel.toUpperCase()}</span>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'baseline',
-          justifyContent: 'center',
-          gap: 4,
-          width: '100%',
-          flexShrink: 0,
-        }}
-      >
+      <span className={WIDGET_KICKER}>{signalLabel.toUpperCase()}</span>
+      <div className={VALUE_ROW}>
         <span
-          style={{
-            color: valueColor,
-            fontFamily: MONO_FONT,
-            fontWeight: 800,
-            fontSize,
-            lineHeight: 1,
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'clip',
-            textAlign: 'left',
-            animation: danger ? BLINK_ANIM : undefined,
-          }}
+          className={cn(VALUE, danger && BLINK)}
+          // eslint-disable-next-line no-inline-style/no-inline-style
+          style={{ color: valueColor, fontSize }}
         >
           {prefix + valueStr}
         </span>
         {signalUnit !== '' && (
           <span
-            style={{
-              color: WIDGET_DIM_COLOR,
-              fontSize: valueUnitFontSize(Math.round(fontSize)),
-              fontFamily: MONO_FONT,
-              fontWeight: 500,
-              lineHeight: 1,
-              whiteSpace: 'nowrap',
-              pointerEvents: 'none',
-            }}
+            className={UNIT}
+            // eslint-disable-next-line no-inline-style/no-inline-style
+            style={{ color: WIDGET_DIM_COLOR, fontSize: valueUnitFontSize(Math.round(fontSize)) }}
           >
             {signalUnit}
           </span>

--- a/src/components/editor/widget-previews/Gear.tsx
+++ b/src/components/editor/widget-previews/Gear.tsx
@@ -5,9 +5,15 @@ import {
   deviceValueFontPx,
   widgetTopRulePx,
 } from '@canshift/core'
+import { cn } from '@/lib/utils'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
-import { MONO_FONT } from '../../../lib/typography'
-import { widgetKickerStyle, widgetTopRuleStyle } from '../widget-preview.styles'
+import { WIDGET_KICKER, ruleTier, widgetTopRule } from '../widget-preview.styles'
+
+const FRAME = 'relative box-border flex flex-col items-center justify-center overflow-hidden'
+
+const VALUE_ROW = 'flex w-full shrink-0 items-center justify-center'
+
+const VALUE = 'inline-block w-full text-center font-mono font-extrabold leading-none'
 
 interface GearRendererProps extends BaseRendererProps {
   unbound?: boolean
@@ -38,41 +44,20 @@ export const GearPreview = memo(function GearPreview({
   const ruleColor = rulePx === WIDGET_TOP_RULE.primaryPx ? st.textColor : WIDGET_TOP_RULE.trackColor
 
   return (
-    <div
-      style={{
-        width: w,
-        height: h,
-        position: 'relative',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        boxSizing: 'border-box',
-        overflow: 'hidden',
-      }}
-    >
-      <span aria-hidden="true" style={widgetTopRuleStyle(rulePx, ruleColor, false)} />
-      <span style={widgetKickerStyle}>{formatSignalLabel(widget.signal)}</span>
-      <div
-        style={{
-          display: 'flex',
-          width: '100%',
-          justifyContent: 'center',
-          alignItems: 'center',
-          flexShrink: 0,
-        }}
-      >
+    // eslint-disable-next-line no-inline-style/no-inline-style
+    <div className={FRAME} style={{ width: w, height: h }}>
+      <span
+        aria-hidden="true"
+        className={cn(widgetTopRule({ tier: ruleTier(rulePx) }))}
+        // eslint-disable-next-line no-inline-style/no-inline-style
+        style={{ background: ruleColor }}
+      />
+      <span className={WIDGET_KICKER}>{formatSignalLabel(widget.signal)}</span>
+      <div className={VALUE_ROW}>
         <span
-          style={{
-            color: st.textColor,
-            fontSize,
-            fontWeight: 800,
-            fontFamily: MONO_FONT,
-            lineHeight: 1,
-            textAlign: 'center',
-            width: '100%',
-            display: 'inline-block',
-          }}
+          className={VALUE}
+          // eslint-disable-next-line no-inline-style/no-inline-style
+          style={{ color: st.textColor, fontSize }}
         >
           {unbound ? STALE_PLACEHOLDER : '3'}
         </span>

--- a/src/components/editor/widget-previews/Image.tsx
+++ b/src/components/editor/widget-previews/Image.tsx
@@ -19,7 +19,7 @@ export const ImagePreview = memo(function ImagePreview({ widget, w, h }: BaseRen
   ].join(' ')
 
   return (
-    <svg width={w} height={h} style={{ display: 'block', overflow: 'hidden' }} aria-hidden="true">
+    <svg width={w} height={h} className="block overflow-hidden" aria-hidden="true">
       <rect
         x={4}
         y={4}

--- a/src/components/editor/widget-previews/ShiftLight.tsx
+++ b/src/components/editor/widget-previews/ShiftLight.tsx
@@ -29,7 +29,7 @@ export const ShiftLightPreview = memo(function ShiftLightPreview({
     cfg.redSegments >= SHIFT_LIGHT.segments ? 0 : SHIFT_LIGHT.segments - cfg.redSegments
 
   return (
-    <svg width={w} height={h} style={{ display: 'block' }} aria-hidden="true">
+    <svg width={w} height={h} className="block" aria-hidden="true">
       {Array.from({ length: SHIFT_LIGHT.segments }, (_, i) => {
         const fill =
           i >= lit ? SHIFT_LIGHT.trackColor : i >= redFrom ? SHIFT_LIGHT.redColor : st.textColor

--- a/src/components/editor/widget-previews/Timer.tsx
+++ b/src/components/editor/widget-previews/Timer.tsx
@@ -1,9 +1,24 @@
 import { memo } from 'react'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
 import type { BaseRendererProps } from './shared'
-import { MONO_FONT, uiLabelAtSize } from '../../../lib/typography'
 
 const DEMO_MMSS = '01:23'
 const DEMO_SS_MMM = '12.847'
+
+const FRAME = 'relative flex items-center justify-center overflow-hidden'
+
+const HEAVY_FONT_MIN_PX = 32
+
+const value = cva('font-mono tracking-[0.06em] tabular-nums', {
+  variants: { heavy: { true: 'font-black', false: 'font-bold' } },
+  defaultVariants: { heavy: false },
+})
+
+const KICKER = [
+  'absolute left-[3px] top-0.5 font-sans text-[9px] font-medium uppercase',
+  'leading-none tracking-[0.05em] text-[#888888]',
+].join(' ')
 
 export const TimerPreview = memo(function TimerPreview({ widget, w, h }: BaseRendererProps) {
   if (widget.config.type !== 'timer') return null
@@ -11,46 +26,18 @@ export const TimerPreview = memo(function TimerPreview({ widget, w, h }: BaseRen
   const st = widget.style
   const timeStr = cfg.format === 'ss.mmm' ? DEMO_SS_MMM : DEMO_MMSS
   const fontSize = Math.max(9, Math.min(h * 0.44, w * 0.22))
-  const sigFontSize = 9
 
   return (
-    <div
-      style={{
-        width: w,
-        height: h,
-        position: 'relative',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        overflow: 'hidden',
-      }}
-    >
+    // eslint-disable-next-line no-inline-style/no-inline-style
+    <div className={FRAME} style={{ width: w, height: h }}>
       <span
-        style={{
-          color: st.textColor,
-          fontSize,
-          fontWeight: fontSize >= 32 ? 900 : 700,
-          fontFamily: MONO_FONT,
-          letterSpacing: '0.06em',
-          fontVariantNumeric: 'tabular-nums',
-        }}
+        className={cn(value({ heavy: fontSize >= HEAVY_FONT_MIN_PX }))}
+        // eslint-disable-next-line no-inline-style/no-inline-style
+        style={{ color: st.textColor, fontSize }}
       >
         {timeStr}
       </span>
-      <span
-        style={{
-          position: 'absolute',
-          top: 2,
-          left: 3,
-          ...uiLabelAtSize(sigFontSize),
-          fontWeight: 500,
-          color: '#888888',
-          lineHeight: 1,
-          letterSpacing: '0.05em',
-        }}
-      >
-        TIMER
-      </span>
+      <span className={KICKER}>TIMER</span>
     </div>
   )
 })

--- a/src/components/editor/widget-previews/Warning.tsx
+++ b/src/components/editor/widget-previews/Warning.tsx
@@ -1,14 +1,29 @@
 import { memo } from 'react'
 import { SensorIcon } from '../../icons/SensorIcons'
-import { BLINK_ANIM } from '../widget-preview.styles'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
-import { uiLabelAtSize } from '../../../lib/typography'
 
 export interface WarningRendererProps extends BaseRendererProps {
   noAnimate: boolean
 }
 
 const DEFAULT_ICON = 'warning' as const
+
+const frame = cva(
+  'relative box-border flex flex-col items-center justify-center gap-1 overflow-hidden rounded-none',
+  {
+    variants: {
+      blink: { true: '[animation:canshift-blink_0.7s_step-end_infinite]', false: '' },
+    },
+    defaultVariants: { blink: false },
+  }
+)
+
+const LABEL = [
+  'whitespace-nowrap font-sans text-[9px] font-medium uppercase',
+  'leading-none tracking-[0.06em]',
+].join(' ')
 
 export const WarningPreview = memo(function WarningPreview({
   widget,
@@ -28,34 +43,16 @@ export const WarningPreview = memo(function WarningPreview({
 
   return (
     <div
-      style={{
-        width: w,
-        height: h,
-        position: 'relative',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: 4,
-        background: st.criticalColor + '22',
-        borderRadius: 0,
-        animation: noAnimate ? undefined : BLINK_ANIM,
-        overflow: 'hidden',
-        boxSizing: 'border-box',
-      }}
+      className={cn(frame({ blink: !noAnimate }))}
+      // eslint-disable-next-line no-inline-style/no-inline-style
+      style={{ width: w, height: h, background: st.criticalColor + '22' }}
     >
       <SensorIcon name={iconName} size={iconSize} color={st.criticalColor} />
       {showSignalLabel && (
         <span
-          style={{
-            ...uiLabelAtSize(sigFontSize),
-            fontWeight: 500,
-            color: st.criticalColor + '99',
-            lineHeight: 1,
-            whiteSpace: 'nowrap',
-            letterSpacing: '0.06em',
-            textTransform: 'uppercase',
-          }}
+          className={LABEL}
+          // eslint-disable-next-line no-inline-style/no-inline-style
+          style={{ color: st.criticalColor + '99' }}
         >
           {formatSignalLabel(widget.signal).toUpperCase()}
         </span>


### PR DESCRIPTION
Slice **C** of #146 — all of `widget-previews/` plus `WidgetListPanel`, `WidgetPalette` and `CruiseControlPreview`. 48 `style=` sites → **17**, all 17 driven by user config colour or computed geometry. Baseline 33 → 22.

This is the slice under the no-drift rule: `widget-previews/` mirrors the firmware through core's shared metrics, so **any** diff means the preview has drifted from the device and must be reverted rather than accepted.

## The first diff was 137 000 px, and it was the harness

Pages 3–6 came back at ~2.5 % each while 1–2 were clean. The mask showed the *entire* page outlined, sidebar included, and the words **"Loading editor…"** — `EditorRoute`'s Suspense fallback. One run had caught the app mid-lazy-load, because the capture script only waited a fixed 500 ms after clicking a page thumbnail, and the branch that had just been rebuilt paid a cold Vite transform.

Nothing had drifted. But a 2.5 % diff on a firmware-mirroring surface is indistinguishable from a real regression until you look, so the harness now:

- waits for `Loading editor…` to detach before touching anything,
- waits for the `PAGE n` label of the page it just selected,
- and **asserts the fallback is absent at capture time**, printing `captured mid-load` if not.

Then measured the noise floor — two runs on the same branch — and got **0 px on all six pages** before trusting any cross-branch number. Worth adding to #146's harness notes: a fixed `waitForTimeout` after a click is not enough on a route behind `React.lazy`.

## Result: zero drift

| Surface | Diff |
| --- | --- |
| dash pages 1–6 (every widget type in the sim config) | **0 px** each |
| cruise control page (`CruiseControlPreview`) | **0 px** |
| Library tab (`WidgetPalette`) | **0 px** |
| Widgets tab (`WidgetListPanel`) | **0 px** |

Noise floor measured at 0 px on the same set first.

## What the 17 survivors are

Three kinds, and none of them is arbitrary:

- **User-config colour.** `st.textColor`, `st.criticalColor`, `palette.text`, `displayColors.active` — a saved config can put any hex there, so no class can express it.
- **Computed font size.** `deviceValueFontPx(big)` or the auto-fit fallback, per widget, per box.
- **Computed geometry.** `w`/`h` from the grid, the value-bar width, the cruise buttons' corner offsets.

Everything around them — flex, position, overflow, `box-sizing`, typography, tracking, the mono/UI font choice — is now classes.

## `widgetTopRuleStyle` became a variant, not a style object

#157 extracted the top rule and the kicker as shared `CSSProperties`. The rule's height comes from `widgetTopRulePx`, which returns **`WIDGET_TOP_RULE.primaryPx` or `secondaryPx` and nothing else** — a closed set wearing a number. It is a `tier: 'primary' | 'secondary'` cva variant now (`h-0.5` / `h-px`), with the blink as a second variant, and only the colour left inline. `widgetKickerStyle` was fully static and is a plain class constant.

`BLINK_ANIM` as a string is gone; the animation is `[animation:canshift-blink_0.7s_step-end_infinite]` applied through `cn()` on the four elements that blink.

## `WidgetListPanel` retires the last positioned-child rail

It held the second of the two `ActiveBar` copies #146 tracks. Both are now the primitive — `page-cell` went in #166, this one here. What remains is the two `box-shadow: inset 3px` sites (`EcuCatalogueList`, `HistoryPanel`) and `RightSidebar`'s **horizontal** tab bar, so the primitive still wants an orientation variant before a shadow one. Unchanged from what #166 recorded.

## Left alone deliberately

`Warning` and `Timer` keep their own kicker values — 9 px, weight 500, `0.06em` — rather than adopting the 10 px / 800 / `0.18em` that #157 gave `GaugeNumeric` and `Gear`. Those two are exactly the sites #158 is about, and normalising them here would be a **visual change inside the slice whose entire safety argument is that nothing changes visually**. They belong with #158, converted faithfully for now.

## Test plan

- `npm run typecheck`, `lint`, `format:check`, `test` (57 files, 359 tests), `build` — all green
- Baseline 33 → 22; eleven files leave the allowlist
- No console errors on any capture run, either branch
- **Not reached:** the danger/blink arms of `GaugeNumeric` and `GaugeArc` (no sim signal crosses its danger level), `revFlash` on `GaugeArc`, the unbound `- -` placeholder, and `Button`'s engaged state. All are colour-and-class swaps of the same shape as the verified ones, but flagging rather than implying them.