### PR TITLE
chore(tuner): pick up @canshift/core 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^6.7.0",
+        "@canshift/core": "^7.0.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-6.7.0.tgz",
-      "integrity": "sha512-fQJyMb0QsTx/pUEwKwXmAmI3Gc+1+FaKoRTHmMqMoC2VCWboAb2XVgtrd1xs28/Vlu9AR7uSi+gC3nHH1tBiKQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-7.0.0.tgz",
+      "integrity": "sha512-OYBaKie+AGOxjpAnDvcuRBZlbZdTUubgr6A2VfhM8ZDzVtIR8XBVFeZMvjZ7Qq3NcgN4keq+nQ+ODqh+NPn+bg==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^6.7.0",
+    "@canshift/core": "^7.0.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",


### PR DESCRIPTION
Moves the range to `^7.0.0`, published from CANShift/canshift-core#107 (`feat(core)!: drop colorRamp from SignalDef`, closes canshift-core#86).

The major is breaking on paper: `SignalDef` loses its `colorRamp` field and `SignalDefSchema` becomes a `ZodPipe` rather than a `ZodObject`. Neither reaches this repo — `grep -rn colorRamp src` is empty and nothing imports `SignalDefSchema` to call `.extend` / `.shape` on it — so this is a range change with no code change.

`npm run typecheck` passing against 7.0.0 is the real check here: it is what proves the tuner never read the dropped field.

Legacy `.canshift` projects are unaffected. Core drops deprecated signal keys in a `z.preprocess` ahead of validation, so a project saved with `colorRamp` still opens, comes back without the field, and does not write it back out.

## Test plan

- `npm run typecheck` clean — the assertion that matters for a major bump
- `npm test` → 60 files, 384 passed
- `npm run build`, `npm run lint` clean
- `npm view @canshift/core version` → `7.0.0`