### PR TITLE
feat(tuner)!: pick one theme identity instead of two competing presets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^7.0.1",
+        "@canshift/core": "^8.0.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-7.0.1.tgz",
-      "integrity": "sha512-VcdfpZvJE5U2nY8RVSxMfIQGMDL8FYtFScm6BfMdyakXYGkl7pfp+z1ksxepeVfHpUutDqeoZcih39/MoaKaGw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-8.0.0.tgz",
+      "integrity": "sha512-Bl+a4TCCdaxBlON1DHC8ZQEpLdsb6dr8VhPvUzgWqLcCWSYUI+2AriFFacPeloLOswQLrquI0FCYVoZ1aTcdJw==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^7.0.1",
+    "@canshift/core": "^8.0.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/components/themes/ThemeCard.tsx
+++ b/src/components/themes/ThemeCard.tsx
@@ -1,14 +1,12 @@
-import type { ThemePresetEntry } from '@canshift/core'
+import type { ThemeFace, ThemePresetEntry } from '@canshift/core'
 import { cva } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 import { MetaText } from '../ui/meta-text'
 
-export type ThemeSlotBadge = 'night' | 'day' | null
-
 export interface ThemeCardProps {
   entry: ThemePresetEntry
-  badge: ThemeSlotBadge
-  targetSlot: 'night' | 'day'
+  active: boolean
+  previewFace: 'night' | 'day'
   onSelect: () => void
 }
 
@@ -22,35 +20,42 @@ export const hexLuminance = (hex: string): number => {
 export const trackColorFor = (bgColor: string): string =>
   hexLuminance(bgColor) < 0.5 ? '#222222' : '#C4C4C4'
 
-export const ThemeCard = ({ entry, badge, targetSlot, onSelect }: ThemeCardProps) => {
-  const palette = entry.preset.palette
-  if (!palette) return null
-  const ramp = [
-    entry.preset.bgColor,
+const rampOf = (face: ThemeFace): string[] => {
+  const palette = face.palette
+  if (!palette) return [face.bgColor, trackColorFor(face.bgColor)]
+  return [
+    face.bgColor,
     palette.surface,
-    trackColorFor(entry.preset.bgColor),
+    trackColorFor(face.bgColor),
     palette.textDim,
     palette.danger,
     palette.accent,
   ]
+}
+
+export const ThemeCard = ({ entry, active, previewFace, onSelect }: ThemeCardProps) => {
+  const face = entry.preset[previewFace]
+  const palette = face.palette
+  if (!palette) return null
+  const otherFace = entry.preset[previewFace === 'night' ? 'day' : 'night']
 
   return (
     <button
       type="button"
       onClick={onSelect}
-      title={`Set as the ${targetSlot} theme of the working dashboard`}
-      className={cn(card({ active: badge === 'night' }))}
+      title={`Use "${entry.label}" — its ${previewFace} face is showing, its other face follows the mode`}
+      className={cn(card({ active }))}
     >
       <div className="flex w-full items-baseline gap-2.5 border-b-2 border-brand-divider px-3.5 py-3">
         <span className="text-[13px] font-extrabold text-brand-text">{entry.label}</span>
-        <MetaText align="end" className={cn(badge === 'night' && 'text-brand-accent')}>
-          {badge === 'night' ? 'active — night' : badge === 'day' ? 'auto at day' : entry.note}
+        <MetaText align="end" className={cn(active && 'text-brand-accent')}>
+          {active ? `active — ${previewFace}` : entry.note}
         </MetaText>
       </div>
       <div
         className="flex h-[140px] w-full items-end gap-4 p-4 font-mono"
         // eslint-disable-next-line no-inline-style/no-inline-style
-        style={{ background: entry.preset.bgColor, color: palette.text }}
+        style={{ background: face.bgColor, color: palette.text }}
       >
         <span className="text-[52px] leading-[0.9]">5200</span>
         {/* eslint-disable-next-line no-inline-style/no-inline-style */}
@@ -63,7 +68,13 @@ export const ThemeCard = ({ entry, badge, targetSlot, onSelect }: ThemeCardProps
         </span>
       </div>
       <div className="flex h-[26px] w-full">
-        {ramp.map((color, i) => (
+        {rampOf(face).map((color, i) => (
+          // eslint-disable-next-line no-inline-style/no-inline-style
+          <div key={i} className="flex-1" style={{ background: color }} />
+        ))}
+      </div>
+      <div className="flex h-[10px] w-full">
+        {rampOf(otherFace).map((color, i) => (
           // eslint-disable-next-line no-inline-style/no-inline-style
           <div key={i} className="flex-1" style={{ background: color }} />
         ))}

--- a/src/components/themes/ThemeTokensRail.tsx
+++ b/src/components/themes/ThemeTokensRail.tsx
@@ -1,17 +1,17 @@
 import type { ReactNode } from 'react'
-import type { ThemePreset } from '@canshift/core'
+import type { ThemeFace } from '@canshift/core'
 import { Eyebrow } from '../ui/meta-text'
 
 export interface ThemeTokensRailProps {
   title: string
-  preset: ThemePreset
+  face: ThemeFace
   children: ReactNode
 }
 
-export const ThemeTokensRail = ({ title, preset, children }: ThemeTokensRailProps) => {
-  const palette = preset.palette
+export const ThemeTokensRail = ({ title, face, children }: ThemeTokensRailProps) => {
+  const palette = face.palette
   const tokens: [string, string][] = [
-    ['bg', preset.bgColor],
+    ['bg', face.bgColor],
     ...(palette
       ? ([
           ['surface', palette.surface],

--- a/src/config/default-sim-config.json
+++ b/src/config/default-sim-config.json
@@ -34,8 +34,13 @@
       }
     ]
   },
-  "dayTheme": {
-    "bgColor": "#E8E8E8"
+  "theme": {
+    "day": {
+      "bgColor": "#E8E8E8"
+    },
+    "night": {
+      "bgColor": "#121212"
+    }
   },
   "pages": [
     {

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -1,1 +1,1 @@
-export { DAY_PALETTE_DEFAULT, DAY_BG_DEFAULT, DAY_THEME_PRESET } from '@canshift/core'
+export { DAY_PALETTE_DEFAULT, DAY_BG_DEFAULT, DAY_THEME_FACE } from '@canshift/core'

--- a/src/hooks/useEffectivePalette.ts
+++ b/src/hooks/useEffectivePalette.ts
@@ -29,19 +29,18 @@ export const resolveBgColor = (
 ): string => (isDayMode ? (dayBgColor ?? DAY_BG_DEFAULT) : (nightBgColor ?? pageBgColor))
 
 export const useEffectivePalette = (page: PageConfig): EffectivePalette => {
-  const dayTheme = useDashboardStore((s) => s.config?.dayTheme)
-  const nightTheme = useDashboardStore((s) => s.config?.nightTheme)
+  const theme = useDashboardStore((s) => s.config?.theme)
   const isDayMode = useDeviceStore((s) => s.isDayMode) ?? false
 
   const palette = useMemo(
-    () => resolvePalette(isDayMode, dayTheme?.palette, nightTheme?.palette, page.palette),
-    [isDayMode, dayTheme?.palette, nightTheme?.palette, page.palette]
+    () => resolvePalette(isDayMode, theme?.day.palette, theme?.night.palette, page.palette),
+    [isDayMode, theme?.day.palette, theme?.night.palette, page.palette]
   )
 
   const bgColor = resolveBgColor(
     isDayMode,
-    dayTheme?.bgColor,
-    nightTheme?.bgColor,
+    theme?.day.bgColor,
+    theme?.night.bgColor,
     page.backgroundColor
   )
 

--- a/src/routes/ThemesRoute.tsx
+++ b/src/routes/ThemesRoute.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
-import { THEME_PRESETS, themePresetById } from '@canshift/core'
+import { THEME_PRESETS, defaultThemePreset } from '@canshift/core'
 import type { ThemePreset, ThemePresetEntry } from '@canshift/core'
 import { useDashboardStore } from '../stores/dashboard.store'
 import { useDeviceStore } from '../stores/device.store'
 import { useLogStore } from '../stores/log.store'
 import { usbService } from '../transport'
-import { ThemeCard, hexLuminance, type ThemeSlotBadge } from '../components/themes/ThemeCard'
+import { ThemeCard } from '../components/themes/ThemeCard'
 import { ThemeTokensRail } from '../components/themes/ThemeTokensRail'
 import { ThemeStatusCard } from '../components/themes/ThemeStatusCard'
 import { ThemeControls } from '../components/themes/ThemeControls'
@@ -13,18 +13,12 @@ import { transportErrorText } from '../transport/humanize-transport-error'
 import { RouteHeader } from '../components/shell/RouteHeader'
 import { RouteBody, RoutePage } from '../components/ui/route-shell'
 
-const LIGHT_BG_LUMINANCE = 0.5
-
 const samePreset = (a: ThemePreset | undefined, b: ThemePreset): boolean =>
   a !== undefined && JSON.stringify(a) === JSON.stringify(b)
 
-const slotFor = (entry: ThemePresetEntry): 'night' | 'day' =>
-  hexLuminance(entry.preset.bgColor) > LIGHT_BG_LUMINANCE ? 'day' : 'night'
-
 const ThemesRoute = () => {
   const config = useDashboardStore((s) => s.config)
-  const setDayTheme = useDashboardStore((s) => s.setDayTheme)
-  const setNightTheme = useDashboardStore((s) => s.setNightTheme)
+  const setTheme = useDashboardStore((s) => s.setTheme)
   const connected = useDeviceStore((s) => s.connected)
   const simulationMode = useDeviceStore((s) => s.simulationMode)
   const isDayMode = useDeviceStore((s) => s.isDayMode)
@@ -34,25 +28,14 @@ const ThemesRoute = () => {
 
   const canControl = connected && !simulationMode
 
-  const nightFallback = themePresetById('night')
-  const activeNight = config?.nightTheme ?? nightFallback?.preset ?? null
-
-  const badgeFor = (entry: ThemePresetEntry): ThemeSlotBadge => {
-    if (config && samePreset(config.nightTheme, entry.preset)) return 'night'
-    if (!config?.nightTheme && entry.id === 'night') return 'night'
-    if (config && samePreset(config.dayTheme, entry.preset)) return 'day'
-    return null
-  }
+  const activeTheme = config?.theme ?? defaultThemePreset()
+  const previewFace = isDayMode === true ? 'day' : 'night'
+  const isCustom =
+    config !== null && THEME_PRESETS.every((entry) => !samePreset(config.theme, entry.preset))
 
   const applyPreset = (entry: ThemePresetEntry) => {
-    const slot = slotFor(entry)
-    if (slot === 'day') {
-      setDayTheme(entry.preset)
-      log('success', `Day theme set to "${entry.label}" — burn to apply on the device`)
-    } else {
-      setNightTheme(entry.preset)
-      log('success', `Night theme set to "${entry.label}" — burn to apply on the device`)
-    }
+    setTheme(entry.preset)
+    log('success', `Theme set to "${entry.label}" — burn to apply on the device`)
   }
 
   const onToggle = async () => {
@@ -105,8 +88,8 @@ const ThemesRoute = () => {
               <ThemeCard
                 key={entry.id}
                 entry={entry}
-                badge={badgeFor(entry)}
-                targetSlot={slotFor(entry)}
+                active={samePreset(config?.theme, entry.preset)}
+                previewFace={previewFace}
                 onSelect={() => {
                   applyPreset(entry)
                 }}
@@ -114,34 +97,41 @@ const ThemesRoute = () => {
             ))}
           </div>
         </div>
-        {activeNight && (
-          <ThemeTokensRail title="NIGHT — TOKENS" preset={activeNight}>
-            <ThemeStatusCard
-              isDayMode={isDayMode}
-              connected={connected}
-              simulationMode={simulationMode}
-            />
-            <ThemeControls
-              isDayMode={isDayMode}
-              disabled={!canControl}
-              busy={busy}
-              onToggle={() => {
-                void onToggle()
-              }}
-              onSetDay={() => {
-                void onSetDay()
-              }}
-              onSetNight={() => {
-                void onSetNight()
-              }}
-            />
-            {!canControl && (
-              <div className="border border-brand-neutral-300 px-3.5 py-2.5 text-xs text-brand-neutral-500">
-                Theme commands are sent over USB. Connect a device to enable them.
-              </div>
-            )}
-          </ThemeTokensRail>
-        )}
+        <ThemeTokensRail
+          title={`${previewFace.toUpperCase()} — TOKENS`}
+          face={activeTheme[previewFace]}
+        >
+          <ThemeStatusCard
+            isDayMode={isDayMode}
+            connected={connected}
+            simulationMode={simulationMode}
+          />
+          <ThemeControls
+            isDayMode={isDayMode}
+            disabled={!canControl}
+            busy={busy}
+            onToggle={() => {
+              void onToggle()
+            }}
+            onSetDay={() => {
+              void onSetDay()
+            }}
+            onSetNight={() => {
+              void onSetNight()
+            }}
+          />
+          {isCustom && (
+            <div className="border border-brand-neutral-300 px-3.5 py-2.5 text-xs text-brand-neutral-500">
+              This dashboard carries a custom pair of faces that matches no preset. Picking one
+              below replaces both.
+            </div>
+          )}
+          {!canControl && (
+            <div className="border border-brand-neutral-300 px-3.5 py-2.5 text-xs text-brand-neutral-500">
+              Theme commands are sent over USB. Connect a device to enable them.
+            </div>
+          )}
+        </ThemeTokensRail>
       </RouteBody>
     </RoutePage>
   )

--- a/src/stores/dashboard/history.slice.test.ts
+++ b/src/stores/dashboard/history.slice.test.ts
@@ -117,13 +117,18 @@ describe('labelled undo stack (#1847)', () => {
     expect(useDashboardStore.getState().config?.targetProfile).toBe(before)
   })
 
-  it('labels theme changes and round-trips them', () => {
-    useDashboardStore.getState().setNightTheme({ bgColor: HexColorSchema.parse('#101010') })
-    expect(lastLabel()).toBe('Changed night theme')
+  it('labels theme changes and round-trips both faces', () => {
+    const before = useDashboardStore.getState().config?.theme
+    useDashboardStore.getState().setTheme({
+      night: { bgColor: HexColorSchema.parse('#101010') },
+      day: { bgColor: HexColorSchema.parse('#EFEFEF') },
+    })
+    expect(lastLabel()).toBe('Changed theme')
     useDashboardStore.getState().undo()
-    expect(useDashboardStore.getState().config?.nightTheme).toBeUndefined()
+    expect(useDashboardStore.getState().config?.theme).toEqual(before)
     useDashboardStore.getState().redo()
-    expect(useDashboardStore.getState().config?.nightTheme?.bgColor).toBe('#101010')
+    expect(useDashboardStore.getState().config?.theme?.night.bgColor).toBe('#101010')
+    expect(useDashboardStore.getState().config?.theme?.day.bgColor).toBe('#EFEFEF')
   })
 
   it('keeps the label across undo and redo', () => {

--- a/src/stores/dashboard/lifecycle.slice.ts
+++ b/src/stores/dashboard/lifecycle.slice.ts
@@ -1,5 +1,5 @@
 import type { DashboardConfig } from '@canshift/core'
-import { DAY_THEME_PRESET } from '../../constants/theme'
+import { defaultThemePreset } from '@canshift/core'
 import { DEFAULT_SIM_CONFIG } from '../../config/default-sim-config'
 import { pushHistory } from './helpers'
 import type {
@@ -28,7 +28,7 @@ export const createLifecycleSlice: SliceCreator<LifecycleSlice> = (set) => ({
 
   setConfig: (config) => {
     set((s) => {
-      applyLoadedConfig(s, { ...config, dayTheme: config.dayTheme ?? DAY_THEME_PRESET })
+      applyLoadedConfig(s, { ...config, theme: config.theme ?? defaultThemePreset() })
     })
   },
 

--- a/src/stores/dashboard/theme.slice.ts
+++ b/src/stores/dashboard/theme.slice.ts
@@ -10,27 +10,14 @@ export const createThemeSlice: SliceCreator<ThemeSlice> = (set) => ({
     })
   },
 
-  setDayTheme: (theme) => {
+  setTheme: (theme) => {
     set((s) => {
       if (!s.config) return
-      pushHistory(s, theme === null ? 'Cleared day theme' : 'Changed day theme')
+      pushHistory(s, theme === null ? 'Cleared theme' : 'Changed theme')
       if (theme === null) {
-        delete s.config.dayTheme
+        delete s.config.theme
       } else {
-        s.config.dayTheme = theme
-      }
-      s.isDirty = true
-    })
-  },
-
-  setNightTheme: (theme) => {
-    set((s) => {
-      if (!s.config) return
-      pushHistory(s, theme === null ? 'Cleared night theme' : 'Changed night theme')
-      if (theme === null) {
-        delete s.config.nightTheme
-      } else {
-        s.config.nightTheme = theme
+        s.config.theme = theme
       }
       s.isDirty = true
     })

--- a/src/stores/dashboard/types.ts
+++ b/src/stores/dashboard/types.ts
@@ -53,8 +53,7 @@ export interface PagesSlice {
 export interface ThemeSlice {
   isPreviewDayMode: boolean
   togglePreviewTheme: () => void
-  setDayTheme: (theme: ThemePreset | null) => void
-  setNightTheme: (theme: ThemePreset | null) => void
+  setTheme: (theme: ThemePreset | null) => void
 }
 
 export interface SelectionSlice {


### PR DESCRIPTION
Third leg of CANShift/canshift-core#103, after CANShift/canshift-core#109 (core) and CANShift/canshift-firmware#206 (firmware).

**Draft on purpose: this cannot go green until core 8.0.0 is on npm.** The range moves to `^8.0.0` but the lockfile still resolves 7.0.1, because the version does not exist yet. Once core #109 merges and publishes, `npm i @canshift/core@8.0.0` finishes it and CI can run. Everything below was verified locally against a `npm pack` of core's branch.

## What the view becomes

Picking a theme was two decisions that could contradict each other: each card guessed its slot from its own luminance (`slotFor`), light presets landed in the day slot, dark ones in the night slot, and the badge logic had to reconstruct which of the two a preset was currently filling. A user could set *paper* as their night theme and the UI would happily show it.

Now a card **is** an identity, and selecting it sets both faces at once:

- `slotFor` and the luminance heuristic are gone — a theme is no longer classified by how bright it happens to be.
- `ThemeSlotBadge` collapses to a plain `active` boolean. `setDayTheme` / `setNightTheme` become one `setTheme`.
- Each card previews the face matching the **current device mode** (day when the device reports day, night otherwise) and carries a thin second ramp underneath showing the face it will switch to. You can see both halves of what you are choosing without toggling.
- The tokens rail follows the same face and retitles itself `DAY — TOKENS` / `NIGHT — TOKENS`, and no longer disappears when no night theme is set — there is always an active identity now, defaulting to core's.

## The Custom state

The migration keeps both faces verbatim rather than discarding one, so a dashboard saved with mismatched presets arrives here as a pair that matches **no** identity. Rather than silently highlight nothing, the rail says so: *"This dashboard carries a custom pair of faces that matches no preset. Picking one below replaces both."* That is the UI half of the decision core#109 deliberately kept out of the migration.

## Also

- `useEffectivePalette` reads one `config.theme` and indexes the face, instead of juggling `dayTheme?.palette` and `nightTheme?.palette` through four hook dependencies.
- `lifecycle.slice` seeds a loaded config from `defaultThemePreset()` rather than patching a lone `dayTheme` in.
- `default-sim-config.json` carries a `theme` pair, so simulation mode exercises the new shape.
- `DAY_THEME_PRESET` re-export follows core's rename to `DAY_THEME_FACE`.

## Test plan (local, against core 8.0.0 packed from its branch)

- `npm run typecheck` clean — the real check that no call site still reaches for `dayTheme` / `nightTheme`
- `npm test` → 61 files, **389 passed**, including the history slice round-tripping both faces through undo/redo
- `npm run build`, `npm run lint`, `npm run format:check` clean

## Merge order

core #109 → publish 8.0.0 → firmware #206 → bump the lockfile here → this.