### PR TITLE
chore(tuner): pick up @canshift/core 6.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^6.6.0",
+        "@canshift/core": "^6.7.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-6.6.0.tgz",
-      "integrity": "sha512-tt+Ln9TkRWpU0mKOpVuHJ8iffgp48l83PdesOr0filzfMqMp57f5aghqmnu4fndQT+eo74lnN0E4Phhusfhfxw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-6.7.0.tgz",
+      "integrity": "sha512-fQJyMb0QsTx/pUEwKwXmAmI3Gc+1+FaKoRTHmMqMoC2VCWboAb2XVgtrd1xs28/Vlu9AR7uSi+gC3nHH1tBiKQ==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^6.6.0",
+    "@canshift/core": "^6.7.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",


### PR DESCRIPTION
Brings in CANShift/canshift-core#104 (`fix(core): disambiguate colliding signal names at parse time`, closes canshift-core#96), published to npm as `6.7.0` with provenance.

The caret in `package.json` already allowed it, but `npm ci` installs the lockfile — so without this the tuner keeps building against 6.6.0 and the fix never lands in production.

## What changes for the user

`parseCanXml` no longer emits two signals under one name. Nine catalogue profiles were affected, 42 signals in total — `tiremagic_tpms` (20), `syvecs`, `toyota_corolla_e150`, `flagtronics`, `haltech_v3`, `dominator_and_terminator_x`, `displaylink`, `maxxecu_default`, `turbolamik_tcu`. The first occurrence keeps its name, so any binding already saved in a `.canshift` project still resolves; later ones get a frame-id or ordinal suffix.

Each rename emits a parser warning, which this repo already surfaces — `useEcuSource` puts `result.warnings` on the source and `SignalPreviewTable` renders the count and the list. Loading `tiremagic_tpms.xml` will now show 15 warnings where it previously showed none and silently produced ambiguous bindings.

## Test plan

- `npm test` → 57 files, 367 passed
- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- `npm run build` clean
- `npm view @canshift/core version` → `6.7.0`; lockfile resolves to the published tarball

`package.json` range moves `^6.6.0` → `^6.7.0` so the floor matches what the code now depends on.