### PR TITLE
feat(tuner): the timer widget has a source, and a button can drive it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^8.0.0",
+        "@canshift/core": "^8.1.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-8.0.0.tgz",
-      "integrity": "sha512-Bl+a4TCCdaxBlON1DHC8ZQEpLdsb6dr8VhPvUzgWqLcCWSYUI+2AriFFacPeloLOswQLrquI0FCYVoZ1aTcdJw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-8.1.0.tgz",
+      "integrity": "sha512-QW3l3IfCEEKwpKlaGxxvc1XH3ZS564K2VcRQ3DlOYU1Dja340sDWIoI4N+cOW2F1LFdv67UqyPqPW2KDsCpK3Q==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^8.0.0",
+    "@canshift/core": "^8.1.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/components/editor/property-panel/button/action-editor.tsx
+++ b/src/components/editor/property-panel/button/action-editor.tsx
@@ -1,11 +1,13 @@
 import {
   CRUISE_CONTROL_OPS,
+  TIMER_CONTROL_OPS,
   type ButtonAction,
   type CanRawAction,
   type CruiseControlAction,
   type CruiseControlOp,
   type MapSwitchAction,
   type NavigateAction,
+  type TimerControlAction,
 } from '@canshift/core'
 
 import { CompactSelect, FieldLabel, PanelInput } from '@/components/ui/form-field'
@@ -120,6 +122,16 @@ const CruiseControlFields = ({ action, onUpdate }: FieldEditorProps<CruiseContro
   </div>
 )
 
+const TimerControlFields = ({ action, onUpdate }: FieldEditorProps<TimerControlAction>) => (
+  <CompactSelect
+    value={action.op}
+    options={TIMER_CONTROL_OPS.map((op) => ({ value: op, label: op.toUpperCase() }))}
+    onChange={(op) => {
+      onUpdate({ ...action, op: op as TimerControlAction['op'] })
+    }}
+  />
+)
+
 const FIELD_EDITORS: Record<
   ButtonAction['type'],
   (props: FieldEditorProps<ButtonAction>) => React.JSX.Element | null
@@ -135,6 +147,10 @@ const FIELD_EDITORS: Record<
   can_raw: ({ action, pageIds, onUpdate }) =>
     action.type !== 'can_raw' ? null : (
       <CanRawFields action={action} pageIds={pageIds} onUpdate={onUpdate} />
+    ),
+  timer_control: ({ action, onUpdate }) =>
+    action.type !== 'timer_control' ? null : (
+      <TimerControlFields action={action} pageIds={[]} onUpdate={onUpdate} />
     ),
   cruise_control: ({ action, pageIds, onUpdate }) =>
     action.type !== 'cruise_control' ? null : (

--- a/src/components/editor/property-panel/button/shared.ts
+++ b/src/components/editor/property-panel/button/shared.ts
@@ -51,6 +51,11 @@ export const buildActionPresets = (pageIds: string[]): ActionPreset[] => [
     color: '#CC8800',
     build: () => ({ category: 'ecu', type: 'cruise_control', op: 'toggle' }),
   },
+  {
+    label: 'Timer',
+    color: '#5577CC',
+    build: () => ({ category: 'device', type: 'timer_control', op: 'toggle' }),
+  },
 ]
 
 type SharedConfigFields = Pick<ButtonWidgetConfig, 'label' | 'showLabel' | 'colors'>

--- a/src/components/editor/property-panel/panels/widget-editor-panel.tsx
+++ b/src/components/editor/property-panel/panels/widget-editor-panel.tsx
@@ -8,6 +8,7 @@ import { IconTrash } from '../../../icons/Icon'
 import { ButtonFields } from '../button-fields'
 import { GaugeFields } from '../gauge-fields'
 import { ShiftLightFields } from '../shift-light-fields'
+import { TimerFields } from '../timer-fields'
 import { ConfigFieldsProps } from '../shared'
 import { CompactSelect, PanelField, SectionLabel } from '@/components/ui/form-field'
 import { ButtonColorsRow } from './button-colors-row'
@@ -26,6 +27,7 @@ const CONFIG_FIELDS: Partial<
   gauge: GaugeFields,
   button: ButtonFields,
   shift_light: ShiftLightFields,
+  timer: TimerFields,
 }
 
 const SIGNAL_HIDDEN_TYPES = new Set<WidgetType>(['button', 'timer', 'image'])

--- a/src/components/editor/property-panel/timer-fields.tsx
+++ b/src/components/editor/property-panel/timer-fields.tsx
@@ -1,0 +1,55 @@
+import { TIMER_SOURCES } from '@canshift/core'
+import type { TimerSource } from '@canshift/core'
+import { ConfigFieldsProps } from './shared'
+import { CompactSelect, PanelField, PanelRow } from '@/components/ui/form-field'
+import {
+  DEFAULT_TIMER_SOURCE,
+  TIMER_SOURCE_LABELS,
+  isTouchInteractive,
+} from '../../../lib/timer-source'
+
+const FORMATS = [
+  { value: 'mm:ss', label: 'MM:SS' },
+  { value: 'ss.mmm', label: 'SS.mmm' },
+]
+
+const READOUT_NOTE = 'A readout — only the elapsed timer answers a touch on the device.'
+
+export const TimerFields = ({ widget, onChange }: ConfigFieldsProps) => {
+  if (widget.config.type !== 'timer') return null
+  const cfg = widget.config
+  const source = cfg.source ?? DEFAULT_TIMER_SOURCE
+
+  return (
+    <>
+      <PanelRow>
+        <PanelField label="Source">
+          <CompactSelect
+            value={source}
+            options={TIMER_SOURCES.map((value) => ({
+              value,
+              label: TIMER_SOURCE_LABELS[value],
+            }))}
+            onChange={(next) => {
+              onChange({ config: { ...cfg, source: next as TimerSource } })
+            }}
+          />
+        </PanelField>
+        {source === 'elapsed' && (
+          <PanelField label="Format">
+            <CompactSelect
+              value={cfg.format ?? 'mm:ss'}
+              options={FORMATS}
+              onChange={(format) => {
+                onChange({ config: { ...cfg, format: format as 'mm:ss' | 'ss.mmm' } })
+              }}
+            />
+          </PanelField>
+        )}
+      </PanelRow>
+      {!isTouchInteractive(source) && (
+        <p className="mt-1.5 text-[11px] leading-[1.5] text-ui-faint">{READOUT_NOTE}</p>
+      )}
+    </>
+  )
+}

--- a/src/components/editor/widget-previews/Timer.tsx
+++ b/src/components/editor/widget-previews/Timer.tsx
@@ -2,9 +2,7 @@ import { memo } from 'react'
 import { cva } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 import type { BaseRendererProps } from './shared'
-
-const DEMO_MMSS = '01:23'
-const DEMO_SS_MMM = '12.847'
+import { timerDemoValue, timerKicker } from '../../../lib/timer-source'
 
 const FRAME = 'relative flex items-center justify-center overflow-hidden'
 
@@ -24,7 +22,7 @@ export const TimerPreview = memo(function TimerPreview({ widget, w, h }: BaseRen
   if (widget.config.type !== 'timer') return null
   const cfg = widget.config
   const st = widget.style
-  const timeStr = cfg.format === 'ss.mmm' ? DEMO_SS_MMM : DEMO_MMSS
+  const timeStr = timerDemoValue(cfg.source, cfg.format)
   const fontSize = Math.max(9, Math.min(h * 0.44, w * 0.22))
 
   return (
@@ -37,7 +35,7 @@ export const TimerPreview = memo(function TimerPreview({ widget, w, h }: BaseRen
       >
         {timeStr}
       </span>
-      <span className={KICKER}>TIMER</span>
+      <span className={KICKER}>{timerKicker(cfg.source)}</span>
     </div>
   )
 })

--- a/src/lib/timer-source.test.ts
+++ b/src/lib/timer-source.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { TIMER_SOURCES } from '@canshift/core'
+import {
+  isTouchInteractive,
+  timerDemoValue,
+  timerKicker,
+  timerPlaceholder,
+  TIMER_SOURCE_LABELS,
+} from './timer-source'
+
+describe('timerKicker', () => {
+  it('derives the kicker from the source, as the device does', () => {
+    expect(timerKicker('elapsed')).toBe('TIMER')
+    expect(timerKicker('lap')).toBe('LAP')
+    expect(timerKicker('best')).toBe('BEST')
+    expect(timerKicker('last')).toBe('LAST')
+    expect(timerKicker('lapCount')).toBe('LAPS')
+    expect(timerKicker('delta')).toBe('DELTA')
+  })
+
+  it('treats a config with no source as the elapsed timer', () => {
+    expect(timerKicker(undefined)).toBe('TIMER')
+  })
+})
+
+describe('timerPlaceholder', () => {
+  it('gives every source the placeholder the device shows when it has no value', () => {
+    expect(timerPlaceholder('elapsed')).toBe('00:00')
+    expect(timerPlaceholder('lap')).toBe('--:--')
+    expect(timerPlaceholder('lapCount')).toBe('0')
+    expect(timerPlaceholder('delta')).toBe('--')
+  })
+})
+
+describe('timerDemoValue', () => {
+  it('follows the format only for the elapsed timer', () => {
+    expect(timerDemoValue('elapsed', 'mm:ss')).toBe('01:23')
+    expect(timerDemoValue('elapsed', 'ss.mmm')).toBe('12.847')
+    expect(timerDemoValue('best', 'ss.mmm')).toBe('1:36.07')
+  })
+
+  it('signs the delta', () => {
+    expect(timerDemoValue('delta', undefined)).toMatch(/^[+-]/)
+  })
+})
+
+describe('isTouchInteractive', () => {
+  it('is true only for the elapsed timer', () => {
+    expect(isTouchInteractive('elapsed')).toBe(true)
+    expect(isTouchInteractive(undefined)).toBe(true)
+    for (const source of TIMER_SOURCES.filter((s) => s !== 'elapsed')) {
+      expect(isTouchInteractive(source)).toBe(false)
+    }
+  })
+})
+
+describe('the source tables', () => {
+  it('cover every source core declares', () => {
+    for (const source of TIMER_SOURCES) {
+      expect(TIMER_SOURCE_LABELS[source]).toBeTruthy()
+      expect(timerKicker(source)).toBeTruthy()
+      expect(timerPlaceholder(source)).toBeTruthy()
+    }
+  })
+})

--- a/src/lib/timer-source.ts
+++ b/src/lib/timer-source.ts
@@ -1,0 +1,59 @@
+import type { TimerSource } from '@canshift/core'
+
+export const DEFAULT_TIMER_SOURCE: TimerSource = 'elapsed'
+
+export const TIMER_SOURCE_LABELS: Record<TimerSource, string> = {
+  elapsed: 'Elapsed',
+  lap: 'Current lap',
+  best: 'Best lap',
+  last: 'Last lap',
+  lapCount: 'Lap count',
+  delta: 'Delta to best',
+}
+
+const KICKERS: Record<TimerSource, string> = {
+  elapsed: 'TIMER',
+  lap: 'LAP',
+  best: 'BEST',
+  last: 'LAST',
+  lapCount: 'LAPS',
+  delta: 'DELTA',
+}
+
+const PLACEHOLDERS: Record<TimerSource, string> = {
+  elapsed: '00:00',
+  lap: '--:--',
+  best: '--:--',
+  last: '--:--',
+  lapCount: '0',
+  delta: '--',
+}
+
+const DEMO_VALUES: Record<TimerSource, string> = {
+  elapsed: '01:23',
+  lap: '1:38.42',
+  best: '1:36.07',
+  last: '1:38.42',
+  lapCount: '4',
+  delta: '+0.31',
+}
+
+const DEMO_ELAPSED_SS_MMM = '12.847'
+
+export const timerKicker = (source: TimerSource | undefined): string =>
+  KICKERS[source ?? DEFAULT_TIMER_SOURCE]
+
+export const timerPlaceholder = (source: TimerSource | undefined): string =>
+  PLACEHOLDERS[source ?? DEFAULT_TIMER_SOURCE]
+
+export const timerDemoValue = (
+  source: TimerSource | undefined,
+  format: 'mm:ss' | 'ss.mmm' | undefined
+): string => {
+  const resolved = source ?? DEFAULT_TIMER_SOURCE
+  if (resolved === 'elapsed' && format === 'ss.mmm') return DEMO_ELAPSED_SS_MMM
+  return DEMO_VALUES[resolved]
+}
+
+export const isTouchInteractive = (source: TimerSource | undefined): boolean =>
+  (source ?? DEFAULT_TIMER_SOURCE) === 'elapsed'

--- a/src/stores/dashboard/lifecycle.slice.ts
+++ b/src/stores/dashboard/lifecycle.slice.ts
@@ -1,5 +1,5 @@
 import type { DashboardConfig } from '@canshift/core'
-import { defaultThemePreset } from '@canshift/core'
+import { DEFAULT_UNIT_SYSTEM, defaultThemePreset } from '@canshift/core'
 import { DEFAULT_SIM_CONFIG } from '../../config/default-sim-config'
 import { pushHistory } from './helpers'
 import type {
@@ -38,6 +38,16 @@ export const createLifecycleSlice: SliceCreator<LifecycleSlice> = (set) => ({
       if (s.config.targetProfile === id) return
       pushHistory(s, 'Changed target screen')
       s.config.targetProfile = id
+      s.isDirty = true
+    })
+  },
+
+  setUnits: (units) => {
+    set((s) => {
+      if (!s.config) return
+      if ((s.config.units ?? DEFAULT_UNIT_SYSTEM) === units) return
+      pushHistory(s, 'Changed units')
+      s.config.units = units
       s.isDirty = true
     })
   },

--- a/src/stores/dashboard/types.ts
+++ b/src/stores/dashboard/types.ts
@@ -7,6 +7,7 @@ import type {
   ScreenProfileId,
   ThemePreset,
   TopBarConfig,
+  UnitSystem,
   Widget,
   WidgetLayout,
 } from '@canshift/core'
@@ -22,6 +23,7 @@ export interface LifecycleSlice {
 
   setConfig: (config: DashboardConfig) => void
   setTargetProfile: (id: ScreenProfileId) => void
+  setUnits: (units: UnitSystem) => void
   loadFromDeviceOrDemo: (deviceConfig: DashboardConfig | null) => LoadFromDeviceOrDemoResult
   acceptPendingDeviceConfig: () => void
   dismissPendingDeviceConfig: () => void


### PR DESCRIPTION
Closes #249. Bumps `@canshift/core` to **8.1.0** (schema 1.39.0), which is what makes both halves available.

## `source` on the timer widget

The Timing page needs six readouts, not one stopwatch. The widget takes `source` — `elapsed` (default) · `lap` · `best` · `last` · `lapCount` · `delta` — and the editor offers it as a select.

**The kicker is derived, not typed.** The device names the widget from its source, so `src/lib/timer-source.ts` holds one table and the preview reads it: `TIMER` · `LAP` · `BEST` · `LAST` · `LAPS` · `DELTA`. The same table holds the placeholder each source shows when it has no value (`00:00`, `--:--`, `0`, `--`) and the demo value the canvas draws, so all three stay in step.

`format` only applies to `elapsed`, so the Format field is hidden for the others rather than offering a choice the device ignores. Only `elapsed` answers a touch, and the panel says so instead of leaving the user to find out.

## `timer_control`

The action joins the palette as `Timer`, with its op as a select — `start` · `pause` · `resume` · `toggle` · `reset` · `lap` — through the same `FIELD_EDITORS` lookup as every other action type. `ButtonActionSchema` is a discriminated union, so the missing case was a type error the moment core landed: this is the fix, not an addition on top of it.

## The core bump

8.0.0 → 8.1.0 also brings the metric/imperial conversion table added for #233. Nothing in this PR consumes it; the units surfaces are the next slice.

## Test plan

- `typecheck` · `lint` · `test` (471) · `build` — green.
- `timer-source.test.ts`: the kicker for each source, the placeholder for each source, `format` applying only to `elapsed`, the delta always signed, `isTouchInteractive` true only for `elapsed`, and a table-coverage test that fails if core adds a seventh source without this repo noticing.
- Verified in Helium at 1440×900 on the page carrying the timer: selecting `Best lap` flips the canvas kicker from `TIMER` to `BEST`, the Format field disappears, and the panel shows *"A readout — only the elapsed timer answers a touch on the device."* No console errors.