### PR TITLE
ci(tuner): skip the deploy job on dependabot pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ jobs:
   deploy:
     name: deploy
     runs-on: ubuntu-latest
+    # Dependabot runs get their own secret store, so VERCEL_TOKEN is empty here
+    # and the deploy fails on every dependency PR.
+    if: github.actor != 'dependabot[bot]'
     env:
       TARGET: ${{ inputs.target || (github.ref == 'refs/heads/main' && 'production') || 'preview' }}
     steps:


### PR DESCRIPTION
## What

`deploy.yml` triggers on `pull_request` with no actor filter, so it runs on Dependabot PRs. GitHub does not expose repository secrets to Dependabot-triggered runs — they live in a separate Dependabot secret store — so the job runs with everything empty:

```
Secret source: Dependabot
vercel pull --yes --environment=preview --token=      <- empty
VERCEL_ORG_ID:        <- empty
VERCEL_PROJECT_ID:    <- empty
Error: You defined "--token", but it's missing a value
```

All six currently open Dependabot PRs fail this way, and every future one would.

`deploy` is not in the `protect-main` ruleset (`lint`, `typecheck`, `test`, `build` are), so nothing was actually blocked. The cost is a permanent red check on dependency PRs, which is how people learn to stop reading CI.

## Why not add the secrets to the Dependabot store instead

That hands a Vercel deploy token to workflow runs triggered by a bot, widening the blast radius of a compromised dependency, in exchange for a preview deployment of a `@types/node` bump. Not worth it.

## Test plan

- [x] YAML parses; the `deploy` job keeps its 9 steps
- [ ] After merge, the next Dependabot PR shows `deploy` skipped rather than failed
- [ ] The next human PR still gets its preview URL comment