### PR TITLE
fix(shell): show the board the dash reports, not only the profile the config names

### DIFF
--- a/src/components/shell/Sidebar.tsx
+++ b/src/components/shell/Sidebar.tsx
@@ -18,11 +18,12 @@ const Sidebar = () => {
   const simulationMode = useDeviceStore((s) => s.simulationMode)
   const firmwareVersion = useDeviceStore((s) => s.firmwareVersion)
   const targetProfile = useDashboardStore((s) => s.config?.targetProfile)
+  const boardId = useDeviceStore((s) => s.boardId)
   const location = useLocation()
   const collapsed = useUiStore((s) => s.leftNavCollapsed)
   const toggleLeftNav = useUiStore((s) => s.toggleLeftNav)
   const offline = status !== 'connected' && !simulationMode
-  const targetLabel = resolveTargetLabel(offline, targetProfile)
+  const targetLabel = resolveTargetLabel(offline, targetProfile, boardId)
 
   if (collapsed) {
     return <CollapseRail side="left" label="Menu" onExpand={toggleLeftNav} />

--- a/src/components/shell/target-label.test.ts
+++ b/src/components/shell/target-label.test.ts
@@ -13,4 +13,16 @@ describe('sidebar TARGET label', () => {
   it('names the profile when connected and the config sets one', () => {
     expect(resolveTargetLabel(false, 'crowpanel-28')).toBe('CrowPanel 2.8"')
   })
+
+  it('prefers what the board reports over what the config was drawn for', () => {
+    expect(resolveTargetLabel(false, 'crowpanel-28', 'waveshare_s3_28')).toBe('waveshare_s3_28')
+  })
+
+  it('falls back to the config profile when the board reports no id', () => {
+    expect(resolveTargetLabel(false, 'crowpanel-28', null)).toBe('CrowPanel 2.8"')
+  })
+
+  it('stays blank offline even when a board id is remembered', () => {
+    expect(resolveTargetLabel(true, 'crowpanel-28', 'waveshare_s3_28')).toBeNull()
+  })
 })

--- a/src/components/shell/target-label.ts
+++ b/src/components/shell/target-label.ts
@@ -2,6 +2,10 @@ import { resolveScreenProfile, type ScreenProfileId } from '@canshift/core'
 
 export const resolveTargetLabel = (
   offline: boolean,
-  targetProfile: ScreenProfileId | undefined
-): string | null =>
-  offline || targetProfile === undefined ? null : resolveScreenProfile(targetProfile).name
+  targetProfile: ScreenProfileId | undefined,
+  boardId?: string | null
+): string | null => {
+  if (offline) return null
+  if (boardId) return boardId
+  return targetProfile === undefined ? null : resolveScreenProfile(targetProfile).name
+}


### PR DESCRIPTION
The sidebar's TARGET row read `—` with a board connected and answering. It was not a detection failure: the label was only ever driven by `config.targetProfile`, an optional field the shipped dashboard config does not set — so it resolved to nothing and fell back to the dash.

Meanwhile the device does announce itself. `usb_dispatch.cpp` puts `board_id` in every status response, the version handshake already parses it, and `device.store` already keeps it. It was simply never displayed anywhere.

TARGET now prefers what the board reports (`waveshare_s3_28`) and falls back to the config's screen profile when there is no board id — which keeps the label meaningful offline, where only the config can speak. The two answer different questions: what am I plugged into, versus what was this dash drawn for. Preferring the hardware is the honest default now that more than one board exists, and a divergence between the two is worth surfacing later as a warning rather than silently picking one.

## Test plan

`vitest run` 367 green — three cases added: board id wins over the config profile, the profile is used when no board id is known, and the row stays blank offline even with a remembered board id. `typecheck` and `lint` clean.