### PR TITLE
fix(tuner): point the canonical host at canshift.app

### DIFF
--- a/api/firmware-download.test.ts
+++ b/api/firmware-download.test.ts
@@ -8,7 +8,7 @@ let ipCounter = 0
 
 const request = (query: string): Request => {
   ipCounter += 1
-  return new Request(`https://tuner.canshift.app/api/firmware-download?${query}`, {
+  return new Request(`https://canshift.app/api/firmware-download?${query}`, {
     headers: { 'x-forwarded-for': `10.0.0.${String(ipCounter)}` },
   })
 }

--- a/docs/configure/with-tuner.md
+++ b/docs/configure/with-tuner.md
@@ -2,12 +2,12 @@
 
 The Tuner is a single-page web app that talks to the dash over Web Serial. You move widgets, bind signals, pick an ECU profile — then click **Burn** and the dash reloads the new config in place. No re-flash, no reboot.
 
-The Tuner lives at [tuner.canshift.app](https://tuner.canshift.app) — open the URL, plug the dash in, you're in.
+The Tuner lives at [canshift.app](https://canshift.app) — open the URL, plug the dash in, you're in.
 
 ## Connecting
 
 1. Plug the dash in over USB-C.
-2. Open [tuner.canshift.app](https://tuner.canshift.app) in a Chromium-based browser.
+2. Open [canshift.app](https://canshift.app) in a Chromium-based browser.
 3. Click **Connect device** in the top-right and pick the serial port.
 
 The header switches from a red _Disconnected_ dot to a green _Connected_ one, with the device's `vendor:product` next to it. The firmware version slot fills in once the handshake completes (~50 ms).

--- a/docs/install/first-flash.md
+++ b/docs/install/first-flash.md
@@ -1,6 +1,6 @@
 # First flash
 
-The flasher is part of the tuner, at [`/firmware`](https://tuner.canshift.app/firmware). It walks three stages — **Device** → **Firmware** → **Flash** — reusing the same Web Serial connection the tuner already opened. There is no separate flasher app to install.
+The flasher is part of the tuner, at [`/firmware`](https://canshift.app/firmware). It walks three stages — **Device** → **Firmware** → **Flash** — reusing the same Web Serial connection the tuner already opened. There is no separate flasher app to install.
 
 > [!WARNING]
 > **Chromium-based browser required**
@@ -31,7 +31,7 @@ The flasher is part of the tuner, at [`/firmware`](https://tuner.canshift.app/fi
 
 1. **Plug the screen into your computer over USB-C.** A blue power LED should come on; the panel itself stays dark until firmware is on it.
 
-2. **Open [Tuner → Firmware](https://tuner.canshift.app/firmware).** The page loads in under a second from Vercel's edge. You should see three numbered cards: _Device_, _Firmware_, _Flash_.
+2. **Open [Tuner → Firmware](https://canshift.app/firmware).** The page loads in under a second from Vercel's edge. You should see three numbered cards: _Device_, _Firmware_, _Flash_.
 
 3. **Click _Connect device_.** The browser prompts you to pick a serial port. On most ESP32-WROOM boards the entry reads `USB JTAG/serial debug unit` or `cu.usbserial-303A`. Pick it and confirm.
 

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -1,6 +1,6 @@
 # Tuner tour
 
-The Tuner ([canshift-tuner](https://tuner.canshift.app)) is a browser app that talks to the dash over Web Serial. It is organised as a set of tabs (`src/constants/routes.ts`); this page is the map, with links to the tabs that have their own guide.
+The Tuner ([canshift-tuner](https://canshift.app)) is a browser app that talks to the dash over Web Serial. It is organised as a set of tabs (`src/constants/routes.ts`); this page is the map, with links to the tabs that have their own guide.
 
 ## The tabs
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       name="description"
       content="Configure your CANShift dash, live. Edit pages, bind CAN signals, tune OBD-II polling and flash firmware — all in your browser."
     />
-    <link rel="canonical" href="https://tuner.canshift.app/" />
+    <link rel="canonical" href="https://canshift.app/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="CANShift" />
     <meta property="og:title" content="CANShift Tuner" />
@@ -21,8 +21,8 @@
       property="og:description"
       content="Configure your CANShift dash, live. Edit pages, bind CAN signals, tune OBD-II polling and flash firmware — all in your browser."
     />
-    <meta property="og:url" content="https://tuner.canshift.app/" />
-    <meta property="og:image" content="https://tuner.canshift.app/og-image-1200x630.png" />
+    <meta property="og:url" content="https://canshift.app/" />
+    <meta property="og:image" content="https://canshift.app/og-image-1200x630.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta
@@ -37,7 +37,7 @@
         "@type": "SoftwareApplication",
         "name": "CANShift Tuner",
         "description": "Browser configurator for CANShift dashes — edit pages and widgets, bind CAN signals, tune OBD-II polling and flash firmware over WebSerial.",
-        "url": "https://tuner.canshift.app/",
+        "url": "https://canshift.app/",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Chromium-based browsers",
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://tuner.canshift.app/sitemap.xml
+Sitemap: https://canshift.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://tuner.canshift.app/</loc>
+    <loc>https://canshift.app/</loc>
   </url>
   <url>
-    <loc>https://tuner.canshift.app/dashboard</loc>
+    <loc>https://canshift.app/dashboard</loc>
   </url>
   <url>
-    <loc>https://tuner.canshift.app/can</loc>
+    <loc>https://canshift.app/can</loc>
   </url>
   <url>
-    <loc>https://tuner.canshift.app/ecu</loc>
+    <loc>https://canshift.app/ecu</loc>
   </url>
   <url>
-    <loc>https://tuner.canshift.app/obd2</loc>
+    <loc>https://canshift.app/obd2</loc>
   </url>
   <url>
-    <loc>https://tuner.canshift.app/themes</loc>
+    <loc>https://canshift.app/themes</loc>
   </url>
   <url>
-    <loc>https://tuner.canshift.app/live</loc>
+    <loc>https://canshift.app/live</loc>
   </url>
   <url>
-    <loc>https://tuner.canshift.app/logs</loc>
+    <loc>https://canshift.app/logs</loc>
   </url>
   <url>
-    <loc>https://tuner.canshift.app/cli</loc>
+    <loc>https://canshift.app/cli</loc>
   </url>
   <url>
-    <loc>https://tuner.canshift.app/board</loc>
+    <loc>https://canshift.app/board</loc>
   </url>
   <url>
-    <loc>https://tuner.canshift.app/firmware</loc>
+    <loc>https://canshift.app/firmware</loc>
   </url>
   <url>
-    <loc>https://tuner.canshift.app/about</loc>
+    <loc>https://canshift.app/about</loc>
   </url>
 </urlset>

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -6,7 +6,7 @@ import { ROUTE_PATHS } from '../src/constants/routes'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const OUTPUT_PATH = resolve(SCRIPT_DIR, '..', 'public', 'sitemap.xml')
-const BASE_URL = 'https://tuner.canshift.app'
+const BASE_URL = 'https://canshift.app'
 
 const urlEntry = (path: string): string =>
   `  <url>\n    <loc>${BASE_URL}${path === '/' ? '/' : path}</loc>\n  </url>`


### PR DESCRIPTION
## What

The tuner now serves from `canshift.app`, and `tuner.canshift.app` no longer resolves. The app still declared the old host in every place that matters to a crawler:

| File | What pointed at the dead host |
| --- | --- |
| `index.html` | `<link rel="canonical">`, `og:url`, `og:image`, and the JSON-LD `url` |
| `public/sitemap.xml` | All 12 route URLs |
| `public/robots.txt` | The `Sitemap:` line |
| `scripts/generate-sitemap.ts` | `BASE_URL` — the generator that produces the sitemap on every `prebuild` |

A canonical tag pointing at a host that does not resolve is the damaging one: it tells search engines the real page lives somewhere unreachable, so the live site can lose its own indexing. The sitemap and robots entries are dead ends on top of that.

Fixed `BASE_URL` and regenerated, so `sitemap.xml` matches what `prebuild` would produce — no drift between the committed file and the generator.

Also updated the three docs pages that told a reader to open `tuner.canshift.app`, including the link labels, and the host in the `firmware-download` test fixture so no stale hostname remains in the repo.

## Test plan

- [x] `npm run test` — 61 files, 389 tests
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run sitemap:gen` reproduces the committed `sitemap.xml` byte for byte
- [x] No `tuner.canshift.app` reference remains anywhere in the repo

## Note

`canshift-firmware` has two doc pages linking to the same dead host — handled separately.