### PR TITLE
restyle(tuner): drag the right edge to resize in whole columns

### DIFF
--- a/src/components/editor/Canvas.tsx
+++ b/src/components/editor/Canvas.tsx
@@ -17,6 +17,7 @@ import { PageFrame } from './canvas/page-frame'
 import { RubberBandRect } from './canvas/rubber-band-rect'
 import { CanvasStatusBar } from './canvas/canvas-status-bar'
 import { useDragState } from '../../hooks/useDragState'
+import { useResizeState } from '../../hooks/useResizeState'
 import { useCanvasKeyboard } from '../../hooks/useCanvasKeyboard'
 import { useCanvasSignalDrop } from '../../hooks/useCanvasSignalDrop'
 import { useClipboardWidgets } from '../../hooks/useClipboardWidgets'
@@ -117,6 +118,10 @@ const Canvas = ({
 
   const handleDragStart = useDragState({ dragInputsRef, zoomRef: scaleRef, scale: 1 })
 
+  const resizeInputsRef = useRef({ pageId: page.id, canvasW: screenProfile.width })
+  resizeInputsRef.current = { pageId: page.id, canvasW: screenProfile.width }
+  const handleResizeStart = useResizeState({ inputsRef: resizeInputsRef, scaleRef })
+
   const { rubberBand, startRubberBand } = useRubberBandSelection({
     containerRef: surfaceRef,
     effScale: scale,
@@ -171,6 +176,7 @@ const Canvas = ({
     onSelect: selectWidget,
     onShiftSelect: toggleWidgetSelection,
     onDragStart: handleDragStart,
+    onResizeStart: handleResizeStart,
     onSignalDrop: handleWidgetSignalDrop,
     settingsOpen,
     overlay: (

--- a/src/components/editor/WidgetBox.tsx
+++ b/src/components/editor/WidgetBox.tsx
@@ -1,4 +1,4 @@
-import { memo, type DragEvent, type MouseEvent } from 'react'
+import { memo, type DragEvent, type MouseEvent, type PointerEvent } from 'react'
 import type { PagePalette, Widget } from '@canshift/core'
 import { resolveGridRect } from '@canshift/core'
 import { cva } from 'class-variance-authority'
@@ -21,8 +21,11 @@ export interface WidgetBoxProps {
   onSelect: (id: string) => void
   onShiftSelect: (id: string) => void
   onDragStart: (e: MouseEvent, widget: Widget) => void
+  onResizeStart?: ((e: PointerEvent, widget: Widget) => void) | undefined
   onSignalDrop: (widget: Widget, signalName: string) => void
 }
+
+const GRIP_WIDTH_PX = 12
 
 type BoxFill = 'overlapping' | 'overflowing' | 'selected' | 'multi' | 'plain'
 type BoxGlow = 'overlapping' | 'overflowing' | 'multi' | 'none'
@@ -97,6 +100,7 @@ export const WidgetBox = memo(function WidgetBox({
   onSelect,
   onShiftSelect,
   onDragStart,
+  onResizeStart,
   onSignalDrop,
 }: WidgetBoxProps) {
   const acceptsSignal = SIGNAL_CONSUMING_TYPES.has(widget.type)
@@ -154,6 +158,22 @@ export const WidgetBox = memo(function WidgetBox({
         height: displayH,
       }}
     >
+      {onResizeStart && (
+        <div
+          role="separator"
+          aria-label={`Resize ${widget.type}`}
+          title="Drag to resize"
+          onPointerDown={(e) => {
+            onResizeStart(e, widget)
+          }}
+          onMouseDown={(e) => {
+            e.stopPropagation()
+          }}
+          className="absolute inset-y-0 right-0 z-[2] cursor-ew-resize bg-transparent hover:bg-white/10"
+          // eslint-disable-next-line no-inline-style/no-inline-style
+          style={{ width: GRIP_WIDTH_PX }}
+        />
+      )}
       <WidgetPreview
         widget={widget}
         palette={palette}

--- a/src/components/editor/canvas/page-frame.tsx
+++ b/src/components/editor/canvas/page-frame.tsx
@@ -19,6 +19,7 @@ export interface PageFrameInteraction {
   onSelect: (widgetId: string) => void
   onShiftSelect: (widgetId: string) => void
   onDragStart: (e: React.MouseEvent, widget: Widget) => void
+  onResizeStart: (e: React.PointerEvent, widget: Widget) => void
   onSignalDrop: (widget: Widget, signalName: string) => void
   settingsOpen: boolean
   overlay: ReactNode
@@ -89,6 +90,7 @@ export const PageFrame = ({
         onSelect={interaction?.onSelect ?? noop}
         onShiftSelect={interaction?.onShiftSelect ?? noop}
         onDragStart={interaction?.onDragStart ?? noop}
+        onResizeStart={interaction?.onResizeStart}
         onSignalDrop={interaction?.onSignalDrop ?? noop}
       />
       {interaction?.overlay}

--- a/src/components/editor/canvas/widget-layer.tsx
+++ b/src/components/editor/canvas/widget-layer.tsx
@@ -18,6 +18,7 @@ export interface WidgetLayerProps {
   onSelect: (widgetId: string) => void
   onShiftSelect: (widgetId: string) => void
   onDragStart: (e: React.MouseEvent, widget: Widget) => void
+  onResizeStart?: ((e: React.PointerEvent, widget: Widget) => void) | undefined
   onSignalDrop: (widget: Widget, signalName: string) => void
 }
 
@@ -46,6 +47,7 @@ const CustomBody = (props: WidgetLayerProps) => (
         onSelect={props.onSelect}
         onShiftSelect={props.onShiftSelect}
         onDragStart={props.onDragStart}
+        onResizeStart={props.onResizeStart}
         isFlashing={widget.id === props.flashWidgetId}
         onSignalDrop={props.onSignalDrop}
       />

--- a/src/hooks/useResizeState.ts
+++ b/src/hooks/useResizeState.ts
@@ -1,0 +1,84 @@
+import { useCallback, useRef, type PointerEvent as ReactPointerEvent, type RefObject } from 'react'
+import type { Widget } from '@canshift/core'
+import { LAYOUT_GRID } from '@canshift/core'
+import { useDashboardStore } from '../stores/dashboard.store'
+
+const MIN_SPAN = 1
+
+interface ResizeState {
+  pageId: string
+  widgetId: string
+  startX: number
+  startSpan: number
+  startCol: number
+  lastSpan: number
+}
+
+export interface ResizeInputs {
+  pageId: string
+  canvasW: number
+}
+
+export interface UseResizeStateOptions {
+  inputsRef: RefObject<ResizeInputs>
+  scaleRef: RefObject<number>
+}
+
+const trackPitch = (areaSize: number, tracks: number): number =>
+  (areaSize - 2 * LAYOUT_GRID.FRAME_PADDING + LAYOUT_GRID.GUTTER) / tracks
+
+export const useResizeState = ({
+  inputsRef,
+  scaleRef,
+}: UseResizeStateOptions): ((e: ReactPointerEvent, widget: Widget) => void) => {
+  const moveWidget = useDashboardStore((s) => s.moveWidget)
+  const beginDrag = useDashboardStore((s) => s.beginDrag)
+  const stateRef = useRef<ResizeState | null>(null)
+
+  return useCallback(
+    (e: ReactPointerEvent, widget: Widget) => {
+      const inputs = inputsRef.current
+      if (!inputs) return
+      e.preventDefault()
+      e.stopPropagation()
+
+      stateRef.current = {
+        pageId: inputs.pageId,
+        widgetId: widget.id,
+        startX: e.clientX,
+        startSpan: widget.layout.colSpan,
+        startCol: widget.layout.col,
+        lastSpan: widget.layout.colSpan,
+      }
+
+      const pitch = trackPitch(inputs.canvasW, LAYOUT_GRID.COLUMNS)
+      let began = false
+
+      const onMove = (ev: PointerEvent) => {
+        const state = stateRef.current
+        if (!state) return
+        const scale = scaleRef.current ?? 1
+        const deltaCols = Math.round((ev.clientX - state.startX) / (pitch * scale))
+        const maxSpan = LAYOUT_GRID.COLUMNS - state.startCol
+        const nextSpan = Math.min(maxSpan, Math.max(MIN_SPAN, state.startSpan + deltaCols))
+        if (nextSpan === state.lastSpan) return
+        if (!began) {
+          beginDrag(state.pageId, [state.widgetId])
+          began = true
+        }
+        state.lastSpan = nextSpan
+        moveWidget(state.pageId, state.widgetId, { colSpan: nextSpan })
+      }
+
+      const onUp = () => {
+        stateRef.current = null
+        window.removeEventListener('pointermove', onMove)
+        window.removeEventListener('pointerup', onUp)
+      }
+
+      window.addEventListener('pointermove', onMove)
+      window.addEventListener('pointerup', onUp)
+    },
+    [inputsRef, scaleRef, moveWidget, beginDrag]
+  )
+}


### PR DESCRIPTION
Closes #224 in part. Seventeenth slice of the v2 restyle (#237), step 4 of the spec's order of work.

## What

`PROMPT_TUNER_APP.md` §4 names three gestures on the edited page. Two already worked — click selects, drag reorders. The third did not exist: **drag the right edge to change the span in whole columns**. `WidgetBox` had no grip at all.

`useResizeState` mirrors the column maths `useDragState` already uses — the same `trackPitch` over `LAYOUT_GRID.COLUMNS`, so a resize and a move agree on where a column boundary is. It snaps to whole columns, clamps at 1 and at what is left of the grid from the widget's own column, and pushes one history entry per gesture rather than one per pixel.

## Measured

Driven in Helium, reading the persisted config rather than the DOM:

| | |
| --- | --- |
| grip width on screen | **12 px** |
| grip width after shrinking the window to 640 px tall | **12 px** |
| drag left 160 px | `colSpan` 7 → **5** |
| grips rendered | 7, for 7 widgets on the current page |

That last row is the thumbnail check: the strip holds six pages, and only the edited one has grips. It is true by construction rather than by a flag — `PageFrame` takes an optional `interaction` object, and a thumbnail simply is not given one, so there is nothing to forget.

## On the spec's divide-by-scale

§4 says the grip's width is divided by the carousel scale so it stays 12 px on screen. That is right for the comp, where the page is CSS-transform-scaled — but this canvas is not. `WidgetBox` computes `left`, `top`, `width` and `height` as device pixels **multiplied** by the scale, so the box already lives in screen pixels and a literal `12px` is 12 screen pixels. Dividing would have made the grip shrink as the page grew.

Verified rather than assumed: the grip measures 12 px at two different carousel scales.

## Still open on #224

- **Drag to reorder** works and is untouched.
- **Rubber-band multi-select** still works on the edited page. Whether it should survive a scaled multi-page strip is the open question this issue carries; it is not answered here.
- **Alt-drag to disable snap** is still in the shortcut dialog and still works for moves; resize is always whole-column, as the spec requires.

## Test plan

- `typecheck`, `lint`, `test` (429 passing) and `build` green.
- The measurements above, plus no console error and no layout thrash while dragging.
