### PR TITLE
docs(tuner): point the in-app documentation links at the repo docs

### DIFF
--- a/src/routes/AboutRoute.tsx
+++ b/src/routes/AboutRoute.tsx
@@ -11,7 +11,7 @@ import { HeapStatsPanel } from '../components/about/HeapStatsPanel'
 import { RouteBody } from '../components/ui/route-shell'
 
 const REPO_URL = 'https://github.com/CANShift/canshift-tuner'
-const DOCS_URL = 'https://canshift.app'
+const DOCS_URL = 'https://github.com/CANShift/canshift-tuner/tree/main/docs'
 const ISSUES_URL = 'https://github.com/CANShift/canshift-tuner/issues'
 
 type ConnectionStatus = ReturnType<typeof useConnectionStore.getState>['status']

--- a/src/routes/WelcomeRoute.tsx
+++ b/src/routes/WelcomeRoute.tsx
@@ -116,7 +116,7 @@ const WelcomeRoute = () => {
             </Link>
             <span className="text-brand-neutral-500">·</span>
             <a
-              href="https://canshift.app/user-guide/install/boot-issues/"
+              href="https://github.com/CANShift/canshift-tuner/blob/main/docs/install/boot-issues.md"
               target="_blank"
               rel="noreferrer"
               className={LINK}


### PR DESCRIPTION
## What

The documentation moved into the repos in #204 and the `canshift-docs` site is being retired, so `canshift.app` will no longer serve documentation — it is being repointed at the tuner app itself.

Two links in the app still pointed at the old site and would have broken:

- `AboutRoute.tsx` — the DOCUMENTATION button pointed at `https://canshift.app`, which is about to be the tuner. It now opens `github.com/CANShift/canshift-tuner/tree/main/docs`.
- `WelcomeRoute.tsx` — the Troubleshooting link pointed at `canshift.app/user-guide/install/boot-issues/`. It now opens `docs/install/boot-issues.md`, the same page in this repo.

The `noscript` fallback in `index.html` was already handled in #204.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] Both target URLs resolve to files on `main`
- [x] No other `canshift.app` link remains in `src/` — the one in `telemetry.test.ts` is a fixture URL for the scrubber test, not a live link