### PR TITLE
fix(tuner): the canvas follows the day/night switch without a device

### DIFF
--- a/src/components/editor/Canvas.tsx
+++ b/src/components/editor/Canvas.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react'
 import type { PageConfig, TopBarConfig } from '@canshift/core'
 import { resolveGridRect, resolveScreenProfile } from '@canshift/core'
 import { useDashboardStore } from '../../stores/dashboard.store'
-import { useDeviceStore } from '../../stores/device.store'
 import { overflowingWidgetIds, overlappingWidgetIds } from '../../utils/widget-diagnostics'
 import { useRebindFlashStore } from '../../stores/rebind-flash.store'
 import ScreenSettingsPanel from './ScreenSettingsPanel'
@@ -27,6 +26,7 @@ import { useSwipeGestures } from '../../hooks/useSwipeGestures'
 import { useCarouselScale } from '../../hooks/useCarouselScale'
 import { useCanvasDialogs } from '../../hooks/useCanvasDialogs'
 import { resolveBgColor, resolvePalette } from '../../hooks/useEffectivePalette'
+import { useActiveDayMode } from '../../hooks/useActiveDayMode'
 import { PreviewOverlay } from './preview/PreviewOverlay'
 import type { PreviewMode } from './preview/preview-modes'
 
@@ -55,7 +55,7 @@ const Canvas = ({
   const screenProfile = useMemo(() => resolveScreenProfile(targetProfileId), [targetProfileId])
   const pages = useDashboardStore((s) => s.config?.pages ?? EMPTY_PAGES)
   const theme = useDashboardStore((s) => s.config?.theme)
-  const isDayMode = useDeviceStore((s) => s.isDayMode) ?? false
+  const isDayMode = useActiveDayMode()
 
   const selectedWidgetId = useDashboardStore((s) => s.selectedWidgetId)
   const selectedWidgetIds = useDashboardStore((s) => s.selectedWidgetIds)

--- a/src/components/editor/ScreenSettingsPanel.tsx
+++ b/src/components/editor/ScreenSettingsPanel.tsx
@@ -6,6 +6,7 @@ import { useScreenSettingsStore } from '../../stores/screen-settings.store'
 import { useLogStore } from '../../stores/log.store'
 import { useDeviceState } from '../../hooks/useDeviceState'
 import { usePreviewTheme } from '../../hooks/useDashboardConfig'
+import { useActiveDayMode } from '../../hooks/useActiveDayMode'
 import { usbService } from '../../transport'
 import { transportErrorText } from '../../transport/humanize-transport-error'
 import {
@@ -89,7 +90,7 @@ const ScreenSettingsPanel = ({ scale }: ScreenSettingsPanelProps) => {
 
   const canDeviceAction = connected && !simulationMode
 
-  const activeDayMode = isDayMode ?? isPreviewDayMode
+  const activeDayMode = useActiveDayMode()
 
   const handleSelectMode = async (target: 'night' | 'day') => {
     const day = target === 'day'

--- a/src/hooks/useActiveDayMode.test.ts
+++ b/src/hooks/useActiveDayMode.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { activeDayMode } from './useActiveDayMode'
+
+describe('activeDayMode', () => {
+  it('follows the device once it has reported a mode', () => {
+    expect(activeDayMode(true, false)).toBe(true)
+    expect(activeDayMode(false, true)).toBe(false)
+  })
+
+  it('falls back to the preview switch while no device has reported one', () => {
+    expect(activeDayMode(null, true)).toBe(true)
+    expect(activeDayMode(null, false)).toBe(false)
+  })
+})

--- a/src/hooks/useActiveDayMode.ts
+++ b/src/hooks/useActiveDayMode.ts
@@ -1,0 +1,11 @@
+import { useDashboardStore } from '../stores/dashboard.store'
+import { useDeviceStore } from '../stores/device.store'
+
+export const activeDayMode = (deviceDayMode: boolean | null, previewDayMode: boolean): boolean =>
+  deviceDayMode ?? previewDayMode
+
+export const useActiveDayMode = (): boolean => {
+  const deviceDayMode = useDeviceStore((s) => s.isDayMode)
+  const previewDayMode = useDashboardStore((s) => s.isPreviewDayMode)
+  return activeDayMode(deviceDayMode, previewDayMode)
+}

--- a/src/hooks/useEffectivePalette.ts
+++ b/src/hooks/useEffectivePalette.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import type { PageConfig, PagePalette } from '@canshift/core'
 import { DEFAULT_PAGE_PALETTE } from '@canshift/core'
 import { useDashboardStore } from '../stores/dashboard.store'
-import { useDeviceStore } from '../stores/device.store'
+import { useActiveDayMode } from './useActiveDayMode'
 import { DAY_PALETTE_DEFAULT, DAY_BG_DEFAULT } from '../constants/theme'
 
 export interface EffectivePalette {
@@ -30,7 +30,7 @@ export const resolveBgColor = (
 
 export const useEffectivePalette = (page: PageConfig): EffectivePalette => {
   const theme = useDashboardStore((s) => s.config?.theme)
-  const isDayMode = useDeviceStore((s) => s.isDayMode) ?? false
+  const isDayMode = useActiveDayMode()
 
   const palette = useMemo(
     () => resolvePalette(isDayMode, theme?.day.palette, theme?.night.palette, page.palette),


### PR DESCRIPTION
Closes #174.

## What #174 reported, and what is actually broken

#174 says the canvas preview leaves its background transparent. That is no longer reproducible — since the canvas rewrite the page frame paints `#121212`, the design system's night ground, and `PageConfig.backgroundColor` is a required hex so the fallback chain can never reach `undefined`.

What *is* broken is the other half of the same sentence — "the preview should fill with the ground of the theme currently selected". It does not, unless a device is connected.

`Canvas` read `useDeviceStore(s => s.isDayMode) ?? false`. Without a device that value is `null`, so the canvas always rendered night. The Screen Settings panel on the canvas has its own switch for exactly this case — it writes `isPreviewDayMode` on the dashboard store — and **nothing that renders read it**. Picking `Day` in simulation flipped a flag and changed nothing on screen.

## The fix

One rule, in one place: `activeDayMode(deviceDayMode, previewDayMode)` — the device wins once it has reported a mode, the preview switch answers while it has not. `Canvas`, `useEffectivePalette` and `ScreenSettingsPanel` all read it through `useActiveDayMode`, so the panel's own `activeDayMode ?? isPreviewDayMode` expression stops being a fourth copy of the rule.

## Noticed while verifying, not fixed here

- The ground the day theme paints is `#E8E8E8`, from the theme preset, where `DASH_DESIGN_SYSTEM.md` §2 says `CS_BG` day is `#DDDDDD`. The preset values were a deliberate decision, so this is flagged rather than overridden.
- Widget boxes keep their stored colours when the ground goes light, so a day page reads as black boxes on a light ground. That is a widget-palette question, not a background one — filed as #272.

## Test plan

- `typecheck` · `lint` · `test` (464) · `build` — green.
- `useActiveDayMode.test.ts`: the device wins when it has reported either mode; the preview switch answers while it has not.
- Verified in Helium at 1440×900, in simulation, driving the real control: swipe the dash top bar to open Screen Settings, pick `Day` — the page ground goes from `rgb(18, 18, 18)` to `rgb(232, 232, 232)` and back with `Night`. Before this change it stayed `rgb(18, 18, 18)`. No console errors.
