### PR TITLE
restyle(tuner): the signals view is one wide editable table

### DIFF
--- a/src/components/signals/CanSignalTable.tsx
+++ b/src/components/signals/CanSignalTable.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react'
+import type { SignalDef } from '@canshift/core'
+import { cn } from '@/lib/utils'
+import { formatByteRange, parseByteRange } from '../../lib/signal-bytes'
+import type { SignalUsage } from '../../hooks/useSignalUsage'
+
+const GRID = 'grid-cols-[minmax(180px,1fr)_132px_104px_128px_116px_minmax(150px,260px)] gap-10'
+const DECIMALS = 1
+const NO_VALUE = '—'
+
+export interface CanSignalTableProps {
+  signals: readonly SignalDef[]
+  values: Record<string, number>
+  usage: SignalUsage
+  onPatch: (name: string, patch: Partial<SignalDef>) => void
+}
+
+const formatValue = (value: number | undefined): string => {
+  if (value === undefined) return NO_VALUE
+  return Number.isInteger(value) ? String(value) : value.toFixed(DECIMALS)
+}
+
+export const CanSignalTable = ({ signals, values, usage, onPatch }: CanSignalTableProps) => (
+  <div className="min-h-0 flex-1 overflow-y-auto">
+    <div
+      className={cn(
+        'sticky top-0 z-[2] grid border-b-2 border-ui-rule bg-ui-panel px-7 py-3',
+        'font-mono text-[10px] tracking-[0.16em] text-ui-muted',
+        GRID
+      )}
+    >
+      <span>SIGNAL</span>
+      <span>CAN ID</span>
+      <span>BYTES</span>
+      <span className="text-right">VALUE</span>
+      <span>UNIT</span>
+      <span>USED ON PAGES</span>
+    </div>
+    {signals.map((signal) => (
+      <SignalRow
+        key={signal.name}
+        signal={signal}
+        value={values[signal.name]}
+        pages={usage.get(signal.name) ?? []}
+        onPatch={onPatch}
+      />
+    ))}
+  </div>
+)
+
+interface SignalRowProps {
+  signal: SignalDef
+  value: number | undefined
+  pages: number[]
+  onPatch: (name: string, patch: Partial<SignalDef>) => void
+}
+
+const SignalRow = ({ signal, value, pages, onPatch }: SignalRowProps) => {
+  const unused = pages.length === 0
+  return (
+    <div
+      className={cn(
+        'group grid items-center border-b border-ui-line px-7 py-[15px] font-mono text-[14px]',
+        'hover:bg-ui-panel',
+        unused ? 'text-ui-faint' : 'text-ui-ink',
+        GRID
+      )}
+    >
+      <span className="truncate font-bold">{signal.name}</span>
+      <CellInput
+        value={signal.canFrameId}
+        label={`CAN ID for ${signal.name}`}
+        accent
+        onCommit={(next) => {
+          if (next.length > 0) onPatch(signal.name, { canFrameId: next })
+        }}
+      />
+      <CellInput
+        value={formatByteRange(signal.startByte, signal.byteLength)}
+        label={`Bytes for ${signal.name}`}
+        validate={(next) => parseByteRange(next) !== null}
+        onCommit={(next) => {
+          const range = parseByteRange(next)
+          if (range) onPatch(signal.name, range)
+        }}
+      />
+      <span className="text-right tabular-nums">{formatValue(value)}</span>
+      <span className="text-[13px] text-ui-faint">{signal.unit}</span>
+      <span className="flex flex-wrap gap-1">
+        {pages.map((page) => (
+          <span key={page} className="border border-ui-line-strong px-[7px] text-[11.5px]">
+            {page}
+          </span>
+        ))}
+        {unused && <span className="text-[12px] text-ui-faint">not used</span>}
+      </span>
+    </div>
+  )
+}
+
+interface CellInputProps {
+  value: string
+  label: string
+  accent?: boolean
+  validate?: (next: string) => boolean
+  onCommit: (next: string) => void
+}
+
+const CellInput = ({ value, label, accent = false, validate, onCommit }: CellInputProps) => {
+  const [draft, setDraft] = useState(value)
+  const [dirty, setDirty] = useState(false)
+  const shown = dirty ? draft : value
+  const invalid = dirty && validate !== undefined && !validate(draft)
+
+  const commit = () => {
+    setDirty(false)
+    if (invalid || draft === value) return
+    onCommit(draft.trim())
+  }
+
+  return (
+    <input
+      value={shown}
+      aria-label={label}
+      spellCheck={false}
+      onChange={(e) => {
+        setDraft(e.target.value)
+        setDirty(true)
+      }}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') e.currentTarget.blur()
+        if (e.key === 'Escape') setDirty(false)
+      }}
+      className={cn(
+        'w-full border bg-transparent px-1.5 py-1 font-mono text-[13.5px] outline-none',
+        invalid ? 'border-ui-danger text-ui-danger' : 'border-ui-line hover:border-ui-ink',
+        accent && !invalid ? 'text-ui-accent' : 'text-inherit'
+      )}
+    />
+  )
+}

--- a/src/components/signals/SignalsToolbar.tsx
+++ b/src/components/signals/SignalsToolbar.tsx
@@ -1,0 +1,112 @@
+import type { ReactNode } from 'react'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+export type SignalSource = 'can' | 'obd2'
+
+export interface SignalsToolbarProps {
+  source: SignalSource
+  onSource: (source: SignalSource) => void
+  profiles: readonly { key: string; label: string }[]
+  profileKey: string
+  onProfile: (key: string) => void
+  meta: string
+  filter: string
+  onFilter: (filter: string) => void
+  actions: ReactNode
+}
+
+const SOURCE_LABELS: Record<SignalSource, string> = { can: 'CAN', obd2: 'OBD-II' }
+const SOURCES = Object.keys(SOURCE_LABELS) as SignalSource[]
+
+export const SignalsToolbar = ({
+  source,
+  onSource,
+  profiles,
+  profileKey,
+  onProfile,
+  meta,
+  filter,
+  onFilter,
+  actions,
+}: SignalsToolbarProps) => (
+  <div className="flex h-[54px] shrink-0 items-center gap-4 border-b-2 border-ui-rule px-6">
+    <div className="flex gap-px">
+      {SOURCES.map((value) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => {
+            onSource(value)
+          }}
+          className={cn(segment({ active: value === source }))}
+        >
+          {SOURCE_LABELS[value]}
+        </button>
+      ))}
+    </div>
+
+    <select
+      value={profileKey}
+      onChange={(e) => {
+        onProfile(e.target.value)
+      }}
+      aria-label="ECU profile"
+      className="max-w-[220px] border border-ui-ink bg-ui-bg py-2 pl-2.5 pr-[26px] font-mono text-[13px] font-bold text-ui-ink"
+    >
+      {profiles.map((profile) => (
+        <option key={profile.key} value={profile.key}>
+          {profile.label}
+        </option>
+      ))}
+    </select>
+
+    <span className="hidden whitespace-nowrap font-mono text-[11.5px] text-ui-muted min-[1240px]:inline">
+      {meta}
+    </span>
+
+    <input
+      value={filter}
+      onChange={(e) => {
+        onFilter(e.target.value)
+      }}
+      placeholder="filter"
+      aria-label="Filter signals"
+      className="ml-auto w-40 border border-ui-ink bg-ui-bg px-2.5 py-2 font-mono text-[13px] text-ui-ink outline-none"
+    />
+
+    {actions}
+  </div>
+)
+
+const segment = cva(
+  [
+    'cursor-pointer whitespace-nowrap border border-ui-ink px-[18px] py-[9px]',
+    'text-[12.5px] font-bold tracking-[0.06em]',
+  ].join(' '),
+  {
+    variants: {
+      active: {
+        true: 'bg-ui-rule text-ui-bg',
+        false: 'bg-transparent text-ui-ink hover:bg-ui-panel',
+      },
+    },
+    defaultVariants: { active: false },
+  }
+)
+
+export const SignalsAction = ({
+  onClick,
+  children,
+}: {
+  onClick: () => void
+  children: ReactNode
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="cursor-pointer whitespace-nowrap border border-ui-ink bg-transparent px-4 py-2 text-left text-[12.5px] font-bold text-ui-ink hover:bg-ui-panel"
+  >
+    {children}
+  </button>
+)

--- a/src/hooks/useSignalUsage.ts
+++ b/src/hooks/useSignalUsage.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react'
+import { useDashboardStore } from '../stores/dashboard.store'
+
+export type SignalUsage = ReadonlyMap<string, number[]>
+
+export const useSignalUsage = (): SignalUsage => {
+  const pages = useDashboardStore((s) => s.config?.pages)
+
+  return useMemo(() => {
+    const usage = new Map<string, number[]>()
+    ;(pages ?? []).forEach((page, index) => {
+      for (const widget of page.widgets) {
+        if (widget.signal.length === 0) continue
+        const seen = usage.get(widget.signal) ?? []
+        if (!seen.includes(index + 1)) usage.set(widget.signal, [...seen, index + 1])
+      }
+    })
+    return usage
+  }, [pages])
+}

--- a/src/lib/signal-bytes.test.ts
+++ b/src/lib/signal-bytes.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { formatByteRange, parseByteRange } from './signal-bytes'
+
+describe('formatByteRange', () => {
+  it('shows a single byte as one number, not a range of itself', () => {
+    expect(formatByteRange(3, 1)).toBe('3')
+  })
+
+  it('shows a multi-byte signal as an inclusive range', () => {
+    expect(formatByteRange(0, 2)).toBe('0–1')
+    expect(formatByteRange(4, 4)).toBe('4–7')
+  })
+})
+
+describe('parseByteRange', () => {
+  it('reads back what it wrote', () => {
+    expect(parseByteRange('0–1')).toEqual({ startByte: 0, byteLength: 2 })
+    expect(parseByteRange('3')).toEqual({ startByte: 3, byteLength: 1 })
+  })
+
+  it('accepts a plain hyphen, which is what a keyboard types', () => {
+    expect(parseByteRange('4-7')).toEqual({ startByte: 4, byteLength: 4 })
+  })
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseByteRange('  2 - 3 ')).toEqual({ startByte: 2, byteLength: 2 })
+  })
+
+  it('refuses a range the frame cannot hold', () => {
+    expect(parseByteRange('6–9')).toBeNull()
+    expect(parseByteRange('8')).toBeNull()
+  })
+
+  it('refuses a length the schema does not allow', () => {
+    expect(parseByteRange('0–4')).toBeNull()
+  })
+
+  it('refuses a reversed range instead of silently swapping it', () => {
+    expect(parseByteRange('3–1')).toBeNull()
+  })
+
+  it('refuses anything that is not a range', () => {
+    expect(parseByteRange('')).toBeNull()
+    expect(parseByteRange('0x1D0')).toBeNull()
+  })
+})

--- a/src/lib/signal-bytes.ts
+++ b/src/lib/signal-bytes.ts
@@ -1,0 +1,24 @@
+import { SIGNAL_BYTE_LENGTHS } from '@canshift/core'
+import type { SignalByteLength } from '@canshift/core'
+
+const MAX_START_BYTE = 7
+const RANGE = /^\s*(\d+)\s*(?:[-–]\s*(\d+)\s*)?$/
+
+export interface ByteRange {
+  startByte: number
+  byteLength: SignalByteLength
+}
+
+export const formatByteRange = (startByte: number, byteLength: number): string =>
+  byteLength <= 1 ? String(startByte) : `${String(startByte)}–${String(startByte + byteLength - 1)}`
+
+export const parseByteRange = (raw: string): ByteRange | null => {
+  const match = RANGE.exec(raw)
+  if (!match) return null
+  const start = Number(match[1])
+  const end = match[2] === undefined ? start : Number(match[2])
+  if (end < start || start > MAX_START_BYTE || end > MAX_START_BYTE) return null
+  const length = end - start + 1
+  if (!SIGNAL_BYTE_LENGTHS.includes(length as SignalByteLength)) return null
+  return { startByte: start, byteLength: length as SignalByteLength }
+}

--- a/src/routes/SignalsRoute.tsx
+++ b/src/routes/SignalsRoute.tsx
@@ -1,70 +1,113 @@
-import { lazy, Suspense, useState } from 'react'
+import { lazy, Suspense, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
-import { cva } from 'class-variance-authority'
-import { cn } from '@/lib/utils'
+import { ECU_PROFILES } from '@canshift/core'
 import { RouteLoading } from '../components/shell/RouteLoading'
+import {
+  SignalsToolbar,
+  SignalsAction,
+  type SignalSource,
+} from '../components/signals/SignalsToolbar'
+import { CanSignalTable } from '../components/signals/CanSignalTable'
+import { useSignalStore } from '../stores/signal.store'
+import { useLiveSignals } from '../hooks/useLiveSignals'
+import { useSignalUsage } from '../hooks/useSignalUsage'
+import { useCatalogueIndex } from '../hooks/useCatalogueIndex'
+import { ecuLabelForKey } from '../utils/ecu-label'
 
 const CanBusRoute = lazy(() => import('./CanBusRoute'))
 const EcuRoute = lazy(() => import('./EcuRoute'))
 const Obd2Route = lazy(() => import('./Obd2Route'))
 
-type SignalSource = 'can' | 'ecu' | 'obd2'
-
-const SOURCE_LABELS: Record<SignalSource, string> = {
-  can: 'CAN',
-  ecu: 'ECU PROFILE',
-  obd2: 'OBD-II',
-}
-
-const SOURCE_PANES: Record<SignalSource, ReactNode> = {
-  can: <CanBusRoute />,
-  ecu: <EcuRoute />,
-  obd2: <Obd2Route />,
-}
-
-const SOURCES = Object.keys(SOURCE_LABELS) as readonly SignalSource[]
+type Pane = SignalSource | 'scan' | 'ecu'
 
 const SignalsRoute = () => {
-  const [source, setSource] = useState<SignalSource>('can')
+  const signals = useSignalStore((s) => s.signals)
+  const selectedProfileKey = useSignalStore((s) => s.selectedProfileKey)
+  const applyProfile = useSignalStore((s) => s.applyProfile)
+  const updateSignal = useSignalStore((s) => s.updateSignal)
+  const values = useLiveSignals()
+  const usage = useSignalUsage()
+  const catalogue = useCatalogueIndex()
+
+  const [pane, setPane] = useState<Pane>('can')
+  const [filter, setFilter] = useState('')
+
+  const profiles = useMemo(() => {
+    const builtin = ECU_PROFILES.map((profile) => ({
+      key: `builtin:${profile.id}`,
+      label: profile.name,
+    }))
+    if (builtin.some((entry) => entry.key === selectedProfileKey)) return builtin
+    return [
+      { key: selectedProfileKey, label: ecuLabelForKey(selectedProfileKey, catalogue) },
+      ...builtin,
+    ]
+  }, [selectedProfileKey, catalogue])
+
+  const shown = useMemo(() => {
+    const query = filter.trim().toLowerCase()
+    if (query.length === 0) return signals
+    return signals.filter(
+      (signal) =>
+        signal.name.toLowerCase().includes(query) ||
+        signal.canFrameId.toLowerCase().includes(query) ||
+        signal.unit.toLowerCase().includes(query)
+    )
+  }, [signals, filter])
+
+  const bound = useMemo(
+    () => signals.filter((signal) => usage.has(signal.name)).length,
+    [signals, usage]
+  )
+
+  const panes: Record<Pane, ReactNode> = {
+    can: <CanSignalTable signals={shown} values={values} usage={usage} onPatch={updateSignal} />,
+    obd2: <Obd2Route />,
+    scan: <CanBusRoute />,
+    ecu: <EcuRoute />,
+  }
+
+  const source: SignalSource = pane === 'obd2' ? 'obd2' : 'can'
+
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-ui-bg">
-      <div className="flex h-[54px] shrink-0 items-center gap-4 border-b-2 border-ui-rule px-6">
-        <div className="flex gap-px">
-          {SOURCES.map((value) => (
-            <button
-              key={value}
-              type="button"
+      <SignalsToolbar
+        source={source}
+        onSource={setPane}
+        profiles={profiles}
+        profileKey={selectedProfileKey}
+        onProfile={(key) => {
+          const id = key.startsWith('builtin:') ? key.slice('builtin:'.length) : null
+          const profile = ECU_PROFILES.find((entry) => entry.id === id)
+          if (profile) applyProfile(key, [...profile.signals])
+        }}
+        meta={`${String(bound)} of ${String(signals.length)} bound`}
+        filter={filter}
+        onFilter={setFilter}
+        actions={
+          <>
+            <SignalsAction
               onClick={() => {
-                setSource(value)
+                setPane((current) => (current === 'scan' ? 'can' : 'scan'))
               }}
-              className={cn(segment({ active: value === source }))}
             >
-              {SOURCE_LABELS[value]}
-            </button>
-          ))}
-        </div>
-      </div>
+              {pane === 'scan' ? 'Back to signals' : 'Scan bus'}
+            </SignalsAction>
+            <SignalsAction
+              onClick={() => {
+                setPane((current) => (current === 'ecu' ? 'can' : 'ecu'))
+              }}
+            >
+              {pane === 'ecu' ? 'Back to signals' : 'ECU profile…'}
+            </SignalsAction>
+          </>
+        }
+      />
       <div className="flex min-h-0 flex-1 flex-col">
-        <Suspense fallback={<RouteLoading />}>{SOURCE_PANES[source]}</Suspense>
+        <Suspense fallback={<RouteLoading />}>{panes[pane]}</Suspense>
       </div>
     </div>
   )
 }
-
-const segment = cva(
-  [
-    'cursor-pointer whitespace-nowrap border border-ui-ink px-[18px] py-[9px]',
-    'text-[12.5px] font-bold tracking-[0.06em]',
-  ].join(' '),
-  {
-    variants: {
-      active: {
-        true: 'bg-ui-rule text-ui-bg',
-        false: 'bg-transparent text-ui-ink hover:bg-ui-panel',
-      },
-    },
-    defaultVariants: { active: false },
-  }
-)
 
 export default SignalsRoute

--- a/src/stores/signal.store.ts
+++ b/src/stores/signal.store.ts
@@ -45,6 +45,7 @@ interface SignalState {
   signals: SignalDef[]
   selectedProfileKey: string
   setSignals: (signals: SignalDef[]) => void
+  updateSignal: (name: string, patch: Partial<SignalDef>) => void
   applyProfile: (key: string, signals: SignalDef[]) => void
 }
 
@@ -59,6 +60,16 @@ export const useSignalStore = create<SignalState>()((set) => ({
 
   setSignals: (signals) => {
     set({ signals })
+  },
+
+  updateSignal: (name, patch) => {
+    set((state) => {
+      const signals = state.signals.map((signal) =>
+        signal.name === name ? { ...signal, ...patch } : signal
+      )
+      writeStored({ selectedProfileKey: state.selectedProfileKey, signals })
+      return { signals }
+    })
   },
 
   applyProfile: (key, signals) => {


### PR DESCRIPTION
Closes #227. Tenth slice of the v2 restyle (#237), step 5 of the spec's order of work.

## What

`PROMPT_TUNER_APP.md` §5, the CAN half:

- **Toolbar** — the `CAN` / `OBD-II` segmented pair, the ECU profile select, the bound count, a `filter` field pushed right, then the actions.
- **The table** — a sticky head on `--ui-panel` under a 2 px rule, then rows on `minmax(180px,1fr) 132px 104px 128px 116px minmax(150px,260px)` with a **40 px gap** and **28 px** horizontal padding. `SIGNAL` in mono 700 · `CAN ID` **editable**, in accent · `BYTES` **editable** · `VALUE` right-aligned and tabular · `UNIT` · `USED ON PAGES` as numbered chips.
- **Unbound signals are faint as a whole row** and read `not used`, rather than being hidden.

The generosity is the point: this table is read leaning over a car, not skimmed.

## Editing

`CAN ID` and `BYTES` commit on blur or Enter, revert on Escape, and persist — `signal.store` gains `updateSignal`, which writes through to local storage rather than leaving the edit in memory until something else saves.

`BYTES` is one field over two schema fields. `SignalDef` stores `startByte` and `byteLength`; the cell shows an **inclusive range** — `3` for one byte, `0–1` for two — and `parseByteRange` reads it back. An edit that the frame cannot hold (`6–9`), a length the schema does not allow (`0–4`, since only 1/2/3/4 are legal) or a reversed range (`3–1`) turns the cell's border danger and is **not committed**, so a bad edit cannot silently corrupt a profile.

## Where the other three quarters went

The old `/can`, `/ecu` and `/obd2` routes became one view in #215 behind a three-way segmented control. That control is now the spec's two — `CAN` and `OBD-II` — and the two surfaces it dropped are reached from the toolbar's actions instead: `Scan bus` and `ECU profile…`. Both still mount the existing routes untouched.

That keeps the segmented control faithful while losing nothing, and leaves the shape #228 and #230 need: the scan becomes a panel above the table, and the ECU profile select in the toolbar grows the catalogue and the XML round-trip.

## Deliberately not here

- **The unit select.** The spec makes `UNIT` a select wherever an imperial equivalent exists, because picking one **converts the displayed value**. Without the conversion a select would change nothing, so the cell is plain text until #233 lands.
- **`SCAN BUS` as a panel**, and the discovered-frame rows — #228.
- **`Import XML` / `Download XML`** as toolbar actions, and the full catalogue in the select — #230. The select currently offers the built-in profiles plus whatever is loaded; the catalogue stays behind `ECU profile…`.
- **The bus rate and frame rate** in the count line (`500 kbit · 842 Hz`). The tuner has no bus-rate reading yet; it arrives with the DEVICE settings in #232.

## Test plan

- `typecheck`, `lint`, `test` (414 passing) and `build` green.
- New `src/lib/signal-bytes.test.ts` — nine cases: the round trip, a plain hyphen as typed, surrounding whitespace, a range past the frame, an illegal length, a reversed range, and a CAN ID pasted into the wrong cell.
- Driven in Helium at 1440 × 900, both themes, no console error: editing `BYTES` to `0-1` commits and re-renders as `0–1`; `0-4` marks the cell danger and Escape reverts it; the filter narrows 18 signals to the 2 matching `oil`; `USED ON PAGES` shows the real page numbers from the open config.
