### PR TITLE
docs(tuner): answer to the firmware's revision of the dash design system, and read its dim token

### DIFF
--- a/docs/design/DASH_DESIGN_SYSTEM.md
+++ b/docs/design/DASH_DESIGN_SYSTEM.md
@@ -151,13 +151,31 @@ Four states, and every control reads the same four ways so the driver never lear
   active control never pulses. A control that is intervening says so in its kicker
   (`TRACTION · CUTTING`), it does not move.
 - **Unavailable**: border `CS_LOCK_LINE`, text `CS_LOCK_INK`, and **the kicker states why** — never a bare
-  grey-out: `ANTI-LAG · EGT HIGH`, `LAUNCH · MOVING`, `TRACTION · NO WHEEL SPEED`,
-  `PIT LIMIT · GEAR 4`, `CRUISE · BRAKE CUT`. State word `LOCKED`, `N/A` or `CANCELLED`.
+  grey-out: `ANTI-LAG` / `EGT HIGH`, `LAUNCH` / `MOVING`, `TRACTION` / `NO WHEEL SPEED`,
+  `PIT LIMIT` / `GEAR 4`, `CRUISE` / `BRAKE CUT`. State word `LOCKED`, `N/A` or `CANCELLED`.
+
+**A button kicker stacks: name on the first line, qualifier on the second** — never joined with `·`.
+The separator is for the splash and the status row, which have a full screen width to spend; a button does
+not. A 4-column button is 79 px of usable width and the kicker face measures ~8 px per character, so 9
+characters is the whole budget — `PIT LIMIT` alone spends it. Any joined form therefore wraps mid-phrase
+(`ANTI-LAG · EGT` / `HIGH`), which is why the qualifier owns its own line and the button is sized for two.
+
+**Armed is declared per control, not carried by all four.** It exists only where the car really holds that
+state — launch armed at a target rpm, cruise set but not holding, traction set to a level but not cutting.
+Anti-lag and pit limit are **binary**: they go straight from off to active, because there is no physical
+in-between for them and a pulse there would only be reporting bus latency, which is not the driver's
+problem. A control with no armed state that is tapped and never confirmed on the bus returns to off after
+15 s — silently, with no error word, because the dash cannot tell a lost frame from a slow ECU.
+
+| Control                      | Armed                         |
+| ---------------------------- | ----------------------------- |
+| Launch, cruise, traction     | yes — a real state of the car |
+| Anti-lag, pit limit, ECU map | no — binary, off ⇄ active     |
 
 **Two kinds of button**, legible from the state word alone:
 
 - **Toggle** — anti-lag, launch, pit limit, cruise. One tap engages, the next disengages; the state word
-  is a word (`ON`/`OFF`, `ARMED`, `READY`).
+  is a word (`ON`/`OFF`, `ARMED`).
 - **Stepper** — traction control and the ECU map. **Each tap raises the level by one** (1, 2, 3 … 6), and
   the tap past the top wraps back to `OFF`, so the whole range is reachable with one finger and no second
   button. A 600 ms long press returns to level 1. The segment row under the state word is the only
@@ -170,6 +188,16 @@ Extra rules:
   320 px; the word plus the state carries it, and the word is what the driver would say out loud.
 - A level control (traction 1–6) shows a row of segment cells under the state word: 2 px device high,
   lit in Ink (white at 30 % over an engaged fill), unlit in `CS_TRACK`.
+
+**A value class sets a floor on its box.** A widget renders a top rule, a kicker line and the value line,
+so the box must hold all three or the value spills past the bottom edge and collides with the row below.
+Measured minimums, device pixels: **hero 48 → 93**, **heroTrack 44 → 71**, **primary 32 → 60**,
+**mid 22 → 40**, **secondary 17 → 40**. Check the floor before changing a `rowSpan` or a `big`.
+
+Track is the one page that cannot hold three tiers at spec sizes: the shift strip (13 px) and the alert
+line band (16 px) leave it 195 px, and `row + rowSpan <= 12` costs it another track because the strip
+takes raw row 0. Its SPEED and OIL PRESS therefore render at **mid**, not primary — a deliberate
+deviation, and the one to revisit first if the alert band ever stops being reserved on every page.
 
 ## 7. Shift light
 
@@ -184,7 +212,7 @@ Only on a page that declares it (Track). One row across the full content width:
 A protection cut (boost, fuel, ignition, knock retard, rev limit, overheat, limp) shows a persistent
 full-width band directly under the shift light for as long as the cut lasts: a 2 px rule in the severity
 colour, the cut name in Archivo 800 (0.16em, uppercase), the measured value against its limit in mono, and
-the elapsed time right-aligned. 13 px device tall.
+the elapsed time right-aligned. One line, flush left, 26 px device tall.
 
 Amber CS_WARN when the cut holds a target (overboost, rev limit, traction, pit limit), detail dim; danger
 CS_DANGER when it protects the engine (oil pressure, overheat, limp), detail in Ink. The causing value
@@ -248,7 +276,8 @@ fit 320 × 240 is **rejected at config load**, and the Tuner flags it before wri
 - [ ] Status row has exactly three fields, bus rate on the left.
 - [ ] Shift light: 7 ink + 2 danger + 3 track, 12 cells.
 - [ ] Warning readings amber `#FF8800`; danger `#FF4444`; engaged buttons filled `#FF4747`; never swapped.
-- [ ] All four button states present, and every unavailable control states its reason in the kicker.
+- [ ] Every unavailable control states its reason in the kicker, and armed appears only on the controls
+      that declare it (§6).
 - [ ] Only armed pulses. No active control, no warning and no cut band moves.
 - [ ] Cut band: right severity colour, name from the profile, 1.5 s minimum, stacks to three.
 - [ ] No animation outside §9; page change is a cut.

--- a/src/components/editor/CruiseControlPreview.tsx
+++ b/src/components/editor/CruiseControlPreview.tsx
@@ -13,7 +13,7 @@ const STROKE_W = 2
 const CENTER = 'absolute box-border flex flex-col items-center justify-center'
 
 const CENTER_LABEL = [
-  'text-center font-sans font-extrabold leading-none tracking-[0.18em] text-[#888888]',
+  'text-center font-sans font-extrabold leading-none tracking-[0.18em] text-[#BABAB8]',
 ].join(' ')
 
 const CENTER_VALUE = [

--- a/src/components/editor/widget-preview.styles.ts
+++ b/src/components/editor/widget-preview.styles.ts
@@ -1,15 +1,15 @@
 import { cva } from 'class-variance-authority'
-import { WIDGET_TOP_RULE } from '@canshift/core'
+import { WIDGET_DIM_COLORS, WIDGET_TOP_RULE } from '@canshift/core'
 
 export const BLINK = '[animation:canshift-blink_0.7s_step-end_infinite]'
 
-export const WIDGET_DIM_COLOR = '#888888'
+export const WIDGET_DIM_COLOR: string = WIDGET_DIM_COLORS.night
 
 export const WIDGET_KICKER = [
   'absolute left-1 top-1 max-w-[calc(100%-8px)]',
   'overflow-hidden text-ellipsis whitespace-nowrap',
   'font-sans text-[10px] font-extrabold uppercase leading-none tracking-[0.18em]',
-  'text-[#888888]',
+  'text-[#BABAB8]',
 ].join(' ')
 
 export const widgetTopRule = cva('absolute left-0 right-0 top-0', {

--- a/src/components/editor/widget-previews/Button.tsx
+++ b/src/components/editor/widget-previews/Button.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react'
-import { WIDGET_ACCENT_COLOR, WIDGET_MUTED_COLOR } from '@canshift/core'
+import { WIDGET_ACCENT_COLOR, WIDGET_DIM_COLORS } from '@canshift/core'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
 
 const FRAME = [
@@ -98,7 +98,7 @@ export const ButtonPreview = memo(function ButtonPreview({
   const bgColor = active ? engagedColor : 'transparent'
   const borderColor = active ? engagedColor : idleBorder
   const textColor = active ? '#FFFFFF' : st.textColor
-  const kickerColor = active ? KICKER_ENGAGED_COLOR : WIDGET_MUTED_COLOR
+  const kickerColor = active ? KICKER_ENGAGED_COLOR : WIDGET_DIM_COLORS.night
 
   return (
     <div

--- a/src/components/editor/widget-previews/GaugeArc.tsx
+++ b/src/components/editor/widget-previews/GaugeArc.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react'
 import { GAUGE_ARC, GAUGE_TRACK_COLORS, STALE_PLACEHOLDER, deviceValueFontPx } from '@canshift/core'
 import { cn } from '@/lib/utils'
-import { thresholdPct } from '../widget-preview.styles'
+import { WIDGET_DIM_COLOR, thresholdPct } from '../widget-preview.styles'
 import { effectiveValue, gaugeArcD } from './gauge-math'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
 import { MONO_FONT, UI_FONT, UI_LABEL_TRACKING, UI_LABEL_WEIGHT } from '../../../lib/typography'
@@ -101,7 +101,7 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
         y={SIGNAL_LABEL_FONT_SIZE + 4}
         textAnchor="start"
         dominantBaseline="auto"
-        fill="#888888"
+        fill={WIDGET_DIM_COLOR}
         fontSize={SIGNAL_LABEL_FONT_SIZE}
         fontFamily={UI_FONT}
         fontWeight={UI_LABEL_WEIGHT}

--- a/src/components/editor/widget-previews/Timer.tsx
+++ b/src/components/editor/widget-previews/Timer.tsx
@@ -17,7 +17,7 @@ const value = cva('font-mono tracking-[0.06em] tabular-nums', {
 
 const KICKER = [
   'absolute left-[3px] top-0.5 font-sans text-[9px] font-medium uppercase',
-  'leading-none tracking-[0.05em] text-[#888888]',
+  'leading-none tracking-[0.05em] text-[#BABAB8]',
 ].join(' ')
 
 export const TimerPreview = memo(function TimerPreview({ widget, w, h }: BaseRendererProps) {


### PR DESCRIPTION
Closes #236. Closes #158.

## Which way the sync runs

#236 assumed the tuner's copy was behind the brand plank. It is behind, but not in the direction the issue expected: the **firmware's** copy is now the furthest ahead, because it learned things from actually rendering the thing. `CLAUDE.md` makes firmware canonical for visuals, so the doc is copied from `canshift-firmware` and reformatted, not merged by hand.

What the tuner's copy was missing:

- **A button kicker stacks** — name on the first line, qualifier on the second, never joined with `·`. A 4-column button is 79 px wide and the kicker face measures ~8 px per character, so `PIT LIMIT` alone spends the budget; any joined form wraps mid-phrase.
- **Armed is declared per control**, not carried by all four. Launch, cruise and traction have a real armed state; anti-lag, pit limit and the ECU map are binary, because a pulse there would only be reporting bus latency. A control with no armed state that is never confirmed on the bus returns to off after 15 s, silently.
- **A value class sets a floor on its box** — hero 48 → 93 px, heroTrack 44 → 71, primary 32 → 60, mid 22 → 40, secondary 17 → 40 — with the measured reason why Track renders SPEED and OIL PRESS at `mid` rather than `primary`.
- The cut band is **26 px device tall, one line, flush left**, not 13 px.
- The pre-flight checklist line on button states, rewritten around armed.

## The token pass

Everything in the nine-token table was checked against all three repos.

**Firmware is complete.** `theme_tokens.h` carries all nine with day and night values, including `kLockLineDay/Night` and `kLockInkDay/Night`, and `src/ui/cut_band.*` implements §7b. Nothing to file there.

**The tuner was reading none of them.** It hardcoded `#888888` for Dim in five canvas places — a much darker grey than the `#BABAB8` the doc and the firmware both specify — which is #158. Core already publishes `WIDGET_DIM_COLORS` with both values, so this is now a read rather than a literal:

- `widget-preview.styles.ts` — `WIDGET_DIM_COLOR` reads `WIDGET_DIM_COLORS.night`, and `WIDGET_KICKER` moves to `#BABAB8`
- `GaugeArc` — the SVG signal label
- `Timer` — the `TIMER` kicker
- `CruiseControlPreview` — the centre label
- `Button` — the kicker was reading `WIDGET_MUTED_COLOR` (`#BABABA`), one hex digit off; it now reads the Dim token

`DiagnosticsPanel` and `screen-settings-controls` keep their `#888888`: they are chrome, not canvas, and #158 puts them out of scope.

**Core has gaps**, filed rather than patched here — adding exports nothing reads would break the rule that a constant must be read by the code it names. Filed as canshift-core#129: `CS_LOCK_LINE` and `CS_LOCK_INK` are absent, `CS_BG` and `CS_TRACK` have no day value, `WIDGET_MUTED_COLOR` is the tenth token the doc says does not exist, and `DEFAULT_PAGE_PALETTE` disagrees with the table on two entries — which is where the tuner's `#888888` came from in the first place.

**The tuner's button preview** renders two of the four states — filed as #269.

## Test plan

- `typecheck` · `lint` · `test` (462) · `build` — green.
- Verified on the canvas in Helium at 1440×900 with the six default pages: every kicker and SVG label now computes to `rgb(186, 186, 184)` / `#BABAB8`, and no element on the canvas is left at `#888888`. No console errors.
