### PR TITLE
fix(tuner): the header wears the tuner mark, not the CANShift monogram

### DIFF
--- a/src/components/brand/BrandLockup.tsx
+++ b/src/components/brand/BrandLockup.tsx
@@ -14,18 +14,44 @@ import {
   WORDMARK_CAN_PATH,
   WORDMARK_SHIFT_PATH,
 } from '@canshift/core'
+import type { ReactElement } from 'react'
+import { TUNER_MARK_BAR_PATH, TUNER_MARK_SCREEN_PATH, TUNER_MARK_STROKE } from './tuner-mark'
+
+export type BrandMark = 'monogram' | 'tuner'
 
 export interface BrandLockupProps {
   height: number
+  mark?: BrandMark
   withBaseline?: boolean
   label?: string
 }
 
+const MonogramMark = () => (
+  <>
+    <path d={MONOGRAM_C_PATH} stroke="currentColor" strokeWidth={MONOGRAM_STROKE_WIDTH} />
+    <path d={MONOGRAM_S_PATH} stroke={BRAND_ACCENT} strokeWidth={MONOGRAM_STROKE_WIDTH} />
+  </>
+)
+
+const TunerMark = () => (
+  <>
+    <path d={TUNER_MARK_SCREEN_PATH} stroke="currentColor" strokeWidth={TUNER_MARK_STROKE} />
+    <path d={TUNER_MARK_BAR_PATH} stroke={BRAND_ACCENT} strokeWidth={TUNER_MARK_STROKE} />
+  </>
+)
+
+const MARKS: Record<BrandMark, () => ReactElement> = {
+  monogram: MonogramMark,
+  tuner: TunerMark,
+}
+
 export const BrandLockup = ({
   height,
+  mark = 'monogram',
   withBaseline = false,
   label = 'CANShift',
 }: BrandLockupProps) => {
+  const Mark = MARKS[mark]
   const viewBox = withBaseline ? LOCKUP_BASELINE_VIEWBOX : LOCKUP_VIEWBOX
   const viewBoxHeight = withBaseline ? 190 : 150
   return (
@@ -37,8 +63,7 @@ export const BrandLockup = ({
       aria-label={label}
     >
       <g transform={LOCKUP_MONOGRAM_TRANSFORM} fill="none" strokeLinecap="butt">
-        <path d={MONOGRAM_C_PATH} stroke="currentColor" strokeWidth={MONOGRAM_STROKE_WIDTH} />
-        <path d={MONOGRAM_S_PATH} stroke={BRAND_ACCENT} strokeWidth={MONOGRAM_STROKE_WIDTH} />
+        <Mark />
       </g>
       <rect
         x={LOCKUP_DIVIDER.x}

--- a/src/components/brand/tuner-mark.ts
+++ b/src/components/brand/tuner-mark.ts
@@ -1,0 +1,3 @@
+export const TUNER_MARK_SCREEN_PATH = 'M18 18 H98 V84 H18 Z'
+export const TUNER_MARK_BAR_PATH = 'M34 38 H74'
+export const TUNER_MARK_STROKE = 15

--- a/src/components/shell/HeaderView.tsx
+++ b/src/components/shell/HeaderView.tsx
@@ -68,7 +68,7 @@ export const HeaderView = ({
   return (
     <header className="flex h-[52px] shrink-0 items-stretch bg-ui-header-bg text-ui-header-ink">
       <div className="flex items-center gap-2.5 px-3 min-[1100px]:px-5">
-        <BrandLockup height={19} />
+        <BrandLockup height={19} mark="tuner" />
         <span className="hidden font-mono text-[11px] tracking-[0.16em] text-ui-faint min-[1000px]:inline">
           TUNER
         </span>


### PR DESCRIPTION
The nav showed the `CS` monogram from `canshift-brand/logo/brand/` — the org mark, the one behind the site favicons. This repo already identifies itself with the **tuner** mark: `public/favicon.svg` is the screen-with-a-bar icon from `canshift-brand/logo/icons/tuner/`, so the browser tab and the nav were showing two different marks for the same app.

The header now carries the tuner mark. `PROMPT_TUNER_APP.md` §Header asks for "mark + `CANSHIFT` + `TUNER` tag" without naming which mark; the per-repo icon is the one that makes the tab and the nav agree.

## What changed

`BrandLockup` takes a `mark` prop — `'monogram'` (default, so nothing else in the repo moves) or `'tuner'` — resolved through a lookup table rather than a branch. The divider, the wordmark and the baseline are untouched, and the tuner mark sits in the same slot under the same `LOCKUP_MONOGRAM_TRANSFORM`, so the lockup's proportions are unchanged.

The geometry is the **small** variant of the tuner icon (`tuner-small.svg`: one accent bar, 15 stroke), not the favicon's three-row variant. At the header's 19 px the three rows close up into a solid block; one bar stays legible.

## Test plan

- `typecheck` · `lint` · `test` (464) · `build` — green.
- Rendered at 4× in Helium, both themes, at 19 px: the mark reads as a screen with an accent bar, keeps the brand skew, and the wordmark is pixel-identical to before.

Flipping back is one word: `mark="tuner"` in `HeaderView`.