### PR TITLE
docs(tuner): move the tuner documentation into the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Betaflight-style web configurator for CANShift dashes. Hosted on Vercel, talks
 to the firmware via **WebSerial** over the CH340 UART that already serves as
 the upload / serial port.
 
+📖 **[Documentation](docs/README.md)** — flashing, configuring, and a tour of
+every tab.
+
 ## Why this package
 
 `canshift-tuner` is the configurator surface for CANShift dashes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,47 @@
+# Tuner documentation
+
+The tuner is the browser configurator: it flashes the dash, edits the
+dashboard, and reads live CAN data over Web Serial. Start with
+[First flash](install/first-flash.md) if the board is still sealed, or
+[Tuner tour](tour.md) if it already boots.
+
+You need a Chromium browser (Chrome, Edge, Brave, Opera) — Web Serial does not
+exist in Firefox or Safari.
+
+Docs for the other repos: [firmware](https://github.com/CANShift/canshift-firmware/tree/main/docs) ·
+[core](https://github.com/CANShift/canshift-core/tree/main/docs) ·
+[mobile](https://github.com/CANShift/canshift-mobile/tree/main/docs)
+
+## Install
+
+| Doc                                        | What it covers                                                      |
+| ------------------------------------------ | ------------------------------------------------------------------- |
+| [First flash](install/first-flash.md)      | Sealed board to booting dashboard, about five minutes               |
+| [Manual flash](install/manual-flash.md)    | `esptool` over USB when the in-browser flasher will not do          |
+| [Boot diagnostics](install/boot-issues.md) | Splash hangs, ErrorBar messages, silent USB — reading the boot logs |
+
+## Configure
+
+| Doc                                                 | What it covers                                                         |
+| --------------------------------------------------- | ---------------------------------------------------------------------- |
+| [Configure with the Tuner](configure/with-tuner.md) | Live editing over Web Serial — pages, signals, ECU profiles, themes    |
+| [ECU profiles](configure/ecu-profiles.md)           | Load a signal set for your car, from the catalogue or your own CAN XML |
+| [Widgets & pages](configure/widgets.md)             | Building the dashboard within the firmware's limits                    |
+| [Live data](configure/live-data.md)                 | Watching decoded signals in real time — car, simulator, or neither     |
+| [Burn errors](configure/burn-errors.md)             | When the burn overlay turns red, and how to recover                    |
+
+## The app itself
+
+| Doc                               | What it covers                        |
+| --------------------------------- | ------------------------------------- |
+| [Tuner tour](tour.md)             | A map of every tab and what it is for |
+| [Layout editor](layout-editor.md) | Canvas, page strip, property panel    |
+
+## Elsewhere
+
+- The JSON the tuner reads and writes is defined in
+  [core's config contract](https://github.com/CANShift/canshift-core/blob/main/docs/config-contract.md);
+  the firmware/tuner handshake rule is in
+  [wire protocol versioning](https://github.com/CANShift/canshift-core/blob/main/docs/wire-protocol-versioning.md).
+- Firmware images and release notes:
+  [canshift-firmware releases](https://github.com/CANShift/canshift-firmware/releases).

--- a/docs/configure/burn-errors.md
+++ b/docs/configure/burn-errors.md
@@ -1,0 +1,63 @@
+# Burn errors
+
+When you click **Burn** in the tuner, the dash shows a "Saving config…" overlay
+while it writes to SPIFFS. If the write fails, the overlay flips red and shows
+one of the messages below.
+
+## "Storage write failed"
+
+The atomic SPIFFS write failed — typically because the flash is nearly full or
+fragmented. The previous config (`.bak`) is still in place; the dash will
+re-load the old config on the next boot, so you keep what you had.
+
+**Recovery:**
+
+1. Reboot the dash.
+2. Open `pio device monitor` to confirm `[BOOT] Ready` prints normally.
+3. Try the burn again — transient SPIFFS errors usually resolve.
+4. If it keeps failing, the SPIFFS partition may be corrupt. Re-flash the
+   filesystem image: `pio run -t uploadfs`.
+
+## "Config reload failed"
+
+The write succeeded but the dash couldn't parse the new file. This means the
+tuner shipped invalid JSON, or the schema version doesn't match the firmware.
+
+The dash falls back to the built-in default config and surfaces
+`SCHEMA_MISMATCH` (or similar) in the ErrorBar.
+
+**Recovery:**
+
+- Refresh the tuner page and re-burn — the tuner reads the current schema
+  from `canshift-core` on every load.
+- If the issue persists, re-flash the firmware to the version your tuner
+  page is configured for. The schema version is logged at boot:
+  `[BOOT] Schema vN.M`.
+
+> [!WARNING]
+> **Don't burn during a CAN scan**
+>
+> The tuner queues frames over USB while CAN scan is active. Burning a config in the middle can
+> cause the burn to time out because the USB rxBuf is busy draining frames. Stop CAN scan first,
+> then burn.
+
+## The overlay clears but the dash didn't reload
+
+If the overlay disappears (success) but the new widgets don't appear, the
+likely cause is the page-rebuild trigger missed the reload. Reboot the dash —
+the new config is on disk and will load on the next boot.
+
+This shouldn't happen in normal operation; if it does, capture the boot log
+and open an issue.
+
+## OOM during burn
+
+A very large `dashboard.json` (close to `CONFIG_JSON_DOC_DASHBOARD = 16 KB`)
+plus a fragmented heap can cause the burn to OOM mid-write. Symptoms:
+
+- The overlay shows "Storage write failed".
+- `[USB]` logs contain `out_of_memory` or `parse_error`.
+
+**Recovery:** simplify the dashboard (fewer pages, fewer widgets per page) and
+re-burn. The 16 KB cap is firmware-side and not user-configurable; the tuner
+will warn before letting you burn an oversized config.

--- a/docs/configure/ecu-profiles.md
+++ b/docs/configure/ecu-profiles.md
@@ -1,0 +1,22 @@
+# ECU profiles
+
+A profile is the signal set the dash decodes: the CAN frame IDs, bit layouts, scales and units that turn raw bus traffic into `rpm`, `coolant_temp`, and the rest. The Tuner's **ECU** tab (`canshift-tuner/src/routes/EcuRoute.tsx`) is where you pick one.
+
+## Two ways in
+
+- **The catalogue.** The Tuner ships a browsable list of vendor definitions, loaded from `/ecu-catalogue/index.json` (`components/ecu/EcuCatalogueList.tsx`). Search by vendor or label, sort the list, and click an entry to preview it.
+- **Your own XML.** Drop a CAN definition file onto the import zone (`components/ecu/XmlImportZone.tsx`). Both paths run the file through `parseCanXml` from `@canshift/core`, so a catalogue entry and a hand-rolled file are validated the same way.
+
+## Preview before you apply
+
+Selecting a source shows its signals in a table (`components/ecu/SignalPreviewTable.tsx`) rather than applying them straight away. The table marks which signals are already **bound** to a widget on one of your pages, so you can see at a glance whether switching profiles will leave a gauge without its signal.
+
+> [!NOTE]
+> Parsing surfaces warnings without blocking. A file with a few unreadable rows still loads the signals it could read, and the warnings show above the preview. A file that yields **zero** signals is rejected outright, with the first warning as the reason.
+
+## Applying
+
+**Apply** opens a confirmation (`components/ecu/ApplyConfirmDialog.tsx`) and then swaps the active signal set. Bindings are by signal name, so a widget bound to a signal the new profile doesn't define keeps its binding — the value simply reads stale until a matching signal arrives.
+
+> [!WARNING]
+> Applying a profile changes what every widget decodes, not just what the CAN scan shows. If a gauge goes blank after a profile switch, the signal it was bound to is missing from the new set — rebind it in the [editor](../configure/widgets.md), or pick a profile that defines it. Confirm on the [Live data](../configure/live-data.md) tab.

--- a/docs/configure/live-data.md
+++ b/docs/configure/live-data.md
@@ -1,0 +1,22 @@
+# Live data
+
+The **Live data** tab (`canshift-tuner/src/routes/LiveDataRoute.tsx`) lists every signal in the active profile with its current value, so you can confirm a binding is working without looking at the dash.
+
+## Where the numbers come from
+
+A badge next to the signal count tells you the source (`components/live-data/SourceBadge.tsx`):
+
+- **live** — a device is connected over Web Serial and streaming real frames,
+- **sim** — the built-in simulator is driving the values,
+- **none** — nothing is connected, so the values hold at their last state.
+
+## Reading the table
+
+Each row shows the signal **name**, its **value**, **unit**, and the **min / max** from the profile. A value at or above 90% of its max is flagged — a quick way to spot a signal that's redlining or mis-scaled. Filter the list by typing part of a name or a unit.
+
+> [!TIP]
+> Use Live data to validate an [ECU profile](../configure/ecu-profiles.md) before you place a single widget: apply the profile, drive the simulator or the car, and check the signals move the way you expect.
+
+## Export
+
+**Export** writes the current signals to a CSV named `canshift-live-<timestamp>.csv`, with the columns `name, value, unit, min, max` — handy for filing a bug or comparing two profiles offline.

--- a/docs/configure/widgets.md
+++ b/docs/configure/widgets.md
@@ -1,0 +1,27 @@
+# Widgets & pages
+
+The **Editor** tab (`canshift-tuner/src/routes/EditorRoute.tsx`) is the visual canvas: a strip of pages down one side, a widget canvas in the middle, and a property panel on the right.
+
+## Pages
+
+The page strip (`components/editor/PageStrip.tsx`) manages the ordered set of dash pages. From it you can:
+
+- **Add** a blank page — it starts on a black background,
+- **Duplicate** a page, or **reorder** pages by dragging,
+- **Set the default** — the page the dash shows on boot,
+- **Delete** a page: select it and press **Delete** (or **Backspace**). A deletion raises an **Undo** toast, and the last remaining page can't be deleted.
+
+## Widgets
+
+A widget binds a signal to a way of drawing it. The built-in types include a plain **label**, a **signal** readout, a **gauge**, a **gear** indicator, a **shift light**, a **warning**, a **timer**, and a **separator** for layout — the same set the firmware renders, all defined in `@canshift/core`. Select a widget to edit its binding, range and colours in the right-hand property panel.
+
+> [!NOTE]
+> Pages, widgets and their layout are bounded by `FIRMWARE_CAPS` in `@canshift/core` — the same ceilings the dash enforces at runtime, so a layout that saves in the Tuner is one the dash can actually build. See [LVGL ownership](https://github.com/CANShift/canshift-firmware/blob/main/docs/architecture/lvgl-ownership.md) for why the ceiling exists.
+
+## Binding to a signal
+
+A widget draws nothing until it's bound to a signal from the active [ECU profile](../configure/ecu-profiles.md). Bindings are by signal **name**, so re-applying a profile that keeps the same names leaves your layout intact. Check what a widget is receiving on the [Live data](../configure/live-data.md) tab.
+
+## Saving
+
+Changes live in the Tuner until you burn them to the dash. The config travels as newline-delimited JSON over the wire — see [Config contract](https://github.com/CANShift/canshift-core/blob/main/docs/config-contract.md) — and the dash reloads without a re-flash. If a burn fails, [Burn errors](../configure/burn-errors.md) walks through it.

--- a/docs/configure/with-tuner.md
+++ b/docs/configure/with-tuner.md
@@ -1,0 +1,73 @@
+# Configure with the Tuner
+
+The Tuner is a single-page web app that talks to the dash over Web Serial. You move widgets, bind signals, pick an ECU profile — then click **Burn** and the dash reloads the new config in place. No re-flash, no reboot.
+
+The Tuner lives at [tuner.canshift.app](https://tuner.canshift.app) — open the URL, plug the dash in, you're in.
+
+## Connecting
+
+1. Plug the dash in over USB-C.
+2. Open [tuner.canshift.app](https://tuner.canshift.app) in a Chromium-based browser.
+3. Click **Connect device** in the top-right and pick the serial port.
+
+The header switches from a red _Disconnected_ dot to a green _Connected_ one, with the device's `vendor:product` next to it. The firmware version slot fills in once the handshake completes (~50 ms).
+
+> [!TIP]
+> **Simulation mode**
+>
+> No dash on hand? The Tuner runs in simulation when no device is connected — pages and widgets are
+> interactive, the signal store fakes values. Useful for laying out a dashboard the night before
+> fitting.
+
+## Edit the dashboard
+
+The **Dashboard** route is the visual editor. Page thumbnails on the left (up to `CONFIG_MAX_PAGES = 5`), the canvas in the middle, the inspector on the right. Click a widget to bind it to a signal, drop a new widget from the palette to add it, drag to reorder.
+
+Changes are local until you burn. The canvas previews exactly what the dash will render — same fonts, same tokens, same units.
+
+## Pick an ECU profile
+
+Open the **ECU** route. CANShift ships presets for the common aftermarket and stock setups:
+
+- **Aftermarket**: Haltech, Ecumaster EmuBlack, Adaptronic, AEM, Link, MaxxECU, MoTeC, Flagtronics.
+- **OEM-style**: stock OBD-II PIDs (works with most road cars supporting the standard).
+
+Pick a preset, preview the signals it would import, click _Apply_. The signal map writes to `signals.json` on the dash.
+
+Custom map? Drop a **CAN XML** export onto the page. The parser lives in `@tmbk/canshift-core/parseCanXml` and validates against the same schema the firmware enforces at boot.
+
+## Style with themes
+
+The **Themes** route swaps the dash's colour palette — day vs night, accent colours, gauge backgrounds. The Tuner reads the active mode from the device on connect and exposes three actions: toggle, force _Day_, force _Night_. The commands hit the dash as `CMD_TOGGLE_DAY_NIGHT` / `CMD_SET_DAY_NIGHT` over USB.
+
+## Burn = write the config
+
+Click **Burn** (top-right) and the Tuner ships the full JSON envelope to the dash. The dash:
+
+1. Shows the "Saving config…" overlay.
+2. Writes the new file to SPIFFS atomically (the previous one is renamed `.bak`).
+3. Reloads the config in memory.
+4. Rebuilds the pages on the next frame.
+
+End-to-end takes ~150–250 ms. The overlay vanishes when the burn completes; the new layout appears on the next page swipe (or immediately if you're on the page that changed).
+
+If the overlay flips red, see [Burn errors](../configure/burn-errors.md).
+
+> [!WARNING]
+> **Don't burn during a CAN scan**
+>
+> The dash's USB RX buffer doubles as the PUT_CONFIG receive buffer. A live CAN scan keeps that
+> buffer busy, and a burn that lands in the middle of a scan can time out. Stop the scan in the
+> **CAN bus** route first, then burn.
+
+## Schema vs firmware version
+
+The firmware validates `dashboard.json` against the schema it was compiled with. If you re-flash a newer firmware but SPIFFS still holds an older config, the dash boots into the built-in default and the ErrorBar shows `SCHEMA_MISMATCH`.
+
+The fix is always the same: re-burn from the Tuner. The Tuner always reads the current schema from `canshift-core`, so a fresh burn matches the running firmware by construction.
+
+## Next
+
+- [Burn errors](../configure/burn-errors.md) — what each red overlay message means and how to recover.
+- [Navigating pages](https://github.com/CANShift/canshift-firmware/blob/main/docs/guide/navigating-pages.md) — gestures, default page, the 5-page cap.
+- [Cruise control](https://github.com/CANShift/canshift-firmware/blob/main/docs/guide/cruise-control.md) — how the cruise page binds to your ECU's `cruise_setpoint`.

--- a/docs/install/boot-issues.md
+++ b/docs/install/boot-issues.md
@@ -1,0 +1,70 @@
+# Boot diagnostics
+
+If the dash flashes successfully but never reaches the dashboard, the boot logs
+on the USB serial line tell you which stage failed. Open a serial monitor at
+**115200 baud** before powering the device.
+
+## Reading the splash progress bar
+
+The splash bar advances through known stages:
+
+| Bar progress | Stage                            | If it stops here                                                |
+| -----------: | -------------------------------- | --------------------------------------------------------------- |
+|         10 % | "Config loaded"                  | SPIFFS mount or JSON parse — check the `[BOOT]` line just above |
+|         40 % | "Applying config…"               | Schema mismatch or out-of-range values                          |
+|         60 % | "Starting runtime…"              | Signal store / timer / track / alert init failed                |
+|         78 % | "CAN ready" or "CAN unavailable" | TWAI install — wiring or transceiver issue                      |
+|         90 % | "USB ready"                      | USB rxBuf allocation failed at boot                             |
+|        100 % | "Ready"                          | Should advance to the dashboard within ~2 s                     |
+
+## "[BOOT] Ready" never prints
+
+The CI smoke test asserts that `[BOOT] Ready` appears exactly once. If you
+never see it:
+
+- Look for `[HEAP]` lines just before the failure — a `largest=` value below
+  ~10 KB means heap fragmentation hit one of the early reservations. Heap
+  ordering is documented in [Boot sequence](https://github.com/CANShift/canshift-firmware/blob/main/docs/architecture/boot-sequence.md).
+- Look for `[BLE]` or `[CAN]` errors — those subsystems tolerate failure and
+  let boot continue, so seeing them does **not** mean boot is stuck.
+
+## Common boot-time errors in ErrorBar
+
+Once the dash boots far enough to show the UI, the ErrorBar (red strip at the
+bottom of the screen) surfaces problems. The codes you'll see most often:
+
+| Code                  | Meaning                                            | Fix                                                     |
+| --------------------- | -------------------------------------------------- | ------------------------------------------------------- |
+| `MOUNT_FAIL`          | SPIFFS mount failed                                | Re-flash; if persistent, the flash partition is corrupt |
+| `SCHEMA_MISMATCH`     | `dashboard.json` schema doesn't match the firmware | Re-burn from the tuner                                  |
+| `CONFIG_PARSE`        | JSON syntax error in a config file                 | Burn a known-good config                                |
+| `BOOT_FAIL` (CAN)     | TWAI driver init failed                            | Check CAN wiring, ECU termination                       |
+| `FONT_PROVISION_FAIL` | A SPIFFS font file is missing or unreadable        | Re-flash filesystem partition                           |
+
+> [!TIP]
+> **The ErrorBar swipes up**
+>
+> Swipe up from the red strip to expand the full error list. Dismiss individual rows with the
+> per-row × button.
+
+## Nothing on screen at all
+
+If the dash is powered but the display stays black:
+
+- Confirm the USB cable is wired for data, not just power.
+- Check the SPI wiring — particularly `TFT_DC=2` and `TFT_CS=15`.
+- Try `pio device monitor` from a fresh PlatformIO env to see if the firmware
+  is actually running (boot logs print regardless of the panel).
+
+If logs print but the panel is dark, the issue is at the LovyanGFX layer.
+Capture the boot log and open an issue.
+
+## Capturing boot logs for an issue
+
+```bash
+pio device monitor --baud 115200 --port /dev/cu.usbserial-XYZ \
+  --filter time --filter colorize > boot.log
+```
+
+Then power the dash. Paste the file into the GitHub issue — boot logs almost
+always contain the exact failure point.

--- a/docs/install/first-flash.md
+++ b/docs/install/first-flash.md
@@ -1,0 +1,72 @@
+# First flash
+
+The flasher is part of the tuner, at [`/firmware`](https://tuner.canshift.app/firmware). It walks three stages — **Device** → **Firmware** → **Flash** — reusing the same Web Serial connection the tuner already opened. There is no separate flasher app to install.
+
+> [!WARNING]
+> **Chromium-based browser required**
+>
+> Web Serial is a Chromium-only API. Use Chrome, Edge, Brave, Arc, or Opera. Firefox and Safari
+> won't surface the serial picker.
+
+## Before you start
+
+<div class="cs-spec-sheet">
+  <div class="title">Sanity check</div>
+  <dl>
+    <dt>Cable</dt>
+    <dd>USB-C, data — not a charge-only cable</dd>
+    <dt>Driver</dt>
+    <dd>CH340 driver installed (macOS bundles it; Windows + Linux usually too)</dd>
+    <dt>Port name</dt>
+    <dd>
+      macOS: <code>/dev/cu.usbserial-*</code> · Linux: <code>/dev/ttyUSB0</code> · Windows:{' '}
+      <code>COMx</code>
+    </dd>
+    <dt>Other monitors</dt>
+    <dd>Close any open serial monitor — only one process can hold the port</dd>
+  </dl>
+</div>
+
+## Walk-through
+
+1. **Plug the screen into your computer over USB-C.** A blue power LED should come on; the panel itself stays dark until firmware is on it.
+
+2. **Open [Tuner → Firmware](https://tuner.canshift.app/firmware).** The page loads in under a second from Vercel's edge. You should see three numbered cards: _Device_, _Firmware_, _Flash_.
+
+3. **Click _Connect device_.** The browser prompts you to pick a serial port. On most ESP32-WROOM boards the entry reads `USB JTAG/serial debug unit` or `cu.usbserial-303A`. Pick it and confirm.
+
+4. **Choose a release.** The dropdown defaults to the latest stable build from GitHub Releases. Pre-release / beta is one click away if you're tracking in-flight features. Local `.bin` is for developers building from source.
+
+5. **Hit _Flash_.** The wizard erases the flash, writes the firmware, verifies the checksum, then reboots into the new image. Total time: ~30 seconds for a stable release on a USB 2.0 host.
+
+## What you should see
+
+| Phase  | Visible                                              |               Timing |
+| ------ | ---------------------------------------------------- | -------------------: |
+| Erase  | "Erasing flash…" with a determinate progress bar     |                 ~3 s |
+| Write  | "Writing 0x10000…" climbing through the image        |                ~20 s |
+| Verify | Checksum compare, no progress bar                    |                 ~3 s |
+| Boot   | Screen comes alive: red CANShift splash + version    | within ~2 s of reset |
+| Ready  | Splash holds for 2 s, then your default page appears |          total ~30 s |
+
+The 2-second splash hold is intentional — it gives you time to read the firmware version. The dash is otherwise fully booted by then.
+
+## It hung at "Writing 0x…"
+
+The most common cause is the cable. Charge-only USB-C cables look identical to data cables and will pass enough current to power the board but won't enumerate. Swap cables and retry.
+
+If the cable is fine, the host may have stolen the port. Close any open `pio device monitor`, `screen`, or `minicom` and reconnect.
+
+## The splash appears but the bar stalls
+
+That's a heap problem, not a flash problem — the firmware is on the device and trying to boot. See [Boot diagnostics](../install/boot-issues.md) for the failure dictionary and how to read the `[BOOT]` markers on the serial line.
+
+## The screen stays black after a successful flash
+
+The flash succeeded but the panel never lights up. Check the SPI wiring — the reference build expects `MOSI=13`, `MISO=12`, `SCLK=14`, `CS=15`, `DC=2`, `BL=27`. Full table on [Pinout](https://github.com/CANShift/canshift-firmware/blob/main/docs/reference/pinout.md).
+
+If the panel stays dark but the serial logs print `[BOOT] Ready` cleanly, the dash is alive — the fault is at the LovyanGFX layer. Capture the boot log and open an issue.
+
+## Next
+
+You have a booting dash. Now point it at your ECU: [Configure with the Tuner](../configure/with-tuner.md).

--- a/docs/install/manual-flash.md
+++ b/docs/install/manual-flash.md
@@ -1,0 +1,153 @@
+# Manual flash
+
+Use the in-browser flasher first — it covers 95% of cases. **This page is
+the fallback** for when the in-browser path can't recover the device
+(corrupted flash, brownout damage, mid-write power glitch, etc.).
+
+The procedure runs `esptool.py` directly against the CH340 UART. Tested on
+CrowPanel-28 (ESP32-D0WDQ6 rev 1.1 + W25Q32 flash).
+
+## Symptoms that send you here
+
+Serial monitor shows the chip stuck in a reset loop:
+
+```
+rst:0x10 (RTCWDT_RTC_RESET),boot:0x33 (SPI_FAST_FLASH_BOOT)
+flash read err, 1000
+ets_main.c 371
+ets Jun  8 2016 00:22:57
+```
+
+`flash read err, 1000` at the second-stage bootloader = the chip can't
+read the bootloader image at `0x1000`. Cause is typically a power glitch
+during a write, or two concurrent `esptool` processes hitting the same
+port at once (don't do this).
+
+## Recovery procedure
+
+### Step 0 — physical reset
+
+The flash chip's SPI bus can be in a marginal state after a partial
+write. Recovery starts physical:
+
+1. Unplug the dash for **60 seconds**. Lets the flash's internal
+   capacitors drain.
+2. Switch to a **known-good USB-C cable** — preferably the one that
+   shipped with the board.
+3. Plug **directly into the laptop USB-A or USB-C port** — no hub, no
+   passive dongle. Power dips during the write are the #1 cause of
+   half-state flash content.
+
+### Step 1 — full chip erase at the slow baud
+
+The default `pio run -t erase` uses 460800 baud and re-negotiates higher
+speeds for actual transfer. On a half-state flash, that re-negotiation
+trips. Run esptool **directly at 115200**:
+
+```bash
+python3 ~/.platformio/packages/tool-esptoolpy/esptool.py \
+  --chip esp32 \
+  --port /dev/cu.usbserial-XXXX \
+  --baud 115200 \
+  erase_flash
+```
+
+(Replace `/dev/cu.usbserial-XXXX` with whatever `ls /dev/cu.* | grep -v
+Bluetooth` shows on macOS, or the equivalent COM port on Windows.)
+
+Expected output ends with:
+
+```
+Erasing flash (this may take a while)...
+Chip erase completed successfully in 0.4s
+Hard resetting via RTS pin...
+```
+
+If it fails with `WARNING: Failed to communicate with the flash chip` →
+try the BOOT-button approach:
+
+1. **Hold BOOT** on the dash.
+2. **Tap EN / RST** while still holding BOOT.
+3. **Release BOOT**.
+4. Run the `erase_flash` command immediately.
+
+### Step 2 — write the bootloader + partition table + firmware
+
+After a clean erase, write the full image set. From the repo root:
+
+```bash
+python3 ~/.platformio/packages/tool-esptoolpy/esptool.py \
+  --chip esp32 \
+  --port /dev/cu.usbserial-XXXX \
+  --baud 115200 \
+  --before default_reset --after hard_reset \
+  write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB \
+  0x1000  canshift-firmware/.pio/build/crowpanel_28/bootloader.bin \
+  0x8000  canshift-firmware/.pio/build/crowpanel_28/partitions.bin \
+  0xe000  ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin \
+  0x10000 canshift-firmware/.pio/build/crowpanel_28/firmware.bin
+```
+
+If you don't have the build outputs locally, build them first:
+
+```bash
+cd canshift-firmware
+pio run -e crowpanel_28
+```
+
+### Step 3 — write the SPIFFS image
+
+For fonts + config defaults:
+
+```bash
+python3 ~/.platformio/packages/tool-esptoolpy/esptool.py \
+  --chip esp32 \
+  --port /dev/cu.usbserial-XXXX \
+  --baud 115200 \
+  write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB \
+  0x370000 canshift-firmware/.pio/build/crowpanel_28/spiffs.bin
+```
+
+The `0x370000` offset comes from `canshift-firmware/ota_4mb_wifi.csv`.
+The bootloader-pinned hash on `firmware.bin` makes esptool reject
+`--flash_freq` overrides on the firmware step — that's by design;
+leave `40m`.
+
+### Step 4 — verify boot
+
+Open the serial monitor at 115200 baud, set DTR/RTS to 0 to avoid
+re-triggering the auto-reset:
+
+```bash
+cd canshift-firmware
+pio device monitor -e crowpanel_28
+# or:
+python3 -c "import serial,time; s=serial.Serial(); s.port='/dev/cu.usbserial-XXXX'; s.baudrate=115200; s.dtr=False; s.rts=False; s.open(); [print(s.readline().decode('utf-8',errors='replace'),end='') or time.sleep(0.01) for _ in range(2000)]"
+```
+
+You should see the second-stage bootloader transition cleanly:
+
+```
+rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
+configsip: 0, SPIWP:0xee
+clk_drv:0x00,q_drv:0x00,...
+load:0x3fff0030,len:1184
+load:0x40078000,len:13104
+load:0x40080400,len:3036
+entry 0x400805e4
+```
+
+Followed by app-level logs.
+
+## What you lose by doing this
+
+- **NVS (Preferences)** is wiped — touch calibration, BLE pairing keys,
+  WiFi AP password, OTA HMAC, persisted brightness. First boot after
+  recovery will prompt for touch calibration; pair BLE again from the
+  mobile app.
+- **Persisted dashboard config** is wiped. Push the config from Studio /
+  Tuner on next connect.
+
+The ROM bootloader (factory-burned, separate from `bootloader.bin`) is
+never touched by this procedure — the chip is physically un-brickable
+through USB this way.

--- a/docs/layout-editor.md
+++ b/docs/layout-editor.md
@@ -1,0 +1,15 @@
+# Layout editor
+
+The **Editor** tab (`/dashboard`, `canshift-tuner/src/routes/EditorRoute.tsx`) is where the dashboard is drawn. Three regions: a strip of pages down one side, the widget canvas in the middle, and a property panel on the right for whatever is selected.
+
+This page is the tool overview. For the step-by-step — adding pages, binding widgets to signals, saving and burning — read [Widgets & pages](configure/widgets.md).
+
+## What you work with
+
+- **Pages** — the page strip adds, duplicates, reorders and deletes pages, and sets which one the dash boots to.
+- **Widgets** — dropped onto the canvas and bound to a signal from the active [ECU profile](configure/ecu-profiles.md). The type list (label, gauge, gear, shift light, warning, timer, and the rest) is the same set the firmware renders.
+- **Properties** — the right-hand panel edits the selected widget's binding, range and colours.
+
+> [!NOTE]
+> The editor holds you inside `FIRMWARE_CAPS` from `@canshift/core` — the runtime ceilings on pages, widgets and layout. A dashboard that saves here is one the dash can actually build; see [LVGL ownership](https://github.com/CANShift/canshift-firmware/blob/main/docs/architecture/lvgl-ownership.md) for why the limits exist.
+> Everything stays in the browser until you burn it to the dash, which reloads without a re-flash.

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -1,0 +1,24 @@
+# Tuner tour
+
+The Tuner ([canshift-tuner](https://tuner.canshift.app)) is a browser app that talks to the dash over Web Serial. It is organised as a set of tabs (`src/constants/routes.ts`); this page is the map, with links to the tabs that have their own guide.
+
+## The tabs
+
+- **Welcome** (`/`) — connect a device, or drop straight into the simulator.
+- **Editor** (`/dashboard`) — the visual layout editor: pages, widgets, colours. See [Layout editor](layout-editor.md) and, for the workflow, [Widgets & pages](configure/widgets.md).
+- **CAN bus** (`/can`) — a live scan of the frames on the bus, for working out which IDs your car sends.
+- **ECU** (`/ecu`) — pick a signal profile from the catalogue or import your own. See [ECU profiles](configure/ecu-profiles.md).
+- **OBD-II** (`/obd2`) — configure OBD-II PID polling for cars that don't broadcast.
+- **Themes** (`/themes`) — day and night palettes for the dash.
+- **Live data** (`/live`) — every decoded signal with its current value. See [Live data](configure/live-data.md).
+- **Logs** (`/logs`) — the dash's log stream.
+- **CLI** (`/cli`) — a command console for the wire protocol, for when you need the raw commands.
+- **Firmware** (`/firmware`) — flash a firmware build to the board; the flasher lives here.
+- **About** (`/about`) — version and project links.
+
+> [!NOTE]
+> The Tuner speaks **Web Serial** over USB — it needs a Chromium-based browser and a wired connection. Bluetooth is the mobile app's job; see [Pairing over BLE](https://github.com/CANShift/canshift-mobile/blob/main/docs/pairing.md).
+
+## No car? Use the simulator
+
+Every tab works against the built-in simulator, so you can lay out a dashboard and watch signals move without a device connected. The [Live data](configure/live-data.md) source badge tells you whether you're looking at **sim** or **live** values.

--- a/index.html
+++ b/index.html
@@ -48,7 +48,10 @@
     <div id="root"></div>
     <noscript>
       CANShift Tuner is a browser configurator for CANShift dashes and needs JavaScript to run. Read
-      more at <a href="https://docs.canshift.tmbk.ch">docs.canshift.tmbk.ch</a>.
+      more at
+      <a href="https://github.com/CANShift/canshift-tuner/tree/main/docs"
+        >github.com/CANShift/canshift-tuner</a
+      >.
     </noscript>
     <script type="module" src="/src/main.tsx"></script>
   </body>


### PR DESCRIPTION
## What

`canshift-docs` (the Astro/Starlight site) is being retired. Each repo now carries its own documentation as plain markdown under `docs/`, rendered natively by GitHub — no build step, no separate deploy, versioned in the same PR as the code it describes.

The tuner takes the surfaces it owns — flashing and configuring:

| Section | Pages | Content |
| --- | --- | --- |
| `docs/install/` | 3 | First flash, manual `esptool` flash, boot diagnostics |
| `docs/configure/` | 5 | Live editing, ECU profiles, widgets and pages, live data, burn errors |
| `docs/tour.md`, `docs/layout-editor.md` | 2 | A map of every tab, and the canvas in detail |

The flasher lives in this repo, so the install guides live here too. `docs/README.md` indexes them and states the Chromium requirement up front. The repo README links to it.

The `noscript` fallback in `index.html` pointed at `docs.canshift.tmbk.ch`; it now points at this repo's `docs/`.

`docs/design/` is untouched.

## Conversion

Starlight frontmatter became an H1. `:::note` / `:::caution` directives and `<Aside>` components became GitHub alerts (`> [!NOTE]`, `> [!WARNING]`). Links to pages that moved to another repo were rewritten to absolute `github.com/CANShift/...` URLs.

`tuner-app/pairing.md` was filed under the tuner on the old site but documents the phone's BLE flow — it went to canshift-mobile instead.

## Test plan

- [x] Every relative link in `docs/` resolves to a file that exists
- [x] Every cross-repo link resolves to a file that exists in the target repo's migration branch
- [x] No Starlight syntax survives — no `:::`, no `<Aside>`, no imports
- [x] `docs/design/` unchanged; README diff is the 3 added lines only
- [x] `prettier --write` applied to the new markdown and to `index.html`

## Note

Pages were migrated verbatim, including pre-existing stale references. A follow-up issue will track the content refresh.