### PR TITLE
chore(tuner): pick up @canshift/core 7.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^7.0.0",
+        "@canshift/core": "^7.0.1",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-7.0.0.tgz",
-      "integrity": "sha512-OYBaKie+AGOxjpAnDvcuRBZlbZdTUubgr6A2VfhM8ZDzVtIR8XBVFeZMvjZ7Qq3NcgN4keq+nQ+ODqh+NPn+bg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-7.0.1.tgz",
+      "integrity": "sha512-VcdfpZvJE5U2nY8RVSxMfIQGMDL8FYtFScm6BfMdyakXYGkl7pfp+z1ksxepeVfHpUutDqeoZcih39/MoaKaGw==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^7.0.0",
+    "@canshift/core": "^7.0.1",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",


### PR DESCRIPTION
Picks up CANShift/canshift-core#108 (`fix(core): typecheck the test suite and fix what it was hiding`, closes canshift-core#106).

The release is mostly a CI gate — core's `src/__tests__/` was outside the type gate entirely, and a `typecheck` step now runs in its required `build` job. One contract change reaches consumers: `EvalContext.bytes` widens from `readonly number[]` to `ArrayLike<number>`, so a `Uint8Array` of CAN frame bytes is finally assignable. Widening an input type is backwards-compatible, so no code changes here.

## Test plan

- `npm run typecheck` clean
- `npm test` → 61 files, 389 passed
- `npm run build`, `npm run lint` clean
- `npm view @canshift/core version` → `7.0.1`