### PR TITLE
design(tuner): T01 connecting + T03 bus silent — inline, no spinner

### DIFF
--- a/src/components/states/BusSilentNotice.tsx
+++ b/src/components/states/BusSilentNotice.tsx
@@ -1,0 +1,22 @@
+import { InlineState } from '@/components/states/InlineState'
+import { useBusSilence } from '../../hooks/useBusSilence'
+
+const TITLE = 'The dash is connected, the bus is not'
+const BODY =
+  'Editing works and Live data stays empty. Check the bus rate and the 120 Ω termination.'
+
+export const BusSilentNotice = () => {
+  const { silent, elapsedSeconds } = useBusSilence()
+
+  if (!silent) return null
+
+  return (
+    <InlineState
+      className="shrink-0"
+      severity="warning"
+      kicker={`CAN · 0 FRAMES IN ${String(elapsedSeconds)} s`}
+      title={TITLE}
+      body={BODY}
+    />
+  )
+}

--- a/src/components/states/InlineState.tsx
+++ b/src/components/states/InlineState.tsx
@@ -75,7 +75,7 @@ const SKINS: Record<InlineStateSeverity, InlineStateSkin> = {
 const FRAMED_REGION = 'gap-[10px] px-4 py-[14px]'
 const HEADER_ROW =
   'flex items-center justify-between border-b border-brand-neutral-300 px-4 py-[11px] font-mono text-[11px] tracking-[0.12em] text-brand-neutral-600'
-const KICKER = 'font-mono text-[11px] uppercase tracking-[0.14em]'
+const KICKER = 'font-mono text-[11px] tracking-[0.14em]'
 const TITLE = 'font-sans text-[17px] font-extrabold'
 const BODY = 'text-[13.5px] leading-[1.55] text-brand-neutral-700'
 const FOOTNOTE = 'mt-3 text-[13px] leading-[1.55] text-brand-neutral-700'

--- a/src/components/welcome/ConnectColumn.tsx
+++ b/src/components/welcome/ConnectColumn.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { Spinner } from '@/components/ui/spinner'
+import { InlineState } from '@/components/states/InlineState'
 
 export interface ConnectColumnProps {
   supported: boolean
@@ -18,6 +18,21 @@ const STEPS = [
 ]
 
 const SUPPORTED_BROWSERS = ['Chrome 89+', 'Edge 89+', 'Brave', 'Opera']
+
+const CONNECT_LABELS = {
+  idle: 'Connect device',
+  connecting: 'Connecting…',
+  reconnecting: 'Reconnecting…',
+}
+
+type ConnectLabel = keyof typeof CONNECT_LABELS
+
+const connectLabel = (busy: boolean, reconnecting: boolean): ConnectLabel => {
+  if (!busy) return 'idle'
+  return reconnecting ? 'reconnecting' : 'connecting'
+}
+
+const OPENING_PORT_BODY = 'Handshake, then the firmware version. Usually under a second.'
 
 const KICKER = 'font-mono text-[10.5px] uppercase tracking-[0.2em] text-brand-neutral-600'
 
@@ -64,14 +79,7 @@ export const ConnectColumn = ({
     {supported ? (
       <div className="mt-8 flex flex-wrap gap-px">
         <button type="button" disabled={busy} onClick={onConnect} className={PRIMARY_ACTION}>
-          {busy ? (
-            <>
-              <Spinner size="sm" />
-              {reconnecting ? 'Reconnecting…' : 'Connecting…'}
-            </>
-          ) : (
-            'Connect device'
-          )}
+          {CONNECT_LABELS[connectLabel(busy, reconnecting)]}
         </button>
         {onExploreSimulation && (
           <button
@@ -86,6 +94,16 @@ export const ConnectColumn = ({
       </div>
     ) : (
       <UnsupportedBrowserPanel />
+    )}
+
+    {busy && (
+      <InlineState
+        className="mt-6"
+        severity="neutral"
+        kicker="USB CDC"
+        title="Opening the port…"
+        body={OPENING_PORT_BODY}
+      />
     )}
 
     {lastError !== null && (

--- a/src/hooks/useBusSilence.ts
+++ b/src/hooks/useBusSilence.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react'
+import { deviceEvents } from '../transport'
+import { useDeviceStore } from '../stores/device.store'
+
+const SILENCE_THRESHOLD_MS = 6000
+const TICK_MS = 1000
+
+export interface BusSilence {
+  silent: boolean
+  elapsedSeconds: number
+}
+
+const QUIET: BusSilence = { silent: false, elapsedSeconds: 0 }
+
+const subscribeToBusTraffic = (markTraffic: () => void): (() => void) => {
+  const unsubscribers = [
+    deviceEvents.onCanFrame(markTraffic),
+    deviceEvents.onSignal(markTraffic),
+    deviceEvents.onCanHealth(({ fps }) => {
+      if (fps > 0) markTraffic()
+    }),
+  ]
+  return () => {
+    unsubscribers.forEach((unsubscribe) => {
+      unsubscribe()
+    })
+  }
+}
+
+const nextSilence = (elapsedMs: number): BusSilence =>
+  elapsedMs >= SILENCE_THRESHOLD_MS
+    ? { silent: true, elapsedSeconds: Math.floor(elapsedMs / 1000) }
+    : QUIET
+
+const sameSilence = (a: BusSilence, b: BusSilence): boolean =>
+  a.silent === b.silent && a.elapsedSeconds === b.elapsedSeconds
+
+export const useBusSilence = (): BusSilence => {
+  const connected = useDeviceStore((s) => s.connected)
+  const simulationMode = useDeviceStore((s) => s.simulationMode)
+  const [silence, setSilence] = useState<BusSilence>(QUIET)
+
+  useEffect(() => {
+    setSilence(QUIET)
+    if (!connected || simulationMode) return
+
+    let lastTrafficAt = Date.now()
+    const unsubscribe = subscribeToBusTraffic(() => {
+      lastTrafficAt = Date.now()
+    })
+    const timer = setInterval(() => {
+      const candidate = nextSilence(Date.now() - lastTrafficAt)
+      setSilence((previous) => (sameSilence(previous, candidate) ? previous : candidate))
+    }, TICK_MS)
+
+    return () => {
+      clearInterval(timer)
+      unsubscribe()
+    }
+  }, [connected, simulationMode])
+
+  return silence
+}

--- a/src/routes/CanBusRoute.tsx
+++ b/src/routes/CanBusRoute.tsx
@@ -9,6 +9,7 @@ import { useLogStore } from '../stores/log.store'
 import { formatFrameIdHex, parseHexFrameId } from '../utils/frame-id'
 import { buildDraftSignal, sortFrames } from '../utils/can-frames'
 import { RoutePage } from '../components/ui/route-shell'
+import { BusSilentNotice } from '../components/states/BusSilentNotice'
 
 const CanBusRoute = () => {
   const connected = useDeviceStore((s) => s.connected)
@@ -76,6 +77,7 @@ const CanBusRoute = () => {
         }}
         onLearnStop={scanner.stopLearn}
       />
+      <BusSilentNotice />
       <CanFrameTable
         frames={sortedFrames}
         mappedTo={mappedTo}

--- a/src/routes/LiveDataRoute.tsx
+++ b/src/routes/LiveDataRoute.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils'
 import { SourceBadge, type SignalSource } from '../components/live-data/SourceBadge'
 import { RouteHeader } from '../components/shell/RouteHeader'
 import { RoutePage } from '../components/ui/route-shell'
+import { BusSilentNotice } from '../components/states/BusSilentNotice'
 import { useLiveSignals } from '../hooks/useLiveSignals'
 import { useSignalStore } from '../stores/signal.store'
 import { useDeviceStore } from '../stores/device.store'
@@ -118,6 +119,8 @@ const LiveDataRoute = () => {
           </>
         }
       />
+
+      <BusSilentNotice />
 
       {filteredSignals.length === 0 ? (
         <div className={EMPTY}>


### PR DESCRIPTION
Stacked on #185 (`design/tuner-inline-state-block`) — review that one first. This PR only consumes the `InlineState` primitive it added.

## What changed

**T01 — Connecting** (`src/components/welcome/ConnectColumn.tsx`)

- The connect button no longer renders a `Spinner`. Its label is now a `Record`-keyed lookup (`CONNECT_LABELS`) instead of a chained ternary.
- While the port is opening (`busy`, i.e. transport status `connecting` or `reconnecting`), the column renders the neutral `InlineState`: 3 px `var(--color-text)` bar on `var(--color-neutral-100)`, kicker `USB CDC`, title `Opening the port…` (U+2026), body `Handshake, then the firmware version. Usually under a second.`
- No progress bar, no percentage, no animation. The sentence carries the wait.

**T03 — Bus silent** (new `src/components/states/BusSilentNotice.tsx` + `src/hooks/useBusSilence.ts`)

- `useBusSilence` watches real transport traffic while the dash is connected and not in simulation: it marks activity on `can` frames, `tele` frames and `can_stat` frames reporting `fps > 0`, ticks once a second, and reports silence past a 6 s threshold. The elapsed count in the kicker is the real number of seconds since the last frame — it keeps counting up past 6.
- `BusSilentNotice` renders the warning `InlineState` (3 px `#FF8800` bar, neutral-600 kicker, neutral-100 ground) with kicker `CAN · 0 FRAMES IN <n> s`, title `The dash is connected, the bus is not`, body `Editing works and Live data stays empty. Check the bus rate and the 120 Ω termination.` (U+03A9). It returns `null` when the bus is talking, so it never occupies space on a healthy link.
- Mounted in `CanBusRoute` (under the scan toolbar) and `LiveDataRoute` (under the route header). Both are inline blocks in the normal flow — the frame table, the signal grid, editing and burning stay reachable.

## Why

Issue #181, planche section C. Both connection states were previously either a spinner in a button or nothing at all. The planche is explicit that the editor never blocks and that neither state animates.

Closes #181

## One change to the base primitive

`InlineState`'s `KICKER` constant dropped `uppercase`. The planche writes `CAN · 0 FRAMES IN 6 s` with a **lowercase** `s` for the seconds unit, and the CSS `text-transform` was rendering it as `6 S`. Every other kicker in the repo (`USB CDC`, `USB CDC · CONFIG DIFFERS`, `PUT_CONFIG · E_CRC`, `PAGES n · MAX n`) is already authored uppercase, so removing the transform is a visual no-op for them — verified by grepping every `kicker=` call site. Nothing else about the primitive was touched.

## Deviations from the planche

1. **The connect button still says `Connecting…` / `Reconnecting…`.** The planche does not draw the welcome button, only the T01 block. Dropping the spinner but keeping a disabled-state label is the smallest change that satisfies "no spinner" without leaving the button silent.
2. **T01 shows for `reconnecting` too.** The planche has one connecting state; auto-reconnect opens the same USB CDC port, so it gets the same block rather than an invented second one.
3. **Silence is inferred from three frame kinds, not just `can`.** The firmware only streams `can` frames while a scan is running, so `tele` and `can_stat` are needed for the state to be honest outside `/can`. `can_stat` with `fps === 0` is deliberately *not* counted as traffic — that frame is itself evidence the bus is quiet.

## Test plan

Ran in the worktree, all green, none were failing on the base branch:

- `npx tsc --noEmit` → No errors found
- `npm run lint` → No issues found
- `npx prettier --check .` → All files formatted correctly
- `npm run build` → built
- `npx vitest run` → PASS (367) FAIL (0)

Visual: rendered both blocks with the exact class strings the components emit against the built `dist` CSS, screenshotted headless in dark and light, and compared to the section C crops — 3 px bar, 18/14 padding, 11 px / 0.14em mono kicker, 17 px 800 title, 13.5 px body, `#FF8800` (`--brand-warning: 32 100% 50%`) all match, and `6 s` / `120 Ω` render with the right glyphs.

What a reviewer should look at:

- Connect a dash on `/` and watch the port open — the block appears, nothing spins.
- Connect a dash with the CAN harness unplugged, then open `/can` and `/live` — the warning block appears after 6 s and the counter climbs; only the bar is amber, the kicker stays grey.
- Plug the harness back in — the block disappears within a second.
- Editing pages and burning stay reachable the whole time.

