### PR TITLE
design(tuner): T04 no ECU profile — the empty state

### DIFF
--- a/src/components/ecu/EcuCatalogueList.tsx
+++ b/src/components/ecu/EcuCatalogueList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, type RefObject } from 'react'
 import { cva } from 'class-variance-authority'
 import { formatBytes } from '../../lib/format'
 import { cn } from '@/lib/utils'
@@ -28,6 +28,7 @@ export interface EcuCatalogueListProps {
   activeKey: string
   selectedId: string | null
   onSelect: (item: CatalogueItem) => Promise<void> | void
+  searchRef?: RefObject<HTMLInputElement | null> | undefined
 }
 
 type LoadState =
@@ -40,7 +41,12 @@ type SortKey = 'vendor' | 'label' | 'size'
 
 const CATALOGUE_URL = '/ecu-catalogue/index.json'
 
-export const EcuCatalogueList = ({ activeKey, selectedId, onSelect }: EcuCatalogueListProps) => {
+export const EcuCatalogueList = ({
+  activeKey,
+  selectedId,
+  onSelect,
+  searchRef,
+}: EcuCatalogueListProps) => {
   const [state, setState] = useState<LoadState>({ kind: 'idle' })
   const [query, setQuery] = useState('')
   const [sortKey, setSortKey] = useState<SortKey>('vendor')
@@ -98,6 +104,7 @@ export const EcuCatalogueList = ({ activeKey, selectedId, onSelect }: EcuCatalog
       <Eyebrow className="block border-b-2 border-brand-divider px-[18px] py-3">PROFILES</Eyebrow>
       <div className="flex flex-col gap-2 px-[18px]">
         <Input
+          ref={searchRef}
           type="search"
           value={query}
           onChange={(e) => {

--- a/src/components/live-data/LiveDataEmpty.tsx
+++ b/src/components/live-data/LiveDataEmpty.tsx
@@ -1,0 +1,22 @@
+import { NoEcuProfileState } from '@/components/states/NoEcuProfileState'
+
+export interface LiveDataEmptyProps {
+  hasProfile: boolean
+  onPickProfile: () => void
+  onCaptureBus: () => void
+}
+
+const FILTER_EMPTY = 'px-6 py-16 text-center text-[13px] text-brand-neutral-500'
+
+const STATE_PLACEMENT = 'mx-7 my-[26px] max-w-[560px]'
+
+export const LiveDataEmpty = ({ hasProfile, onPickProfile, onCaptureBus }: LiveDataEmptyProps) => {
+  if (hasProfile) return <div className={FILTER_EMPTY}>No signals match the current filter.</div>
+  return (
+    <NoEcuProfileState
+      className={STATE_PLACEMENT}
+      onPickProfile={onPickProfile}
+      onCaptureBus={onCaptureBus}
+    />
+  )
+}

--- a/src/components/states/NoEcuProfileState.tsx
+++ b/src/components/states/NoEcuProfileState.tsx
@@ -1,0 +1,25 @@
+import { InlineState } from '@/components/states/InlineState'
+import { SHIPPED_PROFILE_COUNT } from '@/constants/ecu-catalogue'
+
+export interface NoEcuProfileStateProps {
+  onPickProfile: () => void
+  onCaptureBus: () => void
+  className?: string | undefined
+}
+
+const BODY = `Widgets need a profile before they can read anything. Pick one of the ${String(SHIPPED_PROFILE_COUNT)} shipped profiles, or derive one from a bus capture.`
+
+export const NoEcuProfileState = ({
+  onPickProfile,
+  onCaptureBus,
+  className,
+}: NoEcuProfileStateProps) => (
+  <InlineState
+    className={className}
+    severity="empty"
+    title="No signals to bind yet"
+    body={BODY}
+    primaryAction={{ label: 'PICK A PROFILE', onClick: onPickProfile }}
+    secondaryAction={{ label: 'Capture the bus', onClick: onCaptureBus }}
+  />
+)

--- a/src/constants/ecu-catalogue.test.ts
+++ b/src/constants/ecu-catalogue.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { SHIPPED_PROFILE_COUNT } from './ecu-catalogue'
+
+const manifestPath = fileURLToPath(
+  new URL('../../public/ecu-catalogue/index.json', import.meta.url)
+)
+
+const shippedEntryCount = (): number => {
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { entries: unknown[] }
+  return manifest.entries.length
+}
+
+describe('SHIPPED_PROFILE_COUNT', () => {
+  it('matches the entry count of the shipped catalogue manifest', () => {
+    expect(SHIPPED_PROFILE_COUNT).toBe(shippedEntryCount())
+  })
+})

--- a/src/constants/ecu-catalogue.ts
+++ b/src/constants/ecu-catalogue.ts
@@ -1,0 +1,1 @@
+export const SHIPPED_PROFILE_COUNT = 37

--- a/src/routes/EcuRoute.tsx
+++ b/src/routes/EcuRoute.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import type { SignalDef } from '@canshift/core'
 import { useDashboardStore } from '../stores/dashboard.store'
 import { useSignalStore } from '../stores/signal.store'
@@ -10,6 +11,7 @@ import { ApplyConfirmDialog } from '../components/ecu/ApplyConfirmDialog'
 import { cn } from '@/lib/utils'
 import { RouteHeader } from '../components/shell/RouteHeader'
 import { RouteBody, RoutePage, RoutePanel } from '../components/ui/route-shell'
+import { NoEcuProfileState } from '../components/states/NoEcuProfileState'
 import { prettyProfileKey } from '../utils/profile-key'
 import { useEcuSource } from '../hooks/useEcuSource'
 
@@ -24,6 +26,8 @@ const EcuRoute = () => {
   const { source, importError, setImportError, selectCatalogueItem, loadImport, clear } =
     useEcuSource()
   const [confirmOpen, setConfirmOpen] = useState(false)
+  const navigate = useNavigate()
+  const searchRef = useRef<HTMLInputElement>(null)
 
   const previewSignals = useMemo<SignalDef[]>(() => {
     switch (source.kind) {
@@ -84,6 +88,8 @@ const EcuRoute = () => {
 
   const canApply = previewSignals.length > 0
 
+  const hasNothingToShow = shownSignals.length === 0 && previewWarnings.length === 0
+
   const onConfirmApply = () => {
     setConfirmOpen(false)
     applyProfile(selectedKey, previewSignals)
@@ -123,6 +129,7 @@ const EcuRoute = () => {
         <section className="flex w-[250px] min-h-0 shrink-0 flex-col overflow-hidden border-r-2 border-brand-divider">
           <RoutePanel>
             <EcuCatalogueList
+              searchRef={searchRef}
               activeKey={activeProfileKey}
               selectedId={selectedItemId}
               onSelect={(item) => {
@@ -146,7 +153,21 @@ const EcuRoute = () => {
         </section>
 
         <section className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-          <SignalPreviewTable signals={shownSignals} boundTo={boundTo} warnings={previewWarnings} />
+          {hasNothingToShow ? (
+            <NoEcuProfileState
+              className="mx-7 my-[26px] max-w-[560px]"
+              onPickProfile={() => searchRef.current?.focus()}
+              onCaptureBus={() => {
+                void navigate('/can')
+              }}
+            />
+          ) : (
+            <SignalPreviewTable
+              signals={shownSignals}
+              boundTo={boundTo}
+              warnings={previewWarnings}
+            />
+          )}
         </section>
       </RouteBody>
 

--- a/src/routes/LiveDataRoute.tsx
+++ b/src/routes/LiveDataRoute.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { cva } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
+import { LiveDataEmpty } from '../components/live-data/LiveDataEmpty'
 import { SourceBadge, type SignalSource } from '../components/live-data/SourceBadge'
 import { RouteHeader } from '../components/shell/RouteHeader'
 import { RoutePage } from '../components/ui/route-shell'
@@ -16,8 +18,6 @@ const EXPORT_BUTTON = [
   'text-[11px] font-extrabold tracking-[0.08em]',
   'text-brand-text disabled:cursor-not-allowed disabled:text-brand-neutral-500',
 ].join(' ')
-
-const EMPTY = 'px-6 py-16 text-center text-[13px] text-brand-neutral-500'
 
 const GRID = 'grid flex-1 grid-cols-4 overflow-y-auto [grid-auto-rows:minmax(150px,1fr)]'
 
@@ -52,6 +52,7 @@ const LiveDataRoute = () => {
   const connected = useDeviceStore((s) => s.connected)
   const simulationMode = useDeviceStore((s) => s.simulationMode)
   const values = useLiveSignals()
+  const navigate = useNavigate()
   const [filter, setFilter] = useState('')
 
   const isLive = connected && !simulationMode
@@ -120,11 +121,15 @@ const LiveDataRoute = () => {
       />
 
       {filteredSignals.length === 0 ? (
-        <div className={EMPTY}>
-          {signals.length === 0
-            ? 'No signals configured. Pick an ECU profile in the Editor to see live values here.'
-            : 'No signals match the current filter.'}
-        </div>
+        <LiveDataEmpty
+          hasProfile={signals.length > 0}
+          onPickProfile={() => {
+            void navigate('/ecu')
+          }}
+          onCaptureBus={() => {
+            void navigate('/can')
+          }}
+        />
       ) : (
         <div className={GRID}>
           {filteredSignals.map((sig) => {


### PR DESCRIPTION
Stacked on #185 (`design/tuner-inline-state-block`). Reuses the `InlineState` primitive from that branch — no second component, no restyle.

## What changed

- `src/components/states/NoEcuProfileState.tsx` — T04 as `<InlineState severity="empty">`: no bar, 1 px `--color-neutral-400` box on the page ground, title `No signals to bind yet`, the planche body verbatim, `PICK A PROFILE` (primary, uppercase) + `Capture the bus` (secondary, sentence case), `gap: 1px`, flush left.
- `src/routes/EcuRoute.tsx` — the right pane shows the state instead of the "No signals to preview." filler whenever there is no active profile and no preview source. Primary focuses the profile search (the catalogue is the left column of this very route), secondary navigates to `/can`.
- `src/components/live-data/LiveDataEmpty.tsx` + `src/routes/LiveDataRoute.tsx` — the "No signals configured…" sentence is replaced by the state. The nested ternary in the route is gone: the two empty kinds live behind one guard clause in the new component. Primary navigates to `/ecu`, secondary to `/can`.
- `src/constants/ecu-catalogue.ts` (+ test) — `SHIPPED_PROFILE_COUNT`, so the copy carries the real shipped count (37, not the planche's 34). `src/constants/ecu-catalogue.test.ts` reads `public/ecu-catalogue/index.json` and fails the build if the manifest and the constant ever drift apart.
- `src/components/ecu/EcuCatalogueList.tsx` — optional `searchRef` forwarded to the search `Input`, so the primary action has something to move the user to.

The state clears itself: on `/ecu` picking a catalogue entry sets the preview source, on `/live` applying a profile fills the signal store. No reload, no dialog.

## Why

T04 is the only one of the six states where nothing is wrong — there is simply nothing to bind yet — so it gets a box and two ways forward instead of a severity bar. The two surfaces that could show a bare "nothing here" sentence now show the same state with working actions.

Closes #183

## Deviations from the planche

1. **Profile count is 37, not 34.** The issue allows this explicitly — 34 was the count when the planche was drawn, `public/ecu-catalogue/index.json` ships 37 entries today. The constant is test-locked to the manifest.
2. **`PICK A PROFILE` on `/ecu` focuses the catalogue search instead of navigating.** The picker is already the left column of that route; navigating somewhere would be a no-op. On `/live` the same button navigates to `/ecu`.
3. **Placement classes (`mx-7 my-[26px] max-w-[560px]`) are mine.** The planche renders the box in a two-column 26px/28px-padded panel; the routes are full-width, so the box is capped at the planche's column width and gets the same panel padding. Box internals (border, 20/22 padding, 12px gap, type sizes, button metrics) are the planche's, untouched.

## Test plan

Run in the worktree, on top of `design/tuner-inline-state-block`:

- `npx tsc --noEmit` → No errors found
- `npm run lint` → No issues found
- `npx prettier --check .` → All files formatted correctly
- `npm run build` → ok
- `npx vitest run` → PASS (368) FAIL (0), including the new catalogue-count test

Nothing was failing on the base branch.

Visual: the component was server-rendered with its real class strings against the built `dist` CSS and screenshotted headless (Helium) in light and dark, then compared to the section C / T04 crop — 1 px box, no bar, no accent ground, 17px title, 13.5px/1.55 body, 12.5px buttons at 10px/16px with a 1px seam, everything flush left.

Reviewer should look at: `/ecu` with no profile loaded (right pane), `/live` with an empty signal store, and `/live` with a filter that matches nothing (still the plain sentence, not the state).