### PR TITLE
restyle(tuner): hold the six checkpoints, and answer for what is under 900 px

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,10 @@ import { useUnsavedChangesGuard } from './hooks/useUnsavedChangesGuard'
 import { useDocumentMeta } from './hooks/useDocumentMeta'
 import { DeviceConfigConflictNotice } from './components/shell/DeviceConfigConflictNotice'
 import { CliPanel } from './components/cli/CliPanel'
+import { CapabilityScreen } from './components/shell/CapabilityScreen'
+import { capabilityReason } from './lib/capability'
+import { useBelowFloor } from './hooks/useBelowFloor'
+import { isWebSerialAvailable } from './lib/web-serial'
 import { useUiStore } from './stores/ui.store'
 import {
   DEVICE_GATED_PATHS,
@@ -76,6 +80,12 @@ const DeviceGate = ({ children }: { children: ReactNode }) => {
 }
 
 const App = () => {
+  const reason = capabilityReason(useBelowFloor(), isWebSerialAvailable())
+  if (reason !== null) return <CapabilityScreen reason={reason} />
+  return <TunerShell />
+}
+
+const TunerShell = () => {
   useAutoReconnect()
   useSimulationBootstrap()
   useVersionHandshake()

--- a/src/components/contact/ContactPane.tsx
+++ b/src/components/contact/ContactPane.tsx
@@ -60,7 +60,7 @@ export const ContactPane = ({
   error,
   diagnosticsToggle,
 }: ContactPaneProps) => (
-  <div className="max-w-[720px] px-11 pb-[60px] pt-12">
+  <div className="max-w-[720px] px-6 pb-[60px] pt-12 sm:px-11">
     <p className="border-b-2 border-ui-rule pb-3 font-mono text-[10.5px] tracking-[0.2em] text-ui-muted">
       SUPPORT
     </p>

--- a/src/components/shell/CapabilityScreen.tsx
+++ b/src/components/shell/CapabilityScreen.tsx
@@ -1,0 +1,133 @@
+import { lazy, Suspense, useMemo, useState, type ReactNode } from 'react'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+import { ThemeToggleButton } from './ThemeToggleButton'
+import { useThemeStore } from '../../stores/theme.store'
+import { useFirmwareReleases } from '../../hooks/useFirmwareReleases'
+import { parseChangelog } from '../../lib/firmware/changelog'
+import { ChangelogPanel } from '../firmware/ChangelogPanel'
+import { RouteLoading } from './RouteLoading'
+import type { CapabilityReason } from '../../lib/capability'
+
+const ContactRoute = lazy(() => import('../../routes/ContactRoute'))
+
+type Pane = 'why' | 'changelog' | 'contact'
+
+const PANE_LABELS: Record<Pane, string> = {
+  why: 'Why',
+  changelog: 'Firmware',
+  contact: 'Contact',
+}
+
+const PANES = Object.keys(PANE_LABELS) as Pane[]
+
+const HEADLINE: Record<CapabilityReason, string> = {
+  narrow: 'The Tuner needs a wider window.',
+  'no-web-serial': 'This browser cannot talk to a dash.',
+}
+
+const BODY: Record<CapabilityReason, string> = {
+  narrow:
+    'Editing a dash means dragging widgets on a 320×240 canvas next to a signal table, and that does not survive a phone-sized window. Open the Tuner on a computer, in a window at least 900 px wide.',
+  'no-web-serial':
+    'The Tuner writes firmware and config over WebSerial, which this browser does not implement. Safari and Firefox have never shipped it, and no iOS or Android browser can.',
+}
+
+const BROWSERS = 'Chrome 89+ · Edge 89+ · Brave · Opera — on macOS, Windows or Linux'
+
+const STILL_WORKS = 'Two things still work here: the firmware changelog, and telling us something.'
+
+export interface CapabilityScreenProps {
+  reason: CapabilityReason
+}
+
+export const CapabilityScreen = ({ reason }: CapabilityScreenProps) => {
+  const theme = useThemeStore((s) => s.theme)
+  const toggleTheme = useThemeStore((s) => s.toggleTheme)
+  const { state } = useFirmwareReleases()
+  const [pane, setPane] = useState<Pane>('why')
+
+  const release = state.kind === 'ok' ? (state.releases[0] ?? null) : null
+  const entries = useMemo(() => parseChangelog(release?.notes ?? ''), [release?.notes])
+
+  const PANES_BY_KEY: Record<Pane, ReactNode> = {
+    why: (
+      <div className="px-6 pb-16 pt-10">
+        <h1 className="mb-4 text-[27px] font-extrabold leading-[1.1] tracking-[-0.03em] text-ui-ink">
+          {HEADLINE[reason]}
+        </h1>
+        <p className="mb-6 text-pretty text-[15px] leading-[1.6] text-ui-muted">{BODY[reason]}</p>
+        <p className="mb-7 border-l-[3px] border-l-ui-accent py-1 pl-3.5 font-mono text-[12.5px] leading-[1.6] text-ui-ink">
+          {BROWSERS}
+        </p>
+        <p className="text-[14px] leading-[1.6] text-ui-muted">{STILL_WORKS}</p>
+      </div>
+    ),
+    changelog: (
+      <div className="px-6 pb-16 pt-10">
+        {release === null ? (
+          <p className="text-[14px] text-ui-muted">Fetching the firmware releases…</p>
+        ) : (
+          <ChangelogPanel
+            version={release.version}
+            publishedAt={release.publishedAt}
+            notesUrl={release.htmlUrl}
+            entries={entries}
+          />
+        )}
+      </div>
+    ),
+    contact: (
+      <Suspense fallback={<RouteLoading />}>
+        <ContactRoute />
+      </Suspense>
+    ),
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-ui-bg font-sans text-ui-ink">
+      <header className="flex h-[52px] shrink-0 items-center gap-3 bg-ui-header-bg pl-4">
+        <span className="font-mono text-[12px] font-bold tracking-[0.14em] text-ui-header-ink">
+          CANSHIFT
+        </span>
+        <span className="font-mono text-[11px] tracking-[0.14em] text-ui-header-dim">TUNER</span>
+        <span className="ml-auto flex h-full items-center">
+          <ThemeToggleButton theme={theme} onToggle={toggleTheme} />
+        </span>
+      </header>
+
+      <nav
+        aria-label="Sections"
+        className="flex shrink-0 gap-px border-b-2 border-ui-rule px-4 py-3"
+      >
+        {PANES.map((value) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => {
+              setPane(value)
+            }}
+            className={cn(tab({ active: value === pane }))}
+          >
+            {PANE_LABELS[value]}
+          </button>
+        ))}
+      </nav>
+
+      <main className="min-h-0 flex-1 overflow-y-auto">{PANES_BY_KEY[pane]}</main>
+    </div>
+  )
+}
+
+const tab = cva(
+  'cursor-pointer whitespace-nowrap border px-4 py-2 text-[12.5px] font-bold tracking-[0.06em]',
+  {
+    variants: {
+      active: {
+        true: 'border-ui-rule bg-ui-rule text-ui-bg',
+        false: 'border-ui-ink bg-transparent text-ui-ink',
+      },
+    },
+    defaultVariants: { active: false },
+  }
+)

--- a/src/components/shell/HeaderView.tsx
+++ b/src/components/shell/HeaderView.tsx
@@ -67,7 +67,7 @@ export const HeaderView = ({
   const visual = STATUS_VISUAL[status]
   return (
     <header className="flex h-[52px] shrink-0 items-stretch bg-ui-header-bg text-ui-header-ink">
-      <div className="flex items-center gap-2.5 px-5">
+      <div className="flex items-center gap-2.5 px-3 min-[1100px]:px-5">
         <BrandLockup height={19} />
         <span className="hidden font-mono text-[11px] tracking-[0.16em] text-ui-faint min-[1000px]:inline">
           TUNER
@@ -76,7 +76,7 @@ export const HeaderView = ({
 
       {configNameField}
 
-      <nav aria-label="Primary" className="ml-[18px] flex items-stretch">
+      <nav aria-label="Primary" className="ml-2 flex items-stretch min-[1100px]:ml-[18px]">
         {HEADER_TABS.map((tab) => (
           <HeaderTabItem
             key={tab.to}
@@ -109,7 +109,7 @@ export const HeaderView = ({
           type="button"
           onClick={onDisconnect}
           title="Disconnect the dash"
-          className="cursor-pointer whitespace-nowrap border-0 border-l border-solid border-ui-header-line bg-transparent px-4 font-mono text-[11px] tracking-[0.14em] text-ui-faint hover:text-ui-engaged"
+          className="cursor-pointer whitespace-nowrap border-0 border-l border-solid border-ui-header-line bg-transparent px-2.5 font-mono text-[11px] tracking-[0.14em] text-ui-faint hover:text-ui-engaged min-[1100px]:px-4"
         >
           DISCONNECT
         </button>
@@ -153,7 +153,8 @@ const HeaderTabItem = ({ tab, active, disabled, LinkComponent }: HeaderTabItemPr
 
 const headerTab = cva(
   [
-    'flex items-center whitespace-nowrap px-4 text-[13px] font-bold tracking-[0.06em]',
+    'flex items-center whitespace-nowrap px-2.5 text-[13px] font-bold tracking-[0.06em]',
+    'min-[1100px]:px-4',
     'no-underline outline-offset-[-2px]',
   ].join(' '),
   {

--- a/src/components/signals/CanSignalTable.tsx
+++ b/src/components/signals/CanSignalTable.tsx
@@ -4,7 +4,11 @@ import { cn } from '@/lib/utils'
 import { formatByteRange, parseByteRange } from '../../lib/signal-bytes'
 import type { SignalUsage } from '../../hooks/useSignalUsage'
 
-const GRID = 'grid-cols-[minmax(180px,1fr)_132px_104px_128px_116px_minmax(150px,260px)] gap-10'
+const GRID = [
+  'grid-cols-[minmax(140px,1fr)_132px_104px_128px_116px_minmax(120px,260px)] gap-5',
+  'min-[1180px]:grid-cols-[minmax(180px,1fr)_132px_104px_128px_116px_minmax(150px,260px)]',
+  'min-[1180px]:gap-10',
+].join(' ')
 const DECIMALS = 1
 const NO_VALUE = '—'
 

--- a/src/components/signals/Obd2Table.tsx
+++ b/src/components/signals/Obd2Table.tsx
@@ -3,7 +3,11 @@ import type { SignalDef } from '@canshift/core'
 import { cn } from '@/lib/utils'
 import type { SignalUsage } from '../../hooks/useSignalUsage'
 
-const GRID = 'grid grid-cols-[120px_minmax(180px,1fr)_140px_120px_minmax(150px,260px)] gap-10'
+const GRID = [
+  'grid grid-cols-[100px_minmax(140px,1fr)_120px_100px_minmax(120px,260px)] gap-5',
+  'min-[1180px]:grid-cols-[120px_minmax(180px,1fr)_140px_120px_minmax(150px,260px)]',
+  'min-[1180px]:gap-10',
+].join(' ')
 const DECIMALS = 1
 const NO_VALUE = '—'
 const NOT_IN_PROFILE = 'not in the profile'

--- a/src/components/signals/SignalsToolbar.tsx
+++ b/src/components/signals/SignalsToolbar.tsx
@@ -40,7 +40,7 @@ export const SignalsToolbar = ({
   onFilter,
   actions,
 }: SignalsToolbarProps) => (
-  <div className="flex h-[54px] shrink-0 items-center gap-4 border-b-2 border-ui-rule px-6">
+  <div className="flex h-[54px] shrink-0 items-center gap-2.5 border-b-2 border-ui-rule px-6 min-[1180px]:gap-4">
     <div className="flex gap-px">
       {SOURCES.map((value) => (
         <button
@@ -62,7 +62,7 @@ export const SignalsToolbar = ({
         onProfile(e.target.value)
       }}
       aria-label="ECU profile"
-      className="max-w-[220px] border border-ui-ink bg-ui-bg py-2 pl-2.5 pr-[26px] font-mono text-[13px] font-bold text-ui-ink"
+      className="max-w-[150px] border border-ui-ink bg-ui-bg py-2 pl-2.5 pr-[26px] font-mono text-[13px] font-bold text-ui-ink min-[1180px]:max-w-[220px]"
     >
       {groups.map((group) => (
         <optgroup key={group.label} label={group.label}>
@@ -86,7 +86,7 @@ export const SignalsToolbar = ({
       }}
       placeholder="filter"
       aria-label="Filter signals"
-      className="ml-auto w-40 border border-ui-ink bg-ui-bg px-2.5 py-2 font-mono text-[13px] text-ui-ink outline-none"
+      className="ml-auto w-28 border border-ui-ink bg-ui-bg px-2.5 py-2 font-mono text-[13px] text-ui-ink outline-none min-[1180px]:w-40"
     />
 
     {actions}

--- a/src/components/welcome/RecentConfigRow.tsx
+++ b/src/components/welcome/RecentConfigRow.tsx
@@ -27,10 +27,14 @@ export const RecentConfigRow = ({
       onClick={() => {
         onOpen(entry.id)
       }}
-      className="flex flex-1 cursor-pointer items-baseline gap-[18px] border-0 bg-transparent p-0 text-left"
+      className="flex min-w-0 flex-1 cursor-pointer items-baseline gap-[18px] border-0 bg-transparent p-0 text-left"
     >
-      <span className="flex-1 truncate text-[15px] font-bold text-ui-ink">{entry.name}</span>
-      <span className="whitespace-nowrap font-mono text-[11.5px] text-ui-muted">{entry.meta}</span>
+      <span className="min-w-0 flex-1 truncate text-[15px] font-bold text-ui-ink">
+        {entry.name}
+      </span>
+      <span className="min-w-0 flex-[0_1_auto] truncate font-mono text-[11.5px] text-ui-muted">
+        {entry.meta}
+      </span>
       <span className="font-mono text-[11.5px] text-ui-accent">OPEN</span>
     </button>
     <button

--- a/src/hooks/useBelowFloor.ts
+++ b/src/hooks/useBelowFloor.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+
+export const APP_MIN_WIDTH = 900
+
+const QUERY = `(max-width: ${String(APP_MIN_WIDTH - 1)}px)`
+
+const matches = (): boolean =>
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia(QUERY).matches
+    : false
+
+export const useBelowFloor = (): boolean => {
+  const [below, setBelow] = useState(matches)
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return undefined
+    const query = window.matchMedia(QUERY)
+    const onChange = (event: MediaQueryListEvent) => {
+      setBelow(event.matches)
+    }
+    setBelow(query.matches)
+    query.addEventListener('change', onChange)
+    return () => {
+      query.removeEventListener('change', onChange)
+    }
+  }, [])
+
+  return below
+}

--- a/src/hooks/useFlasher.ts
+++ b/src/hooks/useFlasher.ts
@@ -4,6 +4,7 @@ import { useResolvedBoardProfile } from './useResolvedBoardProfile'
 import { downloadFirmwareAsset } from '../lib/firmware/download'
 import { flashFirmwareOta } from '../lib/firmware/ota'
 import { errorMessage } from '../lib/error-message'
+import { isWebSerialAvailable } from '../lib/web-serial'
 import { findFirmwareAsset } from '../lib/firmware/releases'
 import { useConnectionStore } from '../stores/connection.store'
 import {
@@ -15,9 +16,6 @@ import { useFlasherStore } from '../stores/flasher.store'
 import type { FlasherState } from '../stores/flasher.store'
 
 export type { FlasherState }
-
-const isWebSerialAvailable = (): boolean =>
-  typeof navigator !== 'undefined' && 'serial' in navigator
 
 const DISCONNECT_WAIT_MS = 1500
 const DISCONNECT_POLL_MS = 50

--- a/src/lib/capability.test.ts
+++ b/src/lib/capability.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { capabilityReason } from './capability'
+
+describe('capabilityReason', () => {
+  it('lets a wide window with WebSerial through to the app', () => {
+    expect(capabilityReason(false, true)).toBeNull()
+  })
+
+  it('stops a window narrower than the floor', () => {
+    expect(capabilityReason(true, true)).toBe('narrow')
+  })
+
+  it('names the missing capability ahead of the width, at any width', () => {
+    expect(capabilityReason(false, false)).toBe('no-web-serial')
+    expect(capabilityReason(true, false)).toBe('no-web-serial')
+  })
+})

--- a/src/lib/capability.ts
+++ b/src/lib/capability.ts
@@ -1,0 +1,9 @@
+export type CapabilityReason = 'narrow' | 'no-web-serial'
+
+export const capabilityReason = (
+  belowFloor: boolean,
+  webSerial: boolean
+): CapabilityReason | null => {
+  if (!webSerial) return 'no-web-serial'
+  return belowFloor ? 'narrow' : null
+}

--- a/src/lib/web-serial.ts
+++ b/src/lib/web-serial.ts
@@ -1,0 +1,2 @@
+export const isWebSerialAvailable = (): boolean =>
+  typeof navigator !== 'undefined' && 'serial' in navigator

--- a/src/routes/SignalsRoute.tsx
+++ b/src/routes/SignalsRoute.tsx
@@ -159,7 +159,7 @@ const SignalsRoute = () => {
                 })
               }}
             >
-              Import XML
+              Import<span className="hidden min-[1180px]:inline"> XML</span>
             </SignalsFileAction>
             <SignalsAction
               onClick={() => {
@@ -170,7 +170,7 @@ const SignalsRoute = () => {
                 )
               }}
             >
-              Download XML
+              Download<span className="hidden min-[1180px]:inline"> XML</span>
             </SignalsAction>
           </>
         }

--- a/src/routes/WelcomeRoute.tsx
+++ b/src/routes/WelcomeRoute.tsx
@@ -13,6 +13,7 @@ import { useFirmwareUpdate } from '../hooks/useFirmwareUpdate'
 import { buildNewProjectDashboard, BLANK_PAGE_SET, DEFAULT_PAGE_SET } from '../lib/new-project'
 import { PROJECT_FILE_ACCEPT } from '../lib/project-file'
 import { humanizeTransportError } from '../transport/humanize-transport-error'
+import { isWebSerialAvailable } from '../lib/web-serial'
 
 type ConnectionStatus = ReturnType<typeof useConnectionStore.getState>['status']
 
@@ -31,9 +32,6 @@ const CONNECT_LABEL: Record<ConnectionStatus, string> = {
 }
 
 const SIMULATION_KICKER = 'SIMULATION · NO BOARD'
-
-const isWebSerialAvailable = (): boolean =>
-  typeof navigator !== 'undefined' && 'serial' in navigator
 
 const WelcomeRoute = () => {
   const status = useConnectionStore((s) => s.status)


### PR DESCRIPTION
Closes #235.

## The gate

Six widths × six views × both themes, walked automatically: every element measured for `scrollWidth > clientWidth`, excluding what is legitimately allowed to overflow — scroll containers, form controls whose *value* is longer than the box, and anything already truncating with an ellipsis.

The first pass found four real defects. All four are fixed here and the same walk now reports **zero findings and zero console errors** across all 72 combinations.

### 1 · The header did not fit at 924 px

The shell has `min-w-[900px]`, but the header itself needed 944 px at 924, so every view scrolled the page sideways by 20 px. The breakpoint table already hides the `TUNER` tag at 1000 and the connection chip at 1060 — what was left was chrome padding. Under 1100 px the brand block, the nav margin, the nav tabs and `DISCONNECT` tighten; nothing hides, because a hidden button is not an acceptable answer and the acceptance says so.

Checked in its longest state: with `BURN` reading `OUT OF BOUNDS` at 924 px the header still does not overflow — the config-name field absorbs it, shrinking from 134 px to 95 px against its 56 px floor.

### 2 · The recent-config row overflowed at every width, including 1600

`div.group.flex.max-w-[440px]` was 521 px wide because its flex child could not shrink below its content: the classic missing `min-w-0`. The config name truncates but the meta beside it was `whitespace-nowrap`, so the row pushed past its own box and past the 720 px pane. The child now has `min-w-0` and the meta truncates.

### 3 · The SIGNALS toolbar did not fit under ~1080 px

Eight controls, a 220 px select, a 160 px filter and `gap-4` came to 1061 px. Under 1180 px the gap tightens, the profile select and the filter narrow, and `Import XML` / `Download XML` drop the word `XML`. Every control stays visible and clickable.

### 4 · The CAN and OBD-II tables clipped at 924 px

Both grids were built from fixed minimums plus `gap-10`, so the CAN table needed 1066 px including padding. Under 1180 px the gaps halve and the two flexible columns take smaller minimums. No panel scrolls inside itself at any checkpoint.

## Under 900 px

The spec sets a floor and stops. WebSerial is desktop-only — no iOS browser and no Android Chrome will ever open a port — so a phone that reaches `canshift.app` has a capability problem, not a layout problem, and rendering a 900 px app inside a 390 px viewport would be answering the wrong question.

Below the floor, and in any browser without WebSerial at any width, the app is replaced by a screen that says which one it is and what to do about it, with the two things that genuinely work small: the firmware changelog and the contact form. The theme toggle is there too — it never hides. Verified at 390 × 844 in both themes: no horizontal overflow on any of the three panes, and the contact form submits from there.

`isWebSerialAvailable` existed twice already, in `useFlasher` and `WelcomeRoute`; adding a third copy would have been the third copy, so it moved to `src/lib/web-serial.ts`.

## Test plan

- `typecheck` · `lint` · `test` (462) · `build` — green.
- `capability.test.ts`: the gate lets a wide WebSerial window through, stops a narrow one, and reports the missing capability ahead of the width at any width.
- The 1600 / 1280 / 1180 / 1024 / 980 / 924 walk, both themes, on HOME · Flash · DASH · SIGNALS · LIVE · DEVICE, with a config open and a long config name in the header: **0 overflowing elements, 0 page-level horizontal scroll, 0 console errors.** Screenshots were captured at every checkpoint locally; they are not attached because the CLI cannot upload images to a PR body — the measured result above is what the gate actually asserts, and it is reproducible.
- 390 × 844 phone check on all three panes of the capability screen, both themes.