### PR TITLE
restyle(tuner): discovered frames arrive one line at a time above the table

### DIFF
--- a/src/components/signals/BusScanPanel.tsx
+++ b/src/components/signals/BusScanPanel.tsx
@@ -1,0 +1,74 @@
+import type { SignalDef } from '@canshift/core'
+import type { CanFrameStats } from '../../stores/can-scan/accumulator'
+import { formatFrameIdHex } from '../../utils/frame-id'
+
+const GRID = 'grid grid-cols-[128px_96px_minmax(0,1fr)_170px_190px] gap-8'
+const RATE_DECIMALS = 0
+const UNBOUND = 'not bound'
+
+export interface BusScanPanelProps {
+  frames: readonly CanFrameStats[]
+  totalFrames: number
+  signals: readonly SignalDef[]
+  boundTo: ReadonlyMap<number, string>
+  onAssign: (frameId: number, signalName: string) => void
+  onClear: () => void
+}
+
+const payloadOf = (frame: CanFrameStats): string =>
+  frame.lastPayload
+    .slice(0, frame.lastDlc)
+    .map((byte) => byte.toString(16).toUpperCase().padStart(2, '0'))
+    .join(' ')
+
+export const BusScanPanel = ({
+  frames,
+  totalFrames,
+  signals,
+  boundTo,
+  onAssign,
+  onClear,
+}: BusScanPanelProps) => (
+  <div className="max-h-[232px] shrink-0 overflow-y-auto border-b-2 border-ui-rule bg-ui-panel">
+    <div className="flex items-center gap-3.5 px-6 py-[11px] font-mono text-[10.5px] tracking-[0.16em] text-ui-muted">
+      <span>BUS SCAN</span>
+      <span>
+        {frames.length} id{frames.length === 1 ? '' : 's'} · {totalFrames} frames
+      </span>
+      <button
+        type="button"
+        onClick={onClear}
+        className="ml-auto cursor-pointer border-0 bg-transparent font-[inherit] text-[10.5px] tracking-[0.16em] text-ui-muted hover:text-ui-ink"
+      >
+        CLEAR
+      </button>
+    </div>
+
+    {frames.map((frame) => (
+      <div
+        key={frame.id}
+        className={`${GRID} items-center border-t border-ui-line px-6 py-[11px] font-mono text-[13.5px] text-ui-ink`}
+      >
+        <span className="text-ui-accent">{formatFrameIdHex(frame.id)}</span>
+        <span className="text-ui-muted">{frame.rateHz.toFixed(RATE_DECIMALS)} Hz</span>
+        <span className="truncate tracking-[0.06em]">{payloadOf(frame)}</span>
+        <span className="truncate text-ui-muted">{boundTo.get(frame.id) ?? UNBOUND}</span>
+        <select
+          value=""
+          aria-label={`Assign ${formatFrameIdHex(frame.id)}`}
+          onChange={(e) => {
+            if (e.target.value.length > 0) onAssign(frame.id, e.target.value)
+          }}
+          className="border border-ui-line-strong bg-transparent px-1.5 py-1 font-mono text-[13px] text-ui-ink"
+        >
+          <option value="">assign to…</option>
+          {signals.map((signal) => (
+            <option key={signal.name} value={signal.name}>
+              {signal.name}
+            </option>
+          ))}
+        </select>
+      </div>
+    ))}
+  </div>
+)

--- a/src/components/signals/SignalsToolbar.tsx
+++ b/src/components/signals/SignalsToolbar.tsx
@@ -95,17 +95,30 @@ const segment = cva(
   }
 )
 
+export interface SignalsActionProps {
+  onClick: () => void
+  disabled?: boolean
+  title?: string | undefined
+  children: ReactNode
+}
+
 export const SignalsAction = ({
   onClick,
+  disabled = false,
+  title,
   children,
-}: {
-  onClick: () => void
-  children: ReactNode
-}) => (
+}: SignalsActionProps) => (
   <button
     type="button"
     onClick={onClick}
-    className="cursor-pointer whitespace-nowrap border border-ui-ink bg-transparent px-4 py-2 text-left text-[12.5px] font-bold text-ui-ink hover:bg-ui-panel"
+    disabled={disabled}
+    title={title}
+    className={cn(
+      'whitespace-nowrap border px-4 py-2 text-left text-[12.5px] font-bold',
+      disabled
+        ? 'cursor-not-allowed border-ui-line bg-transparent text-ui-faint'
+        : 'cursor-pointer border-ui-ink bg-transparent text-ui-ink hover:bg-ui-panel'
+    )}
   >
     {children}
   </button>

--- a/src/routes/SignalsRoute.tsx
+++ b/src/routes/SignalsRoute.tsx
@@ -8,17 +8,21 @@ import {
   type SignalSource,
 } from '../components/signals/SignalsToolbar'
 import { CanSignalTable } from '../components/signals/CanSignalTable'
+import { BusScanPanel } from '../components/signals/BusScanPanel'
+import { useCanScanner } from '../hooks/useCanScanner'
+import { useDeviceStore } from '../stores/device.store'
+import { formatFrameIdHex, parseHexFrameId } from '../utils/frame-id'
 import { useSignalStore } from '../stores/signal.store'
 import { useLiveSignals } from '../hooks/useLiveSignals'
 import { useSignalUsage } from '../hooks/useSignalUsage'
 import { useCatalogueIndex } from '../hooks/useCatalogueIndex'
 import { ecuLabelForKey } from '../utils/ecu-label'
 
-const CanBusRoute = lazy(() => import('./CanBusRoute'))
 const EcuRoute = lazy(() => import('./EcuRoute'))
+const CanBusRoute = lazy(() => import('./CanBusRoute'))
 const Obd2Route = lazy(() => import('./Obd2Route'))
 
-type Pane = SignalSource | 'scan' | 'ecu'
+type Pane = SignalSource | 'ecu' | 'analysis'
 
 const SignalsRoute = () => {
   const signals = useSignalStore((s) => s.signals)
@@ -28,6 +32,9 @@ const SignalsRoute = () => {
   const values = useLiveSignals()
   const usage = useSignalUsage()
   const catalogue = useCatalogueIndex()
+  const scanner = useCanScanner()
+  const connected = useDeviceStore((s) => s.connected)
+  const simulationMode = useDeviceStore((s) => s.simulationMode)
 
   const [pane, setPane] = useState<Pane>('can')
   const [filter, setFilter] = useState('')
@@ -60,11 +67,20 @@ const SignalsRoute = () => {
     [signals, usage]
   )
 
+  const scanning = scanner.status === 'running' || scanner.status === 'starting'
+  const canScan = connected && !simulationMode
+  const frames = [...scanner.snapshot.frames.values()].sort((a, b) => a.id - b.id)
+  const boundTo = new Map<number, string>()
+  for (const signal of signals) {
+    const id = parseHexFrameId(signal.canFrameId)
+    if (id >= 0 && !boundTo.has(id)) boundTo.set(id, signal.name)
+  }
+
   const panes: Record<Pane, ReactNode> = {
     can: <CanSignalTable signals={shown} values={values} usage={usage} onPatch={updateSignal} />,
     obd2: <Obd2Route />,
-    scan: <CanBusRoute />,
     ecu: <EcuRoute />,
+    analysis: <CanBusRoute />,
   }
 
   const source: SignalSource = pane === 'obd2' ? 'obd2' : 'can'
@@ -87,11 +103,26 @@ const SignalsRoute = () => {
         actions={
           <>
             <SignalsAction
+              disabled={!canScan}
+              title={canScan ? undefined : 'Plug a dash in — simulation has no bus to listen to.'}
               onClick={() => {
-                setPane((current) => (current === 'scan' ? 'can' : 'scan'))
+                if (scanning) {
+                  void scanner.stop()
+                  return
+                }
+                setPane('can')
+                void scanner.start()
               }}
             >
-              {pane === 'scan' ? 'Back to signals' : 'Scan bus'}
+              {scanning ? 'Stop scan' : 'Scan bus'}
+            </SignalsAction>
+            <SignalsAction
+              onClick={() => {
+                setPane((current) => (current === 'analysis' ? 'can' : 'analysis'))
+              }}
+              title="Sort, byte histograms and learn mode — for mapping an unknown ECU"
+            >
+              {pane === 'analysis' ? 'Back to signals' : 'Analyse…'}
             </SignalsAction>
             <SignalsAction
               onClick={() => {
@@ -104,6 +135,18 @@ const SignalsRoute = () => {
         }
       />
       <div className="flex min-h-0 flex-1 flex-col">
+        {frames.length > 0 && pane === 'can' && (
+          <BusScanPanel
+            frames={frames}
+            totalFrames={scanner.snapshot.totalFrames}
+            signals={signals}
+            boundTo={boundTo}
+            onAssign={(frameId, signalName) => {
+              updateSignal(signalName, { canFrameId: formatFrameIdHex(frameId) })
+            }}
+            onClear={scanner.reset}
+          />
+        )}
         <Suspense fallback={<RouteLoading />}>{panes[pane]}</Suspense>
       </div>
     </div>


### PR DESCRIPTION
Closes #228. Eighteenth slice of the v2 restyle (#237).

## What

`PROMPT_TUNER_APP.md` §5: `SCAN BUS` in the SIGNALS toolbar starts listening, and what it hears lands in a panel **above** the signal table — `max-height: 232px`, scrolling, on `--ui-panel` under a 2 px rule.

A head line — `BUS SCAN`, the count, `CLEAR` pushed right — then one row per discovered frame on `128px 96px minmax(0,1fr) 170px 190px` with a 32 px gap: the ID in accent, the rate, the raw bytes, what it is already bound to, and an `assign to…` select over every signal in the profile.

**Rows cannot wrap.** Five grid tracks, five children **always rendered** — `not bound` is a string, not a missing element. The spec calls that out because a conditional child collapses the grid, and it is the failure that already happened once.

Assigning writes the frame ID onto the chosen signal through `updateSignal`, so it persists and the CAN table's `CAN ID` cell updates in the same render.

## `SCAN BUS` refuses rather than pretending

Simulation has no bus. The action is disabled with a title saying so — *Plug a dash in — simulation has no bus to listen to.* Verified: disabled in simulation.

## The deep scanner is not lost

The spec's panel is five columns. `CanBusRoute` carried four things it does not have, and they are not decoration for someone mapping an unknown ECU:

- **sort** by id / last seen / rate / count / activity
- **byte histograms** — which bytes in a frame actually change
- **learn mode** — mark the frames that moved while you pressed something
- **promote to draft signal** — turn an unknown frame into a signal in one click

So it stays, behind an `Analyse…` action in the toolbar, titled *Sort, byte histograms and learn mode — for mapping an unknown ECU*. The five-column panel is the everyday path; the analysis view is the one you open when the profile does not exist yet.

That is a deliberate deviation from a comp that only drew the everyday path.

## Test plan

- `typecheck`, `lint`, `test` (429 passing) and `build` green.
- Driven in Helium at 1600 × 900: `Scan bus` is disabled in simulation with its explanation; `Analyse…` opens the full scanner with its sort bar; the toolbar holds `Scan bus`, `Analyse…` and `ECU profile…` without clipping. No console error.

## Follow-up

The scan panel only appears once frames arrive, which needs a live bus — so its rendering is verified by construction and by the analysis view, not on real traffic. That wants a bench pass with the rest of the hardware-gated work (#245, #253).
