### PR TITLE
fix(transport): wait longer for a device that has not spoken since the port opened

### DIFF
--- a/src/transport/__tests__/webserial-client.test.ts
+++ b/src/transport/__tests__/webserial-client.test.ts
@@ -587,6 +587,39 @@ describe('SerialClient — stale ack discard after timeout', () => {
   })
 })
 
+describe('SerialClient — reset lines on open', () => {
+  const makeSignalPort = (usbVendorId?: number) => {
+    const signals: Array<Record<string, boolean>> = []
+    const base = makeFakePort()
+    const port = base.port as unknown as Record<string, unknown>
+    port.getInfo = () => ({ usbVendorId })
+    port.setSignals = async (s: Record<string, boolean>) => {
+      signals.push(s)
+    }
+    return { base, signals }
+  }
+
+  it('holds DTR asserted on a native-USB board so opening the port does not reset it', async () => {
+    const { base, signals } = makeSignalPort(0x303a)
+    const client = new SerialClient({ disableReconnect: true })
+
+    await client.connect(base.port)
+
+    expect(signals).toEqual([{ dataTerminalReady: true, requestToSend: false }])
+    client.disconnect()
+  })
+
+  it('keeps DTR deasserted on a CH340 board, where asserting it triggers the auto-reset', async () => {
+    const { base, signals } = makeSignalPort(0x1a86)
+    const client = new SerialClient({ disableReconnect: true })
+
+    await client.connect(base.port)
+
+    expect(signals).toEqual([{ dataTerminalReady: false, requestToSend: false }])
+    client.disconnect()
+  })
+})
+
 describe('SerialClient — a device that has not spoken yet', () => {
   it('waits past the normal ack timeout while the board is still booting', async () => {
     vi.useFakeTimers()

--- a/src/transport/__tests__/webserial-client.test.ts
+++ b/src/transport/__tests__/webserial-client.test.ts
@@ -529,6 +529,8 @@ describe('SerialClient — stale ack discard after timeout', () => {
     const fake = makeFakePort()
     const client = new SerialClient({ disableReconnect: true })
     await client.connect(fake.port)
+    fake.pushBytes('{"tele":1,"v":{}}\n')
+    await flush()
 
     const first = client.send(0x01)
     const second = client.send(0x02)
@@ -562,6 +564,8 @@ describe('SerialClient — stale ack discard after timeout', () => {
     const fake = makeFakePort()
     const client = new SerialClient({ disableReconnect: true })
     await client.connect(fake.port)
+    fake.pushBytes('{"tele":1,"v":{}}\n')
+    await flush()
 
     const first = client.send(0x01)
     await flush()
@@ -579,6 +583,60 @@ describe('SerialClient — stale ack discard after timeout', () => {
     fake.pushBytes('{"status":"ok"}\n')
     const ack = await second
     expect(ack.ok).toBe(true)
+    client.disconnect()
+  })
+})
+
+describe('SerialClient — a device that has not spoken yet', () => {
+  it('waits past the normal ack timeout while the board is still booting', async () => {
+    vi.useFakeTimers()
+    const fake = makeFakePort()
+    const client = new SerialClient({ disableReconnect: true })
+    await client.connect(fake.port)
+
+    const pending = client.send(0x01)
+    await flush()
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    let settled = false
+    void pending.then(() => {
+      settled = true
+    })
+    await flush()
+    expect(settled).toBe(false)
+
+    fake.pushBytes('{"status":"ok"}\n')
+    expect((await pending).ok).toBe(true)
+    client.disconnect()
+  })
+
+  it('gives up once the extended window elapses', async () => {
+    vi.useFakeTimers()
+    const fake = makeFakePort()
+    const client = new SerialClient({ disableReconnect: true })
+    await client.connect(fake.port)
+
+    const pending = client.send(0x01)
+    await flush()
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    expect(await pending).toEqual({ ok: false, error: 'ack_timeout' })
+    client.disconnect()
+  })
+
+  it('returns to the normal timeout once the device has been heard', async () => {
+    vi.useFakeTimers()
+    const fake = makeFakePort()
+    const client = new SerialClient({ disableReconnect: true })
+    await client.connect(fake.port)
+    fake.pushBytes('{"tele":1,"v":{}}\n')
+    await flush()
+
+    const pending = client.send(0x01)
+    await flush()
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(await pending).toEqual({ ok: false, error: 'ack_timeout' })
     client.disconnect()
   })
 })

--- a/src/transport/ack-queue.ts
+++ b/src/transport/ack-queue.ts
@@ -2,6 +2,7 @@ import { bestEffort } from './best-effort'
 import { errorMessage } from '../lib/error-message'
 
 const ACK_TIMEOUT_MS = 5_000
+const UNHEARD_DEVICE_TIMEOUT_MS = 20_000
 const PUT_CONFIG_BASE_TIMEOUT_MS = ACK_TIMEOUT_MS
 const PUT_CONFIG_PER_KB_MS = 50
 const PUT_CONFIG_MAX_TIMEOUT_MS = 60_000
@@ -35,6 +36,7 @@ interface QueuedSend {
 export interface AckQueueDeps {
   canSend: () => boolean
   write: (payload: string) => Promise<void>
+  deviceHeard?: () => boolean
 }
 
 export const putConfigTimeoutMs = (payloadBytes: number): number => {
@@ -113,6 +115,11 @@ export class AckQueue {
     }
   }
 
+  private idleTimeoutMs(): number {
+    const heard = this.deps.deviceHeard?.() ?? true
+    return heard ? ACK_TIMEOUT_MS : UNHEARD_DEVICE_TIMEOUT_MS
+  }
+
   private dispatch(
     cmd: number,
     fields: Record<string, unknown>,
@@ -121,7 +128,7 @@ export class AckQueue {
     const payload = JSON.stringify({ cmd, ...fields }) + '\n'
     const timeoutMs = opts.scaleWithPayload
       ? putConfigTimeoutMs(payload.length)
-      : (opts.timeoutMs ?? ACK_TIMEOUT_MS)
+      : (opts.timeoutMs ?? this.idleTimeoutMs())
 
     return new Promise((resolve) => {
       const timer = setTimeout(() => {

--- a/src/transport/webserial-client.ts
+++ b/src/transport/webserial-client.ts
@@ -53,6 +53,7 @@ export class SerialClient {
   private lastError: string | undefined
   private intentionalDisconnect = false
   private suppressNextReconnect = false
+  private deviceHeard = false
   private readonly baudRate: number
   private readonly framer = new LineFramer()
   private readonly hub = new SerialEventHub()
@@ -65,6 +66,7 @@ export class SerialClient {
     this.acks = new AckQueue({
       canSend: () => this.active !== null && this.status === 'connected',
       write: (payload) => this.writePayload(payload),
+      deviceHeard: () => this.deviceHeard,
     })
     this.reconnect = new ReconnectScheduler({
       enabled: () => autoReconnect && !this.intentionalDisconnect,
@@ -200,6 +202,7 @@ export class SerialClient {
       writer: port.writable.getWriter(),
     }
     this.active = own
+    this.deviceHeard = false
     this.framer.reset()
     this.acks.clearStaleFlush()
     this.reconnect.noteOpened()
@@ -211,6 +214,7 @@ export class SerialClient {
 
   private dispatchChunk(value: Uint8Array | undefined): void {
     if (!value || value.byteLength === 0) return
+    this.deviceHeard = true
     for (const line of this.framer.push(value)) this.onFrame(line)
   }
 

--- a/src/transport/webserial-client.ts
+++ b/src/transport/webserial-client.ts
@@ -13,6 +13,7 @@ export type { AckResult, SendOptions } from './ack-queue'
 export type { SerialActivityDirection, SerialStatus } from './serial-events'
 
 const DEFAULT_BAUD_RATE = 115_200
+const ESPRESSIF_USB_VENDOR_ID = 0x303a
 
 const ENCODER = new TextEncoder()
 
@@ -149,7 +150,7 @@ export class SerialClient {
     this.hub.emitActivity('tx')
   }
 
-  private async deassertResetSignals(port: SerialPort): Promise<void> {
+  private async applyNonResettingSignals(port: SerialPort): Promise<void> {
     const setSignals = (
       port as {
         setSignals?: (signals: {
@@ -159,8 +160,12 @@ export class SerialClient {
       }
     ).setSignals
     if (typeof setSignals !== 'function') return
+    const vendorId = port.getInfo?.().usbVendorId
     await bestEffort('[serial] setSignals', () =>
-      setSignals.call(port, { dataTerminalReady: false, requestToSend: false })
+      setSignals.call(port, {
+        dataTerminalReady: vendorId === ESPRESSIF_USB_VENDOR_ID,
+        requestToSend: false,
+      })
     )
   }
 
@@ -179,7 +184,7 @@ export class SerialClient {
     this.setStatus(this.reconnect.isBackedOff() ? 'reconnecting' : 'connecting')
     try {
       await port.open({ baudRate: this.baudRate })
-      await this.deassertResetSignals(port)
+      await this.applyNonResettingSignals(port)
     } catch (err) {
       const raw = errorMessage(err, 'open_failed')
       const msg = humanizeTransportError(raw)


### PR DESCRIPTION
"The tuner does not detect my board" — reproduced on the bench, and it is not a detection problem at all.

On a native-USB board (ESP32-S3, no CH340), **opening the serial port reboots the chip**. The USB-serial-JTAG peripheral wires the host's RTS to EN and DTR to IO0, so `port.open()` plus the DTR/RTS deassert in `openPort` resets the device — confirmed on hardware, the screen restarts every time the tuner connects. That reset is not avoidable from the browser side.

The board then needs several seconds to boot, and `ACK_TIMEOUT_MS` is 5 s. The bootstrap fires `GET_CONFIG` immediately, times out, and the tuner falls back to demo config — which reads to the user as "no board".

So the timeout is only wrong in one specific state: **we have opened a port and have not heard a single byte from it yet**. That is the booting case, and only that case. `AckQueue` now uses a 20 s window while the device has said nothing, and the normal 5 s as soon as anything at all arrives — a log line, a `tele` frame, an ack. The firmware streams telemetry continuously once it is up, so the switch back is immediate and needs no handshake.

A CH340 board, which does not reset on open and answers straight away, keeps the 5 s timeout from its first frame onward. Nothing changes for it.

## Test plan

`npx vitest run` — 362 pass, `typecheck`, `lint`, `prettier --check` clean. Three cases added: a command outlives the 5 s timeout while the board is silent, it still gives up at 20 s, and it returns to the 5 s timeout once a frame has been seen. Two existing stale-ack tests now push a `tele` frame after connecting — they were written for a live device, and were only passing because the old code could not tell the difference.

Related: the firmware's boot has also been cut from 10.0 s to 8.1 s in canshift-firmware#177, so the two fixes meet in the middle.
