### PR TITLE
restyle(tuner): simulation is a visible mode, not a silent dev fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Footer } from './components/shell/Footer'
 import { RouteLoading } from './components/shell/RouteLoading'
 import FeedbackButton from './components/shell/FeedbackButton'
 import { DeviceAlertBar } from './components/shell/DeviceAlertBar'
+import { SimulationStrip } from './components/shell/SimulationStrip'
 import HomeRoute from './routes/HomeRoute'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { useConnectionStore } from './stores/connection.store'
@@ -96,6 +97,7 @@ const App = () => {
   return (
     <div className={SHELL}>
       <Header />
+      <SimulationStrip />
       <DeviceAlertBar />
       <DeviceConfigConflictNotice />
       <main className={MAIN}>

--- a/src/components/shell/BurnButton.tsx
+++ b/src/components/shell/BurnButton.tsx
@@ -7,10 +7,17 @@ export interface BurnButtonProps {
   disabled?: boolean
   busy?: boolean
   title?: string
+  label?: string
   onClick?: () => void
 }
 
-export const BurnButton = ({ disabled = false, busy = false, title, onClick }: BurnButtonProps) => {
+export const BurnButton = ({
+  disabled = false,
+  busy = false,
+  title,
+  label = 'BURN',
+  onClick,
+}: BurnButtonProps) => {
   const isDisabled = disabled && !busy
   return (
     <Button
@@ -21,7 +28,7 @@ export const BurnButton = ({ disabled = false, busy = false, title, onClick }: B
       className={cn('h-auto gap-0 shell-burn-button', burnFace({ disabled: isDisabled }))}
     >
       {busy ? <Spinner size="sm" /> : null}
-      {busy ? 'BURNING…' : 'BURN'}
+      {busy ? 'BURNING…' : label}
     </Button>
   )
 }

--- a/src/components/shell/Header.tsx
+++ b/src/components/shell/Header.tsx
@@ -116,12 +116,15 @@ const useBurnDeniedShake = (): boolean => {
 
 const BurnButton = () => {
   const { canBurn, isBurning, burn, requestBurn } = useBurnDashboard()
+  const connected = useDeviceStore((s) => s.connected)
+  const simulationMode = useDeviceStore((s) => s.simulationMode)
   const lastBurnResult = useDeviceStore((s) => s.lastBurnResult)
   const unboundBurnConfirm = useUiStore((s) => s.unboundBurnConfirm)
   const clearUnboundBurnConfirm = useUiStore((s) => s.clearUnboundBurnConfirm)
   useBurnSuccessAutoClear()
   const shaking = useBurnDeniedShake()
 
+  const noDevice = simulationMode || !connected
   const title = isBurning
     ? 'Burning dashboard to the device…'
     : canBurn
@@ -143,7 +146,13 @@ const BurnButton = () => {
             : undefined
         }
       >
-        <UiBurnButton disabled={!canBurn} busy={isBurning} title={title} onClick={requestBurn} />
+        <UiBurnButton
+          disabled={!canBurn}
+          busy={isBurning}
+          title={title}
+          label={noDevice ? 'NO DEVICE' : 'BURN'}
+          onClick={requestBurn}
+        />
       </span>
       <AlertDialog
         open={unboundBurnConfirm !== null}

--- a/src/components/shell/SimulationStrip.tsx
+++ b/src/components/shell/SimulationStrip.tsx
@@ -1,0 +1,26 @@
+import { useDeviceStore } from '../../stores/device.store'
+
+export const SimulationStrip = () => {
+  const simulationMode = useDeviceStore((s) => s.simulationMode)
+  const exitSimulation = useDeviceStore((s) => s.exitSimulation)
+  if (!simulationMode) return null
+  return (
+    <div
+      role="status"
+      className="flex shrink-0 items-center gap-3.5 bg-ui-accent px-5 py-2.5 font-mono text-[11.5px] tracking-[0.14em] text-white"
+    >
+      <span aria-hidden="true" className="block size-[7px] bg-white" />
+      <span>MODE SIMULATION ACTIVATED</span>
+      <span className="tracking-[0.06em] opacity-75">
+        editing a config without a board · burning is disabled
+      </span>
+      <button
+        type="button"
+        onClick={exitSimulation}
+        className="ml-auto cursor-pointer border border-white/50 bg-transparent px-2.5 py-1 font-[inherit] text-[10.5px] tracking-[0.14em] text-white hover:bg-white/10"
+      >
+        TURN OFF
+      </button>
+    </div>
+  )
+}

--- a/src/hooks/useSimulationBootstrap.ts
+++ b/src/hooks/useSimulationBootstrap.ts
@@ -1,24 +1,12 @@
 import { useEffect } from 'react'
 import { useDeviceStore } from '../stores/device.store'
 import { useDashboardStore } from '../stores/dashboard.store'
-import { useFlasherStore } from '../stores/flasher.store'
 import { DEFAULT_SIM_CONFIG } from '../config/default-sim-config'
 
 export const useSimulationBootstrap = (): void => {
-  const connected = useDeviceStore((s) => s.connected)
   const simulationMode = useDeviceStore((s) => s.simulationMode)
-  const simulationDismissed = useDeviceStore((s) => s.simulationDismissed)
-  const enterSimulation = useDeviceStore((s) => s.enterSimulation)
-  const flasherKind = useFlasherStore((s) => s.state.kind)
   const hasConfig = useDashboardStore((s) => s.config !== null)
   const setConfig = useDashboardStore((s) => s.setConfig)
-
-  useEffect(() => {
-    if (!import.meta.env.DEV) return
-    if (connected || simulationMode || simulationDismissed) return
-    if (flasherKind === 'flashing') return
-    enterSimulation()
-  }, [connected, simulationMode, simulationDismissed, flasherKind, enterSimulation])
 
   useEffect(() => {
     if (simulationMode && !hasConfig) {

--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -14,6 +14,7 @@ export const STORAGE_KEYS = {
   pageTemplates: key('page-templates'),
   projectIndex: key('projects'),
   selectedBoard: key('selected-board'),
+  simulationMode: key('simulation-mode'),
   signals: key('signals'),
   theme: key('theme'),
 } as const

--- a/src/routes/DeviceRoute.tsx
+++ b/src/routes/DeviceRoute.tsx
@@ -1,11 +1,23 @@
 import { lazy, Suspense } from 'react'
 import { RouteLoading } from '../components/shell/RouteLoading'
+import { useDeviceStore } from '../stores/device.store'
 
 const BoardConfigRoute = lazy(() => import('./BoardConfigRoute'))
 const ThemesRoute = lazy(() => import('./ThemesRoute'))
 
+const SimulationNote = () => {
+  const simulationMode = useDeviceStore((s) => s.simulationMode)
+  if (!simulationMode) return null
+  return (
+    <p className="border-b border-ui-line border-l-[3px] border-l-ui-accent bg-ui-panel px-7 py-3.5 font-mono text-[12.5px] text-ui-ink">
+      No board attached — these are the values your config will write, not what a dash reports.
+    </p>
+  )
+}
+
 const DeviceRoute = () => (
   <div className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-ui-bg">
+    <SimulationNote />
     <Suspense fallback={<RouteLoading />}>
       <section aria-label="Board" className="flex flex-col border-b-2 border-ui-rule">
         <BoardConfigRoute />

--- a/src/stores/device.store.ts
+++ b/src/stores/device.store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { readItem, writeItem, STORAGE_KEYS } from '../lib/local-storage'
 import type { DashboardConfig } from '@canshift/core'
 import type { BurnFailure } from '../lib/burn-failure'
 
@@ -44,7 +45,6 @@ interface DeviceState {
   syncing: boolean
 
   simulationMode: boolean
-  simulationDismissed: boolean
 
   firmwareCompat: FirmwareCompat
 
@@ -80,18 +80,27 @@ interface DeviceState {
   setLastBurnResult: (result: BurnResult | null) => void
 }
 
+const SIMULATION_ON = '1'
+
+const readSimulationMode = (): boolean => readItem(STORAGE_KEYS.simulationMode) === SIMULATION_ON
+
+const writeSimulationMode = (on: boolean): void => {
+  writeItem(STORAGE_KEYS.simulationMode, on ? SIMULATION_ON : '0')
+}
+
+const simulationRestored = readSimulationMode()
+
 export const useDeviceStore = create<DeviceState>()((set) => ({
-  status: 'disconnected',
+  status: simulationRestored ? 'connected' : 'disconnected',
   portPath: null,
   transport: null,
   firmwareVersion: null,
   boardId: null,
   lastSyncAt: null,
   errorMessage: null,
-  connected: false,
+  connected: simulationRestored,
   syncing: false,
-  simulationMode: false,
-  simulationDismissed: false,
+  simulationMode: simulationRestored,
   firmwareCompat: { kind: 'unknown' },
   firmwareLiveness: { kind: 'unknown' },
   heapStats: [],
@@ -189,9 +198,9 @@ export const useDeviceStore = create<DeviceState>()((set) => ({
   },
 
   enterSimulation: () => {
+    writeSimulationMode(true)
     set({
       simulationMode: true,
-      simulationDismissed: false,
       status: 'connected',
       connected: true,
       portPath: null,
@@ -200,9 +209,9 @@ export const useDeviceStore = create<DeviceState>()((set) => ({
   },
 
   exitSimulation: () => {
+    writeSimulationMode(false)
     set({
       simulationMode: false,
-      simulationDismissed: true,
       status: 'disconnected',
       connected: false,
       portPath: null,


### PR DESCRIPTION
Closes #216. Fourth slice of the v2 restyle (#237). Also closes the behaviour half of the (already closed) #177.

## What

- **The strip.** A full-width `--ui-accent` band under the header: a 7 px white square, `MODE SIMULATION ACTIVATED`, then at 75 % opacity `editing a config without a board · burning is disabled`, and `TURN OFF` pushed right. In the flow, so it pushes the view down and never overlaps content.
- **`BURN` reads `NO DEVICE`** whenever there is no board or simulation is on. The full verdict — `OUT OF BOUNDS`, `N UNBOUND` — is #225; this is the one label #216 owns.
- **DEVICE states the caveat**: a line at the top of the view saying these are the values the config will write, not what a dash reports.
- **Dev no longer auto-enters simulation.** `useSimulationBootstrap` kept only its second effect, the one that seeds `DEFAULT_SIM_CONFIG` once the mode is actually on.

## Why the dev auto-entry had to go

It is the specific thing that made connecting invisible. In dev the app entered simulation on load, which meant the welcome screen never appeared, the browser's port picker never opened, and the only way to reach the connect path was to press *Disconnect* first — the complaint in #177, found on the bench.

It also broke the route gate: simulation was set in an effect, so a gate running on first render bounced `/dash` to `/` before the mode existed. #215 held the gate off for one commit to work around it; with auto-entry gone, that guard is now belt-and-braces rather than load-bearing.

## Simulation now survives a reload

Turning auto-entry off exposed that `simulationMode` lived only in memory: a refresh dropped you out of the mode and the gate bounced you to HOME mid-edit. It is now persisted under `canshift.tuner.simulation-mode`, and `status` / `connected` restore with it.

This is not the silent fallback that was removed. The mode is entered by an explicit act, the accent strip is on screen the whole time it is on, and `TURN OFF` clears the flag. What changed is only that a refresh no longer throws away a deliberate choice.

## Refactor carried along

`simulationDismissed` is deleted. Its only reader was the auto-entry effect — after this it was written by both simulation actions and read by nothing.

## Test plan

- `typecheck`, `lint`, `test` (389 passing) and `build` green.
- Driven in Helium: with no board the four tabs are gated and `BURN` reads `NO DEVICE`; `Explore with sample data` shows the strip and opens the tabs; `/device` then carries the caveat line; a reload keeps the mode and the path; `TURN OFF` gates the tabs again. No console error.
- Verified the app no longer enters simulation on load in dev.

## Follow-up

The Welcome button still reads `Explore with sample data`; the spec's label is `Edit offline`. That copy belongs to #217 with the rest of the pane.
