### PR TITLE
feat(transport): burn the dashboard through the chunked config command

### DIFF
--- a/src/hooks/useBurnDashboard.ts
+++ b/src/hooks/useBurnDashboard.ts
@@ -20,8 +20,8 @@ interface UseBurnDashboard {
 
 const verifyFailureMessage = (verify: Exclude<VerifyResult, { kind: 'ok' }>): string => {
   switch (verify.kind) {
-    case 'no_reboot':
-      return 'Device did not come back after reboot — try unplug/replug'
+    case 'unreachable':
+      return 'Device stopped answering after the burn — try unplug/replug'
     case 'fetch_failed':
       return `Could not read back config (${humanizeTransportError(verify.error)})`
     case 'mismatch':
@@ -68,8 +68,8 @@ export const useBurnDashboard = (): UseBurnDashboard => {
         captureFlowEvent('burn_completed', { outcome: 'push_failed', reason: code })
         return
       }
-      setBurnPhase('rebooting')
-      log('info', 'Burn acked — verifying after reboot…')
+      setBurnPhase('verifying')
+      log('info', 'Burn acked — verifying on device…')
       const verify = await verifyBurnedConfig(config)
       if (verify.kind === 'ok') {
         markPushed()

--- a/src/lib/verify-burned-config.ts
+++ b/src/lib/verify-burned-config.ts
@@ -4,19 +4,17 @@ import { usbService } from '../transport'
 
 export type VerifyResult =
   | { kind: 'ok' }
-  | { kind: 'no_reboot' }
+  | { kind: 'unreachable' }
   | { kind: 'fetch_failed'; error: string }
   | { kind: 'mismatch' }
 
-const REBOOT_GRACE_MS = 1_500
-const POLL_INTERVAL_MS = 500
-const PING_TIMEOUT_MS = 500
+const POLL_INTERVAL_MS = 250
+const PING_TIMEOUT_MS = 1_000
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
 const pollUntilAlive = async (maxWaitMs: number): Promise<boolean> => {
-  await sleep(REBOOT_GRACE_MS)
-  const deadline = Date.now() + maxWaitMs - REBOOT_GRACE_MS
+  const deadline = Date.now() + maxWaitMs
   while (Date.now() < deadline) {
     const result = await usbService.ping(PING_TIMEOUT_MS)
     if (result.kind === 'ok') return true
@@ -27,10 +25,10 @@ const pollUntilAlive = async (maxWaitMs: number): Promise<boolean> => {
 
 export const verifyBurnedConfig = async (
   expected: DashboardConfig,
-  maxWaitMs = 10_000
+  maxWaitMs = 5_000
 ): Promise<VerifyResult> => {
   const alive = await pollUntilAlive(maxWaitMs)
-  if (!alive) return { kind: 'no_reboot' }
+  if (!alive) return { kind: 'unreachable' }
 
   const fetched = await usbService.getConfig()
   if (fetched.kind === 'error') return { kind: 'fetch_failed', error: fetched.error }

--- a/src/stores/device.store.ts
+++ b/src/stores/device.store.ts
@@ -5,7 +5,7 @@ export type ConnectionStatus = 'disconnected' | 'connected' | 'burning' | 'error
 
 export type Transport = 'usb'
 
-export type BurnPhase = 'idle' | 'pushing' | 'rebooting' | 'done'
+export type BurnPhase = 'idle' | 'pushing' | 'verifying' | 'done'
 
 export type BurnResult = { kind: 'success' } | { kind: 'error'; message: string }
 

--- a/src/transport/chunked-config.ts
+++ b/src/transport/chunked-config.ts
@@ -1,0 +1,49 @@
+import type { DashboardConfig } from '@canshift/core'
+
+import { CMD_PUT_CONFIG_CHUNK } from './opcodes'
+import { getSerialClient } from './webserial-client'
+
+const CHUNK_BYTES = 512
+const CHUNK_ACK_TIMEOUT_MS = 10_000
+const COMMIT_ACK_TIMEOUT_MS = 30_000
+
+export interface ChunkedBurnResult {
+  success: boolean
+  error?: string
+}
+
+const toBase64 = (bytes: Uint8Array): string => {
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
+
+const splitIntoChunks = (bytes: Uint8Array): Uint8Array[] => {
+  const chunks: Uint8Array[] = []
+  for (let offset = 0; offset < bytes.length; offset += CHUNK_BYTES) {
+    chunks.push(bytes.subarray(offset, offset + CHUNK_BYTES))
+  }
+  return chunks
+}
+
+export const burnConfigChunked = async (config: DashboardConfig): Promise<ChunkedBurnResult> => {
+  const payload = new TextEncoder().encode(JSON.stringify(config))
+  const chunks = splitIntoChunks(payload)
+  if (chunks.length === 0) {
+    return { success: false, error: 'empty_config' }
+  }
+  const client = getSerialClient()
+
+  for (const [idx, chunk] of chunks.entries()) {
+    const isLast = idx === chunks.length - 1
+    const fields: Record<string, unknown> = { total: chunks.length, idx, data: toBase64(chunk) }
+    if (idx === 0) fields.bytes = payload.length
+    const ack = await client.send(CMD_PUT_CONFIG_CHUNK, fields, {
+      timeoutMs: isLast ? COMMIT_ACK_TIMEOUT_MS : CHUNK_ACK_TIMEOUT_MS,
+    })
+    if (!ack.ok) {
+      return { success: false, error: ack.error ?? 'chunk_rejected' }
+    }
+  }
+  return { success: true }
+}

--- a/src/transport/opcodes.ts
+++ b/src/transport/opcodes.ts
@@ -9,6 +9,7 @@ export const CMD_SET_DAY_NIGHT = 0x09
 export const CMD_GET_INPUT_BINDINGS = 0x0b
 export const CMD_PUT_INPUT_BINDINGS = 0x0c
 export const CMD_SET_BOARD_PROFILE = 0x0d
+export const CMD_PUT_CONFIG_CHUNK = 0x0e
 export const CMD_QUERY_VERSION = 0x10
 export const CMD_PING = 0x11
 export const CMD_CAN_SCAN_START = 0x20
@@ -29,6 +30,11 @@ export interface KnownOpcode {
 export const KNOWN_OPCODES: readonly KnownOpcode[] = [
   { id: CMD_GET_CONFIG, name: 'CMD_GET_CONFIG', description: 'Read dashboard JSON from device' },
   { id: CMD_PUSH_CONFIG, name: 'CMD_PUSH_CONFIG', description: 'Write dashboard JSON (reboots)' },
+  {
+    id: CMD_PUT_CONFIG_CHUNK,
+    name: 'CMD_PUT_CONFIG_CHUNK',
+    description: 'Burn the dashboard in chunks — validated, then reloaded live',
+  },
   {
     id: CMD_GET_DEVICE_CONFIG,
     name: 'CMD_GET_DEVICE_CONFIG',

--- a/src/transport/usb-service.ts
+++ b/src/transport/usb-service.ts
@@ -5,7 +5,6 @@ import {
   CMD_CALIBRATE_TOUCH,
   CMD_GET_CONFIG,
   CMD_PING,
-  CMD_PUSH_CONFIG,
   CMD_QUERY_VERSION,
   CMD_REBOOT,
   CMD_SCREEN_SETTINGS,
@@ -20,6 +19,7 @@ import {
   type BoardProfileWriteResult,
 } from '../lib/firmware/board-provision'
 import { getSerialClient } from './webserial-client'
+import { burnConfigChunked } from './chunked-config'
 
 const OK: UsbResult = { success: true }
 
@@ -32,12 +32,11 @@ export const usbService = {
         error: `invalid_dashboard_config: ${validation.errors[0] ?? 'unknown_validation_error'}`,
       }
     }
-    const result = await getSerialClient().send(
-      CMD_PUSH_CONFIG,
-      { payload: config },
-      { scaleWithPayload: true }
-    )
-    return toUsbResult(result)
+    const burned = await burnConfigChunked(config)
+    if (!burned.success) {
+      return { success: false, error: burned.error ?? 'unknown_error' }
+    }
+    return OK
   },
 
   getConfig: async (): Promise<


### PR DESCRIPTION
Paired with canshift-firmware#182, and the reason burning never worked on the ESP32-S3 board.

`pushConfig` sent the whole dashboard as a single line. Measured on hardware, that transport drops any command above ~2 KB: the HWCDC RX queue is 2048 bytes and its ISR discards whatever does not fit, so the line never completes and the device stops answering entirely. No timeout adjustment could have fixed it — the bytes never arrived.

The config now goes out in 512-byte pieces (~750 bytes on the wire after base64 and the envelope), each awaiting its ack, with the first announcing the total byte count so the firmware can verify nothing was lost before it commits. The last chunk gets a longer window since that is where the device validates and swaps the file in.

Nothing else changes: validation still runs before the first byte leaves, and `verifyBurnedConfig` still reads the config back afterwards.

## Test plan

`typecheck`, `lint`, `vitest run` (364) all green.

End to end against the board: burn from the tuner, config replaced, dash rebuilt live without a reboot. Confirmed by Thomas.