### PR TITLE
restyle(tuner): four preview modes overlay the real dash states

### DIFF
--- a/src/components/editor/Canvas.tsx
+++ b/src/components/editor/Canvas.tsx
@@ -25,6 +25,8 @@ import { useSwipeGestures } from '../../hooks/useSwipeGestures'
 import { useCarouselScale } from '../../hooks/useCarouselScale'
 import { useCanvasDialogs } from '../../hooks/useCanvasDialogs'
 import { resolveBgColor, resolvePalette } from '../../hooks/useEffectivePalette'
+import { PreviewOverlay } from './preview/PreviewOverlay'
+import type { PreviewMode } from './preview/preview-modes'
 
 const THUMBNAIL_RATIO = 0.42
 const STRIP_CHROME_PX = 66
@@ -35,10 +37,18 @@ interface CanvasProps {
   topBar: TopBarConfig
   toolbar?: ReactNode
   inspector?: ReactNode
+  previewMode?: PreviewMode
   onPageContextMenu?: ((pageId: string, x: number, y: number) => void) | undefined
 }
 
-const Canvas = ({ page, topBar, toolbar, inspector, onPageContextMenu }: CanvasProps) => {
+const Canvas = ({
+  page,
+  topBar,
+  toolbar,
+  inspector,
+  previewMode = 'normal',
+  onPageContextMenu,
+}: CanvasProps) => {
   const targetProfileId = useDashboardStore((s) => s.config?.targetProfile)
   const screenProfile = useMemo(() => resolveScreenProfile(targetProfileId), [targetProfileId])
   const pages = useDashboardStore((s) => s.config?.pages ?? EMPTY_PAGES)
@@ -174,6 +184,22 @@ const Canvas = ({ page, topBar, toolbar, inspector, onPageContextMenu }: CanvasP
             scale={scale}
           />
         )}
+        <PreviewOverlay
+          mode={previewMode}
+          scale={scale}
+          bgColor={resolveBgColor(
+            isDayMode,
+            theme?.day.bgColor,
+            theme?.night.bgColor,
+            page.backgroundColor
+          )}
+          palette={resolvePalette(
+            isDayMode,
+            theme?.day.palette,
+            theme?.night.palette,
+            page.palette
+          )}
+        />
       </>
     ),
   }

--- a/src/components/editor/DashToolbar.tsx
+++ b/src/components/editor/DashToolbar.tsx
@@ -36,6 +36,9 @@ export interface DashToolbarProps {
   onSelectPanel: (id: string) => void
   pageMeta: string
   profileMeta: string
+  previewModes: readonly { value: string; label: string; title: string }[]
+  previewMode: string
+  onPreviewMode: (mode: string) => void
   onAddWidget: () => void
   onImport: () => void
   onExport: () => void
@@ -65,6 +68,9 @@ export const DashToolbar = ({
   onSelectPanel,
   pageMeta,
   profileMeta,
+  previewModes,
+  previewMode,
+  onPreviewMode,
   onAddWidget,
   onImport,
   onExport,
@@ -151,6 +157,22 @@ export const DashToolbar = ({
 
     <div className="flex-1" />
 
+    <div className="hidden gap-px min-[1240px]:flex">
+      {previewModes.map((mode) => (
+        <button
+          key={mode.value}
+          type="button"
+          onClick={() => {
+            onPreviewMode(mode.value)
+          }}
+          title={mode.title}
+          className={cn(previewSegment({ active: mode.value === previewMode }))}
+        >
+          {mode.label}
+        </button>
+      ))}
+    </div>
+
     <span className="hidden min-[1500px]:contents">{extras}</span>
 
     <span className="hidden whitespace-nowrap font-mono text-[11.5px] text-ui-muted min-[1320px]:inline">
@@ -208,6 +230,19 @@ const square = cva('grid size-[38px] place-items-center border bg-transparent', 
   },
   defaultVariants: { tone: 'default', disabled: false },
 })
+
+const previewSegment = cva(
+  'cursor-pointer whitespace-nowrap border border-ui-ink px-2.5 py-[7px] font-mono text-[10.5px] tracking-[0.08em]',
+  {
+    variants: {
+      active: {
+        true: 'bg-ui-rule text-ui-bg',
+        false: 'bg-transparent text-ui-muted hover:bg-ui-panel',
+      },
+    },
+    defaultVariants: { active: false },
+  }
+)
 
 const GhostButton = ({ onClick, children }: { onClick: () => void; children: ReactNode }) => (
   <button

--- a/src/components/editor/preview/CutBand.tsx
+++ b/src/components/editor/preview/CutBand.tsx
@@ -1,0 +1,61 @@
+import { CS_DANGER, CS_WARN } from './preview-modes'
+
+const RULE_PX = 1
+const NAME_PX = 7
+const DETAIL_PX = 7
+const PADDING_PX = 4
+const TRACKING = '0.16em'
+
+export interface CutBandProps {
+  scale: number
+  dimColor: string
+  inkColor: string
+  name: string
+  detail: string
+  elapsed: string
+  protective: boolean
+}
+
+export const CutBand = ({
+  scale,
+  dimColor,
+  inkColor,
+  name,
+  detail,
+  elapsed,
+  protective,
+}: CutBandProps) => {
+  const tone = protective ? CS_DANGER : CS_WARN
+  return (
+    <div
+      className="flex shrink-0 items-baseline"
+      // eslint-disable-next-line no-inline-style/no-inline-style
+      style={{
+        borderTop: `${String(RULE_PX * scale)}px solid ${tone}`,
+        paddingTop: PADDING_PX * scale,
+        gap: 7 * scale,
+      }}
+    >
+      <span
+        className="font-sans font-extrabold uppercase"
+        // eslint-disable-next-line no-inline-style/no-inline-style
+        style={{ fontSize: NAME_PX * scale, letterSpacing: TRACKING, color: tone }}
+      >
+        {name}
+      </span>
+      <span
+        // eslint-disable-next-line no-inline-style/no-inline-style
+        style={{ fontSize: DETAIL_PX * scale, color: protective ? inkColor : dimColor }}
+      >
+        {detail}
+      </span>
+      <span
+        className="ml-auto"
+        // eslint-disable-next-line no-inline-style/no-inline-style
+        style={{ fontSize: DETAIL_PX * scale, color: dimColor }}
+      >
+        {elapsed}
+      </span>
+    </div>
+  )
+}

--- a/src/components/editor/preview/PreviewOverlay.tsx
+++ b/src/components/editor/preview/PreviewOverlay.tsx
@@ -1,0 +1,77 @@
+import type { PagePalette } from '@canshift/core'
+import { CutBand } from './CutBand'
+import { AlertTakeover, SplashTakeover } from './Takeover'
+import type { PreviewMode } from './preview-modes'
+
+const TRACK_DARK = '#222222'
+const TRACK_LIGHT = '#C4C4C4'
+const LUMINANCE_MID = 0.5
+
+const SAMPLE_CUT = {
+  name: 'OVERBOOST',
+  detail: '1.61 bar against 1.50',
+  elapsed: '2.4 s',
+  protective: false,
+}
+
+const SAMPLE_SPLASH = { name: 'ANTI-LAG', state: 'ARMED', detail: 'EGT 780 °C · 12 s' }
+
+const SAMPLE_ALERT = { name: 'OIL PRESS', value: '1.1', rule: 'below 1.5 bar' }
+
+const luminance = (hex: string): number => {
+  const value = hex.replace('#', '')
+  if (value.length !== 6) return 0
+  const channel = (offset: number): number => parseInt(value.slice(offset, offset + 2), 16) / 255
+  return 0.2126 * channel(0) + 0.7152 * channel(2) + 0.0722 * channel(4)
+}
+
+export interface PreviewOverlayProps {
+  mode: PreviewMode
+  scale: number
+  bgColor: string
+  palette: PagePalette
+}
+
+export const PreviewOverlay = ({ mode, scale, bgColor, palette }: PreviewOverlayProps) => {
+  if (mode === 'normal') return null
+  const track = luminance(bgColor) < LUMINANCE_MID ? TRACK_DARK : TRACK_LIGHT
+
+  if (mode === 'cut') {
+    return (
+      <div className="absolute inset-x-0 top-0 z-[3]">
+        <CutBand
+          scale={scale}
+          dimColor={palette.textDim}
+          inkColor={palette.text}
+          name={SAMPLE_CUT.name}
+          detail={SAMPLE_CUT.detail}
+          elapsed={SAMPLE_CUT.elapsed}
+          protective={SAMPLE_CUT.protective}
+        />
+      </div>
+    )
+  }
+
+  if (mode === 'splash') {
+    return (
+      <SplashTakeover
+        scale={scale}
+        bgColor={bgColor}
+        dimColor={palette.textDim}
+        trackColor={track}
+        name={SAMPLE_SPLASH.name}
+        state={SAMPLE_SPLASH.state}
+        detail={SAMPLE_SPLASH.detail}
+      />
+    )
+  }
+
+  return (
+    <AlertTakeover
+      scale={scale}
+      name={SAMPLE_ALERT.name}
+      value={SAMPLE_ALERT.value}
+      rule={SAMPLE_ALERT.rule}
+    />
+  )
+}

--- a/src/components/editor/preview/Takeover.tsx
+++ b/src/components/editor/preview/Takeover.tsx
@@ -1,0 +1,129 @@
+import { CS_DANGER, CS_ENGAGED } from './preview-modes'
+
+const SPLASH_NAME_PX = 6
+const SPLASH_STATE_PX = 64
+const SPLASH_DETAIL_PX = 10
+const ALERT_NAME_PX = 13
+const ALERT_VALUE_PX = 66
+const ALERT_RULE_PX = 10
+const ALERT_FOOTER_PX = 11
+const RULE_PX = 1
+
+export interface SplashTakeoverProps {
+  scale: number
+  bgColor: string
+  dimColor: string
+  trackColor: string
+  name: string
+  state: string
+  detail: string
+}
+
+export const SplashTakeover = ({
+  scale,
+  bgColor,
+  dimColor,
+  trackColor,
+  name,
+  state,
+  detail,
+}: SplashTakeoverProps) => (
+  <div
+    className="absolute inset-0 z-[3] flex flex-col"
+    // eslint-disable-next-line no-inline-style/no-inline-style
+    style={{ background: bgColor, padding: 4 * scale }}
+  >
+    <div
+      // eslint-disable-next-line no-inline-style/no-inline-style
+      style={{
+        borderTop: `${String(RULE_PX * scale)}px solid ${CS_ENGAGED}`,
+        paddingTop: 4 * scale,
+      }}
+    >
+      <div
+        className="font-sans font-extrabold uppercase"
+        // eslint-disable-next-line no-inline-style/no-inline-style
+        style={{ fontSize: SPLASH_NAME_PX * scale, letterSpacing: '0.2em', color: CS_ENGAGED }}
+      >
+        {name}
+      </div>
+    </div>
+    <div
+      // eslint-disable-next-line no-inline-style/no-inline-style
+      style={{
+        fontSize: SPLASH_STATE_PX * scale,
+        lineHeight: 0.9,
+        letterSpacing: '-0.045em',
+        color: CS_ENGAGED,
+        marginTop: 11 * scale,
+      }}
+    >
+      {state}
+    </div>
+    <div
+      className="mt-auto"
+      // eslint-disable-next-line no-inline-style/no-inline-style
+      style={{
+        borderTop: `${String(scale)}px solid ${trackColor}`,
+        paddingTop: 7 * scale,
+        fontSize: SPLASH_DETAIL_PX * scale,
+        color: dimColor,
+      }}
+    >
+      {detail}
+    </div>
+  </div>
+)
+
+export interface AlertTakeoverProps {
+  scale: number
+  name: string
+  value: string
+  rule: string
+}
+
+export const AlertTakeover = ({ scale, name, value, rule }: AlertTakeoverProps) => (
+  <div
+    className="absolute inset-0 z-[3] flex flex-col text-white"
+    // eslint-disable-next-line no-inline-style/no-inline-style
+    style={{ background: CS_DANGER, padding: 4 * scale }}
+  >
+    <div
+      className="font-sans font-extrabold uppercase"
+      // eslint-disable-next-line no-inline-style/no-inline-style
+      style={{ fontSize: ALERT_NAME_PX * scale, letterSpacing: '0.16em' }}
+    >
+      {name}
+    </div>
+    <div
+      // eslint-disable-next-line no-inline-style/no-inline-style
+      style={{
+        fontSize: ALERT_VALUE_PX * scale,
+        lineHeight: 0.9,
+        letterSpacing: '-0.045em',
+        marginTop: 5 * scale,
+      }}
+    >
+      {value}
+    </div>
+    <div
+      className="opacity-85"
+      // eslint-disable-next-line no-inline-style/no-inline-style
+      style={{ fontSize: ALERT_RULE_PX * scale, marginTop: 10 * scale }}
+    >
+      {rule}
+    </div>
+    <div
+      className="mt-auto font-sans font-extrabold uppercase"
+      // eslint-disable-next-line no-inline-style/no-inline-style
+      style={{
+        borderTop: `${String(RULE_PX * scale)}px solid rgba(255,255,255,0.5)`,
+        paddingTop: 7 * scale,
+        fontSize: ALERT_FOOTER_PX * scale,
+        letterSpacing: '0.14em',
+      }}
+    >
+      STOP THE ENGINE
+    </div>
+  </div>
+)

--- a/src/components/editor/preview/preview-modes.ts
+++ b/src/components/editor/preview/preview-modes.ts
@@ -1,0 +1,14 @@
+export const PREVIEW_MODES = ['normal', 'cut', 'splash', 'alert'] as const
+
+export type PreviewMode = (typeof PREVIEW_MODES)[number]
+
+export const PREVIEW_LABELS: Record<PreviewMode, string> = {
+  normal: 'NORMAL',
+  cut: 'CUT',
+  splash: 'SPLASH',
+  alert: 'ALERT',
+}
+
+export const CS_WARN = '#FF8800'
+export const CS_DANGER = '#FF4444'
+export const CS_ENGAGED = '#FF4747'

--- a/src/routes/EditorRoute.tsx
+++ b/src/routes/EditorRoute.tsx
@@ -15,6 +15,11 @@ import { useProjectStore } from '../stores/project/project.store'
 import { PROJECT_FILE_ACCEPT } from '../lib/project-file'
 import { ecuLabelForKey } from '../utils/ecu-label'
 import { buildWidget, DEFAULT_NEW_WIDGET } from '../lib/new-widget'
+import {
+  PREVIEW_LABELS,
+  PREVIEW_MODES,
+  type PreviewMode,
+} from '../components/editor/preview/preview-modes'
 import { useCatalogueIndex } from '../hooks/useCatalogueIndex'
 import { useDashboardStore } from '../stores/dashboard.store'
 import { SaveTemplateDialog } from '../components/editor/SaveTemplateDialog'
@@ -42,6 +47,13 @@ const buildBlankPage = (): PageConfig => ({
   visible: true,
   widgets: [],
 })
+
+const PREVIEW_TITLES: Record<PreviewMode, string> = {
+  normal: 'The page as it renders',
+  cut: 'A protection cut, banded under the status row',
+  splash: 'A driver-requested function taking the screen',
+  alert: 'The critical alert takeover',
+}
 
 const CanvasFallback = () => {
   return (
@@ -104,6 +116,7 @@ const EditorRoute = () => {
   const templates = useTemplateStore((s) => s.templates)
   const [saveTemplatePageId, setSaveTemplatePageId] = useState<string | null>(null)
   const [manageOpen, setManageOpen] = useState(false)
+  const [previewMode, setPreviewMode] = useState<PreviewMode>('normal')
 
   const showUndoToast = useUndoToastStore((s) => s.showForLastAction)
 
@@ -198,6 +211,15 @@ const EditorRoute = () => {
         setTargetProfile(id as ScreenProfileId)
       }}
       pageMeta={`${String(screenProfile.width)} × ${String(screenProfile.height)} · ${String(widgetCount)} widgets`}
+      previewModes={PREVIEW_MODES.map((mode) => ({
+        value: mode,
+        label: PREVIEW_LABELS[mode],
+        title: PREVIEW_TITLES[mode],
+      }))}
+      previewMode={previewMode}
+      onPreviewMode={(mode) => {
+        setPreviewMode(mode as PreviewMode)
+      }}
       profileMeta={ecuLabelForKey(selectedProfileKey, catalogue)}
       onAddWidget={() => {
         addWidget(currentPage.id, buildWidget(DEFAULT_NEW_WIDGET))
@@ -218,6 +240,7 @@ const EditorRoute = () => {
               page={currentPage}
               topBar={topBar}
               toolbar={toolbar}
+              previewMode={previewMode}
               onPageContextMenu={handlePageContextMenu}
               inspector={<RightSidebar pageId={currentPage.id} />}
             />


### PR DESCRIPTION
Closes #222. Fourteenth slice of the v2 restyle (#237), step 4 of the spec's order of work.

## What

`NORMAL / CUT / SPLASH / ALERT` in the DASH toolbar, overlaying the real dash states on the edited page so they can be designed and checked without provoking them on a car.

- **CUT** — a band directly under the status row: a rule in the severity colour, the cut name in Archivo 800 at `0.16em`, the measured value against its limit, the elapsed time right-aligned. Amber `#FF8800` when the cut holds a target, danger `#FF4444` when it protects the engine, with the detail switching between Dim and Ink accordingly. `DASH_DESIGN_SYSTEM.md` §7b — a cut is not driver-requested, so **it never takes the screen and never pulses**.
- **SPLASH** — takes the widget area: the theme ground, a `#FF4747` rule, the function name at `0.2em`, the state large, and the detail pinned to the bottom over a track rule. The anti-lag receipt.
- **ALERT** — takes the widget area in solid `#FF4444` with white text: the name in Archivo 800, the value large, the rule under it at 85 %, and `STOP THE ENGINE` pinned to the bottom over a white rule at 50 %.

Both takeovers cover **the widget grid only** — the shift light and the status row stay visible and correct, as the spec requires.

## The bug in the first draft

The mockup's numbers are **canvas pixels at 2×**, and the carousel already scales device pixels by its own measured factor. Taking `132px` from the comp and multiplying it by the carousel scale rendered the alert value at roughly twice its size, and `STOP THE ENGINE` fell off the bottom of the panel.

Every constant is now in **device pixels** — the comp's value halved — and multiplied by the carousel scale once. That is the same rule the widget renderer already follows, so a preview mode now scales with the page instead of against it.

## A lens, never a state

No preview mode touches the config. Nothing in them pulses or blinks: per the design system only `armed` pulses on the device, and none of these four is armed. Leaving DASH does not reset the mode — it is a toolbar setting, not a transient — but it cannot be burned, because it never reaches the config.

The three fixed colours are the only ones used. There is no fourth red.

## Sample content

The comp hard-codes its own examples and so does this: `OVERBOOST 1.61 bar against 1.50`, `ANTI-LAG · ARMED`, `OIL PRESS 1.1 below 1.5 bar`. That is deliberate — **cut names come from the ECU profile, never invented at runtime**, and the profile has no cut list yet. Deriving a fake one from the signal set would be exactly the invention the design system forbids. When profiles carry cuts, the sample is replaced by the real list.

## Responsive

The segmented control hides below 1240 px, in the same order the rest of the toolbar drops (#235). Re-measured at all six checkpoints: no clipping.

## Test plan

- `typecheck`, `lint`, `test` (433 passing) and `build` green.
- Driven in Helium at 1600 × 900: each of the four modes switches, `CUT` bands under the status row, `SPLASH` and `ALERT` take the widget area with the status row still visible, `STOP THE ENGINE` renders inside the panel, and `NORMAL` clears every overlay. No console error.
