### PR TITLE
design(live-data): T06 listening state with skeleton rows

### DIFF
--- a/src/components/live-data/LiveDataGrid.tsx
+++ b/src/components/live-data/LiveDataGrid.tsx
@@ -1,6 +1,7 @@
 import { cva } from 'class-variance-authority'
 import type { SignalDef } from '@canshift/core'
 import { cn } from '@/lib/utils'
+import { LIVE_DATA_CELL, LIVE_DATA_GRID } from './grid-shape'
 
 export interface LiveDataGridProps {
   signals: readonly SignalDef[]
@@ -8,13 +9,6 @@ export interface LiveDataGridProps {
 }
 
 const DANGER_FRACTION = 0.9
-
-const GRID = 'grid flex-1 grid-cols-4 overflow-y-auto [grid-auto-rows:minmax(150px,1fr)]'
-
-const CELL = [
-  'flex min-w-0 flex-col justify-center gap-[9px] px-5 py-[18px]',
-  'border-r border-b border-solid border-brand-neutral-300',
-].join(' ')
 
 const CELL_LABEL = [
   'overflow-hidden text-ellipsis whitespace-nowrap',
@@ -47,13 +41,13 @@ const fractionOf = (signal: SignalDef, raw: number | undefined): number => {
 }
 
 export const LiveDataGrid = ({ signals, values }: LiveDataGridProps) => (
-  <div className={GRID}>
+  <div className={LIVE_DATA_GRID}>
     {signals.map((signal) => {
       const raw = values[signal.name]
       const fraction = fractionOf(signal, raw)
       const danger = fraction >= DANGER_FRACTION
       return (
-        <div key={signal.name} className={CELL}>
+        <div key={signal.name} className={LIVE_DATA_CELL}>
           <span className={CELL_LABEL}>{signal.name.replace(/_/g, ' ').toUpperCase()}</span>
           <div className="flex items-baseline gap-1.5">
             <span className={cn(CELL_VALUE, tinted({ danger }))}>

--- a/src/components/live-data/LiveDataGrid.tsx
+++ b/src/components/live-data/LiveDataGrid.tsx
@@ -1,0 +1,75 @@
+import { cva } from 'class-variance-authority'
+import type { SignalDef } from '@canshift/core'
+import { cn } from '@/lib/utils'
+
+export interface LiveDataGridProps {
+  signals: readonly SignalDef[]
+  values: Record<string, number>
+}
+
+const DANGER_FRACTION = 0.9
+
+const GRID = 'grid flex-1 grid-cols-4 overflow-y-auto [grid-auto-rows:minmax(150px,1fr)]'
+
+const CELL = [
+  'flex min-w-0 flex-col justify-center gap-[9px] px-5 py-[18px]',
+  'border-r border-b border-solid border-brand-neutral-300',
+].join(' ')
+
+const CELL_LABEL = [
+  'overflow-hidden text-ellipsis whitespace-nowrap',
+  'text-[10px] font-extrabold tracking-[0.18em] text-brand-neutral-600',
+].join(' ')
+
+const CELL_VALUE = 'font-mono text-[44px] leading-[1.1] tabular-nums'
+
+const tinted = cva('', {
+  variants: {
+    danger: { true: 'text-brand-accent', false: 'text-brand-text' },
+  },
+  defaultVariants: { danger: false },
+})
+
+const barFill = cva('h-full', {
+  variants: {
+    danger: { true: 'bg-brand-accent', false: 'bg-brand-text' },
+  },
+  defaultVariants: { danger: false },
+})
+
+const formatValue = (value: number): string =>
+  Number.isInteger(value) ? String(value) : value.toFixed(1)
+
+const fractionOf = (signal: SignalDef, raw: number | undefined): number => {
+  if (raw === undefined) return 0
+  const range = signal.max - signal.min || 1
+  return Math.max(0, Math.min(1, (raw - signal.min) / range))
+}
+
+export const LiveDataGrid = ({ signals, values }: LiveDataGridProps) => (
+  <div className={GRID}>
+    {signals.map((signal) => {
+      const raw = values[signal.name]
+      const fraction = fractionOf(signal, raw)
+      const danger = fraction >= DANGER_FRACTION
+      return (
+        <div key={signal.name} className={CELL}>
+          <span className={CELL_LABEL}>{signal.name.replace(/_/g, ' ').toUpperCase()}</span>
+          <div className="flex items-baseline gap-1.5">
+            <span className={cn(CELL_VALUE, tinted({ danger }))}>
+              {raw !== undefined ? formatValue(raw) : '—'}
+            </span>
+            <span className="font-mono text-[13px] text-brand-neutral-600">{signal.unit}</span>
+          </div>
+          <div className="h-1 bg-brand-neutral-300">
+            <div
+              className={cn(barFill({ danger }))}
+              // eslint-disable-next-line no-inline-style/no-inline-style
+              style={{ width: `${String(Math.round(fraction * 100))}%` }}
+            />
+          </div>
+        </div>
+      )
+    })}
+  </div>
+)

--- a/src/components/live-data/LiveDataSkeleton.test.tsx
+++ b/src/components/live-data/LiveDataSkeleton.test.tsx
@@ -1,31 +1,73 @@
 import { describe, expect, it } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
+import type { SignalDef } from '@canshift/core'
+import { LiveDataGrid } from './LiveDataGrid'
 import { LiveDataSkeleton } from './LiveDataSkeleton'
 
-const ROW_MARKER = 'items-center gap-[14px]'
+const CELL_MARKER = 'py-[18px]'
+const GRID_MARKER = 'grid-cols-'
 
-const render = (signalNames: string[]): string =>
-  renderToStaticMarkup(<LiveDataSkeleton signalNames={signalNames} />)
+const signal = (name: string): SignalDef =>
+  ({
+    name,
+    canFrameId: '0x370',
+    startByte: 0,
+    byteLength: 2,
+    bigEndian: true,
+    signed: false,
+    scale: 0.1,
+    offset: 0,
+    unit: '°C',
+    min: 0,
+    max: 150,
+    timeoutMs: 1000,
+  }) as SignalDef
 
-const countRows = (markup: string): number => markup.split(ROW_MARKER).length - 1
+const SIGNALS = ['rpm', 'coolant_temp', 'oil_pressure_front'].map(signal)
+
+const classAttributes = (markup: string): string[] =>
+  [...markup.matchAll(/class="([^"]*)"/g)].map((match) => match[1] ?? '')
+
+const gridClassOf = (markup: string): string =>
+  classAttributes(markup).find((value) => value.includes(GRID_MARKER)) ?? ''
+
+const cellClassesOf = (markup: string): string[] =>
+  classAttributes(markup).filter((value) => value.includes(CELL_MARKER))
+
+const renderSkeleton = (names: string[]): string =>
+  renderToStaticMarkup(<LiveDataSkeleton signalNames={names} />)
+
+const renderGrid = (signals: SignalDef[]): string =>
+  renderToStaticMarkup(<LiveDataGrid signals={signals} values={{}} />)
 
 describe('LiveDataSkeleton', () => {
-  it('renders one row per bound signal so the panel keeps its height', () => {
-    expect(countRows(render(['rpm', 'coolant_temp', 'oil_pressure_front']))).toBe(3)
-    expect(countRows(render(['rpm']))).toBe(1)
-    expect(countRows(render([]))).toBe(0)
+  it('renders one cell per bound signal so the panel keeps its height', () => {
+    expect(cellClassesOf(renderSkeleton(SIGNALS.map((s) => s.name)))).toHaveLength(3)
+    expect(cellClassesOf(renderSkeleton(['rpm']))).toHaveLength(1)
+    expect(cellClassesOf(renderSkeleton([]))).toHaveLength(0)
+  })
+
+  it('lays out on the same columns and row metrics as the loaded grid', () => {
+    const skeleton = renderSkeleton(SIGNALS.map((s) => s.name))
+    const grid = renderGrid(SIGNALS)
+    expect(gridClassOf(skeleton)).toBe(gridClassOf(grid))
+    expect(cellClassesOf(skeleton)).toEqual(cellClassesOf(grid))
   })
 
   it('sizes the label block from the signal name length', () => {
-    expect(render(['rpm'])).toContain('w-[64px]')
-    expect(render(['coolant_temp'])).toContain('w-[88px]')
-    expect(render(['oil_pressure_front'])).toContain('w-[104px]')
+    expect(renderSkeleton(['rpm'])).toContain('w-[64px]')
+    expect(renderSkeleton(['coolant_temp'])).toContain('w-[88px]')
+    expect(renderSkeleton(['oil_pressure_front'])).toContain('w-[104px]')
   })
 
   it('announces listening with no spinner and no animation', () => {
-    const markup = render(['rpm', 'coolant_temp'])
+    const markup = renderSkeleton(['rpm', 'coolant_temp'])
     expect(markup).toContain('LIVE DATA')
     expect(markup).toContain('LISTENING…')
     expect(markup).not.toMatch(/animate-|shimmer|<svg/i)
+  })
+
+  it('ships the box only, without the planche caption', () => {
+    expect(renderSkeleton(['rpm'])).not.toMatch(/skeleton rows|no spinner|does not resize/i)
   })
 })

--- a/src/components/live-data/LiveDataSkeleton.test.tsx
+++ b/src/components/live-data/LiveDataSkeleton.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { LiveDataSkeleton } from './LiveDataSkeleton'
+
+const ROW_MARKER = 'items-center gap-[14px]'
+
+const render = (signalNames: string[]): string =>
+  renderToStaticMarkup(<LiveDataSkeleton signalNames={signalNames} />)
+
+const countRows = (markup: string): number => markup.split(ROW_MARKER).length - 1
+
+describe('LiveDataSkeleton', () => {
+  it('renders one row per bound signal so the panel keeps its height', () => {
+    expect(countRows(render(['rpm', 'coolant_temp', 'oil_pressure_front']))).toBe(3)
+    expect(countRows(render(['rpm']))).toBe(1)
+    expect(countRows(render([]))).toBe(0)
+  })
+
+  it('sizes the label block from the signal name length', () => {
+    expect(render(['rpm'])).toContain('w-[64px]')
+    expect(render(['coolant_temp'])).toContain('w-[88px]')
+    expect(render(['oil_pressure_front'])).toContain('w-[104px]')
+  })
+
+  it('announces listening with no spinner and no animation', () => {
+    const markup = render(['rpm', 'coolant_temp'])
+    expect(markup).toContain('LIVE DATA')
+    expect(markup).toContain('LISTENING…')
+    expect(markup).not.toMatch(/animate-|shimmer|<svg/i)
+  })
+})

--- a/src/components/live-data/LiveDataSkeleton.tsx
+++ b/src/components/live-data/LiveDataSkeleton.tsx
@@ -1,14 +1,15 @@
-import { InlineState } from '@/components/states/InlineState'
+import { InlineStateHeaderRow } from '@/components/states/InlineState'
 import { cn } from '@/lib/utils'
+import { LIVE_DATA_CELL, LIVE_DATA_GRID } from './grid-shape'
 
 export interface LiveDataSkeletonProps {
   signalNames: readonly string[]
   className?: string | undefined
 }
 
-const ROW = 'flex w-full items-center gap-[14px]'
+const PANEL = 'flex min-h-0 flex-1 flex-col'
 const LABEL_BLOCK = 'h-[11px] bg-brand-neutral-300'
-const VALUE_BLOCK = 'h-[11px] flex-1 bg-brand-neutral-200'
+const VALUE_BLOCK = 'h-[48px] w-full bg-brand-neutral-200'
 
 const LABEL_WIDTH_STEPS = [
   { maxNameLength: 6, className: 'w-[64px]' },
@@ -22,17 +23,15 @@ const labelWidthFor = (name: string): string =>
   LONGEST_LABEL_WIDTH
 
 export const LiveDataSkeleton = ({ signalNames, className }: LiveDataSkeletonProps) => (
-  <InlineState
-    severity="empty"
-    className={className}
-    header={{ label: 'LIVE DATA', status: 'LISTENING…' }}
-    footnote="Skeleton rows, no spinner. The row count is the profile's signal count, so the panel does not resize when data arrives."
-  >
-    {signalNames.map((name) => (
-      <div key={name} className={ROW}>
-        <div className={cn(LABEL_BLOCK, labelWidthFor(name))} />
-        <div className={VALUE_BLOCK} />
-      </div>
-    ))}
-  </InlineState>
+  <div role="status" className={cn(PANEL, className)}>
+    <InlineStateHeaderRow header={{ label: 'LIVE DATA', status: 'LISTENING…' }} />
+    <div className={LIVE_DATA_GRID}>
+      {signalNames.map((name) => (
+        <div key={name} className={LIVE_DATA_CELL}>
+          <div className={cn(LABEL_BLOCK, labelWidthFor(name))} />
+          <div className={VALUE_BLOCK} />
+        </div>
+      ))}
+    </div>
+  </div>
 )

--- a/src/components/live-data/LiveDataSkeleton.tsx
+++ b/src/components/live-data/LiveDataSkeleton.tsx
@@ -1,0 +1,38 @@
+import { InlineState } from '@/components/states/InlineState'
+import { cn } from '@/lib/utils'
+
+export interface LiveDataSkeletonProps {
+  signalNames: readonly string[]
+  className?: string | undefined
+}
+
+const ROW = 'flex w-full items-center gap-[14px]'
+const LABEL_BLOCK = 'h-[11px] bg-brand-neutral-300'
+const VALUE_BLOCK = 'h-[11px] flex-1 bg-brand-neutral-200'
+
+const LABEL_WIDTH_STEPS = [
+  { maxNameLength: 6, className: 'w-[64px]' },
+  { maxNameLength: 12, className: 'w-[88px]' },
+] as const
+
+const LONGEST_LABEL_WIDTH = 'w-[104px]'
+
+const labelWidthFor = (name: string): string =>
+  LABEL_WIDTH_STEPS.find((step) => name.length <= step.maxNameLength)?.className ??
+  LONGEST_LABEL_WIDTH
+
+export const LiveDataSkeleton = ({ signalNames, className }: LiveDataSkeletonProps) => (
+  <InlineState
+    severity="empty"
+    className={className}
+    header={{ label: 'LIVE DATA', status: 'LISTENING…' }}
+    footnote="Skeleton rows, no spinner. The row count is the profile's signal count, so the panel does not resize when data arrives."
+  >
+    {signalNames.map((name) => (
+      <div key={name} className={ROW}>
+        <div className={cn(LABEL_BLOCK, labelWidthFor(name))} />
+        <div className={VALUE_BLOCK} />
+      </div>
+    ))}
+  </InlineState>
+)

--- a/src/components/live-data/grid-shape.ts
+++ b/src/components/live-data/grid-shape.ts
@@ -1,0 +1,7 @@
+export const LIVE_DATA_GRID =
+  'grid flex-1 grid-cols-4 overflow-y-auto [grid-auto-rows:minmax(150px,1fr)]'
+
+export const LIVE_DATA_CELL = [
+  'flex min-w-0 flex-col justify-center gap-[9px] px-5 py-[18px]',
+  'border-r border-b border-solid border-brand-neutral-300',
+].join(' ')

--- a/src/components/states/InlineState.tsx
+++ b/src/components/states/InlineState.tsx
@@ -122,7 +122,11 @@ const InlineStateActions = ({
   )
 }
 
-const InlineStateHeaderRow = ({ header }: { header: InlineStateHeader | undefined }) => {
+export interface InlineStateHeaderRowProps {
+  header: InlineStateHeader | undefined
+}
+
+export const InlineStateHeaderRow = ({ header }: InlineStateHeaderRowProps) => {
   if (!header) return null
   return (
     <div className={HEADER_ROW}>

--- a/src/routes/LiveDataRoute.tsx
+++ b/src/routes/LiveDataRoute.tsx
@@ -22,8 +22,6 @@ const EXPORT_BUTTON = [
   'text-brand-text disabled:cursor-not-allowed disabled:text-brand-neutral-500',
 ].join(' ')
 
-const LISTENING = 'flex-1 overflow-y-auto px-6 py-5'
-
 const escapeCsv = (value: string): string => {
   if (/[",\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`
   return value
@@ -98,11 +96,7 @@ const LiveDataRoute = () => {
         }}
       />
     ),
-    listening: (
-      <div className={LISTENING}>
-        <LiveDataSkeleton signalNames={filteredSignals.map((s) => s.name)} />
-      </div>
-    ),
+    listening: <LiveDataSkeleton signalNames={filteredSignals.map((s) => s.name)} />,
     values: <LiveDataGrid signals={filteredSignals} values={values} />,
   }
 

--- a/src/routes/LiveDataRoute.tsx
+++ b/src/routes/LiveDataRoute.tsx
@@ -1,9 +1,11 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { cva } from 'class-variance-authority'
+import type { SignalDef } from '@canshift/core'
 import { cn } from '@/lib/utils'
 import { LiveDataEmpty } from '../components/live-data/LiveDataEmpty'
 import { SourceBadge, type SignalSource } from '../components/live-data/SourceBadge'
+import { LiveDataGrid } from '../components/live-data/LiveDataGrid'
+import { LiveDataSkeleton } from '../components/live-data/LiveDataSkeleton'
 import { RouteHeader } from '../components/shell/RouteHeader'
 import { RoutePage } from '../components/ui/route-shell'
 import { BusSilentNotice } from '../components/states/BusSilentNotice'
@@ -12,7 +14,7 @@ import { useSignalStore } from '../stores/signal.store'
 import { useDeviceStore } from '../stores/device.store'
 import { Input } from '../components/ui/input'
 
-const DANGER_FRACTION = 0.9
+type LiveDataView = 'empty' | 'listening' | 'values'
 
 const EXPORT_BUTTON = [
   'border border-solid border-brand-neutral-400 bg-transparent px-3.5 py-1.5',
@@ -20,33 +22,48 @@ const EXPORT_BUTTON = [
   'text-brand-text disabled:cursor-not-allowed disabled:text-brand-neutral-500',
 ].join(' ')
 
-const GRID = 'grid flex-1 grid-cols-4 overflow-y-auto [grid-auto-rows:minmax(150px,1fr)]'
+const LISTENING = 'flex-1 overflow-y-auto px-6 py-5'
 
-const CELL = [
-  'flex min-w-0 flex-col justify-center gap-[9px] px-5 py-[18px]',
-  'border-r border-b border-solid border-brand-neutral-300',
-].join(' ')
+const escapeCsv = (value: string): string => {
+  if (/[",\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`
+  return value
+}
 
-const CELL_LABEL = [
-  'overflow-hidden text-ellipsis whitespace-nowrap',
-  'text-[10px] font-extrabold tracking-[0.18em] text-brand-neutral-600',
-].join(' ')
+const buildCsv = (signals: readonly SignalDef[], values: Record<string, number>): string => {
+  const rows = [
+    ['name', 'value', 'unit', 'min', 'max'],
+    ...signals.map((s) => {
+      const v = values[s.name]
+      return [s.name, v !== undefined ? String(v) : '', s.unit, String(s.min), String(s.max)]
+    }),
+  ]
+  return rows.map((r) => r.map(escapeCsv).join(',')).join('\n')
+}
 
-const tinted = cva('', {
-  variants: {
-    danger: { true: 'text-brand-accent', false: 'text-brand-text' },
-  },
-  defaultVariants: { danger: false },
-})
+const downloadCsv = (signals: readonly SignalDef[], values: Record<string, number>): void => {
+  const blob = new Blob([buildCsv(signals, values)], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+  a.href = url
+  a.download = `canshift-live-${stamp}.csv`
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
 
-const barFill = cva('h-full', {
-  variants: {
-    danger: { true: 'bg-brand-accent', false: 'bg-brand-text' },
-  },
-  defaultVariants: { danger: false },
-})
+const resolveSource = (connected: boolean, simulationMode: boolean): SignalSource => {
+  if (simulationMode) return 'sim'
+  if (connected) return 'live'
+  return 'none'
+}
 
-const CELL_VALUE = 'font-mono text-[44px] leading-[1.1] tabular-nums'
+const resolveView = (hasRows: boolean, awaitingFirstFrame: boolean): LiveDataView => {
+  if (!hasRows) return 'empty'
+  if (awaitingFirstFrame) return 'listening'
+  return 'values'
+}
 
 const LiveDataRoute = () => {
   const signals = useSignalStore((s) => s.signals)
@@ -56,8 +73,7 @@ const LiveDataRoute = () => {
   const navigate = useNavigate()
   const [filter, setFilter] = useState('')
 
-  const isLive = connected && !simulationMode
-  const source: SignalSource = isLive ? 'live' : simulationMode ? 'sim' : 'none'
+  const source = resolveSource(connected, simulationMode)
 
   const filteredSignals = useMemo(() => {
     const q = filter.trim().toLowerCase()
@@ -67,25 +83,27 @@ const LiveDataRoute = () => {
     )
   }, [signals, filter])
 
-  const handleExport = () => {
-    const rows = [
-      ['name', 'value', 'unit', 'min', 'max'],
-      ...signals.map((s) => {
-        const v = values[s.name]
-        return [s.name, v !== undefined ? String(v) : '', s.unit, String(s.min), String(s.max)]
-      }),
-    ]
-    const csv = rows.map((r) => r.map(escapeCsv).join(',')).join('\n')
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    const stamp = new Date().toISOString().replace(/[:.]/g, '-')
-    a.href = url
-    a.download = `canshift-live-${stamp}.csv`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
+  const awaitingFirstFrame = (connected || simulationMode) && Object.keys(values).length === 0
+  const view = resolveView(filteredSignals.length > 0, awaitingFirstFrame)
+
+  const views: Record<LiveDataView, ReactNode> = {
+    empty: (
+      <LiveDataEmpty
+        hasProfile={signals.length > 0}
+        onPickProfile={() => {
+          void navigate('/ecu')
+        }}
+        onCaptureBus={() => {
+          void navigate('/can')
+        }}
+      />
+    ),
+    listening: (
+      <div className={LISTENING}>
+        <LiveDataSkeleton signalNames={filteredSignals.map((s) => s.name)} />
+      </div>
+    ),
+    values: <LiveDataGrid signals={filteredSignals} values={values} />,
   }
 
   return (
@@ -112,7 +130,9 @@ const LiveDataRoute = () => {
             <button
               type="button"
               className={cn('editor-ghost-accent', EXPORT_BUTTON)}
-              onClick={handleExport}
+              onClick={() => {
+                downloadCsv(signals, values)
+              }}
               disabled={signals.length === 0}
             >
               EXPORT CSV
@@ -123,54 +143,9 @@ const LiveDataRoute = () => {
 
       <BusSilentNotice />
 
-      {filteredSignals.length === 0 ? (
-        <LiveDataEmpty
-          hasProfile={signals.length > 0}
-          onPickProfile={() => {
-            void navigate('/ecu')
-          }}
-          onCaptureBus={() => {
-            void navigate('/can')
-          }}
-        />
-      ) : (
-        <div className={GRID}>
-          {filteredSignals.map((sig) => {
-            const raw = values[sig.name]
-            const range = sig.max - sig.min || 1
-            const pct = raw !== undefined ? Math.max(0, Math.min(1, (raw - sig.min) / range)) : 0
-            const danger = pct >= DANGER_FRACTION
-            return (
-              <div key={sig.name} className={CELL}>
-                <span className={CELL_LABEL}>{sig.name.replace(/_/g, ' ').toUpperCase()}</span>
-                <div className="flex items-baseline gap-1.5">
-                  <span className={cn(CELL_VALUE, tinted({ danger }))}>
-                    {raw !== undefined ? formatValue(raw) : '—'}
-                  </span>
-                  <span className="font-mono text-[13px] text-brand-neutral-600">{sig.unit}</span>
-                </div>
-                <div className="h-1 bg-brand-neutral-300">
-                  <div
-                    className={cn(barFill({ danger }))}
-                    // eslint-disable-next-line no-inline-style/no-inline-style
-                    style={{ width: `${String(Math.round(pct * 100))}%` }}
-                  />
-                </div>
-              </div>
-            )
-          })}
-        </div>
-      )}
+      {views[view]}
     </RoutePage>
   )
-}
-
-const formatValue = (value: number): string =>
-  Number.isInteger(value) ? String(value) : value.toFixed(1)
-
-const escapeCsv = (value: string): string => {
-  if (/[",\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`
-  return value
 }
 
 export default LiveDataRoute


### PR DESCRIPTION
Replaces #187, which GitHub auto-closed when its base branch (`design/tuner-inline-state-block`, #185) was deleted at merge time. Same work, rebased onto today's `main` — T01/T03 (`BusSilentNotice`), T04 (`LiveDataEmpty` / `NoEcuProfileState`) and T02/T05 have landed since, and all of them are preserved here.

## What T06 is

The live-data panel used to render a full grid of `—` placeholders while it waited for the first CAN frame. T06 replaces that with an explicit **listening** state: the panel header reads `LIVE DATA · LISTENING…` and the body shows **skeleton rows, no spinner**. The row count equals the bound profile's signal count, so the panel does not resize when data arrives.

## What changed

- `src/components/live-data/LiveDataSkeleton.tsx` — new. Header frame from the shared `InlineState` primitive (`InlineStateHeaderRow`, now exported), then one skeleton cell per bound signal. No spinner, no shimmer, no pulse, no icon, radius 0. Label-block width comes from the signal-name length through the three planche widths (64 / 88 / 104 px) via a lookup table, so the Tailwind class strings stay literal.
- `src/components/live-data/grid-shape.ts` — new. `LIVE_DATA_GRID` and `LIVE_DATA_CELL` are the single source of the grid geometry: columns, row height, cell padding and borders. **Both** `LiveDataGrid` and `LiveDataSkeleton` import them, so the skeleton and the loaded grid are pixel-identical in layout and nothing shifts when the first frame lands.
- `src/components/live-data/LiveDataGrid.tsx` — new. The value grid moved out of the route **verbatim**: same `DANGER_FRACTION`, same `cva` tinting through `cn`, same `CELL_VALUE` at 44 px, same bar fill. Behaviour is unchanged.
- `src/routes/LiveDataRoute.tsx` — the panel body is now a `Record<LiveDataView, ReactNode>` lookup on one named state (`empty` | `listening` | `values`) instead of a chained conditional, per the repo's Code shape rule. `listening` is entered when the route is connected or simulating and no frame has landed yet; a disconnected route still shows the value grid, unchanged. `BusSilentNotice` stays mounted exactly as `main` mounts it, and `empty` renders T04's `LiveDataEmpty` exactly as `main` wires it (filter-empty vs. no-profile is `LiveDataEmpty`'s own branch).
- The CSV export helpers were hoisted to module scope for the function-length budget. Behaviour is unchanged.
- No designer caption ships as UI text; a test asserts it.

## Deviations from the planche

1. **No 1 px outer border on the listening box.** The planche draws T06 as a standalone bordered card, but `/live` is a full-height route whose grid already carries the cell borders — an outer box would double the rule against the grid's own right/bottom borders. The header rule stays.
2. **The header keeps `px-4 py-[11px]`** — the shared `InlineState` header-row metrics — rather than re-typing the planche's slightly different padding. Consistency with T01–T05 wins over a 1 px difference nobody can see side by side.

## Test plan

Run in the worktree on the rebased branch, all green:

- `npx tsc --noEmit` → No errors found
- `npm run lint` → No issues found
- `npx prettier --check .` → All files formatted correctly
- `npm run build` → built
- `npx vitest run` → PASS (389) FAIL (0)

`LiveDataSkeleton.test.tsx` covers: one cell per bound signal (3 / 1 / 0), the skeleton and the loaded grid rendering **the same grid class string and the same cell class strings** (the shared-geometry guarantee), the label width tracking the name length, the header saying `LISTENING…` with no animation and no `<svg>`, and no designer caption in the markup.

What a reviewer should look at: `grid-shape.ts` as the shared geometry, and the `views` lookup in `LiveDataRoute.tsx` for the branch that decides when the state shows.

Closes #184
