### PR TITLE
feat(tuner): one units switch, applied to every surface that shows a value

### DIFF
--- a/src/components/editor/WidgetPreview.tsx
+++ b/src/components/editor/WidgetPreview.tsx
@@ -14,6 +14,7 @@ import { TimerPreview } from './widget-previews/Timer'
 import { WarningPreview } from './widget-previews/Warning'
 import { isDangerState } from './widget-previews/gauge-math'
 import { isUnboundWidget } from '../../utils/unbound-widgets'
+import { useDisplayUnits } from '../../hooks/useDisplayUnits'
 
 const FALLBACK_UNIT_TABLE: Readonly<Record<string, string>> = MAXXECU_SIGNAL_UNITS
 
@@ -105,14 +106,15 @@ interface WidgetPreviewProps {
 
 const useResolvedSignalUnit = (widget: Widget): string => {
   const signals = useSignalStore((s) => s.signals)
+  const units = useDisplayUnits()
   const cfg = widget.config
   const configSuffix =
     cfg.type === 'gauge' || cfg.type === 'timer' ? ((cfg as { suffix?: string }).suffix ?? '') : ''
   if (configSuffix !== '') return configSuffix
   if (!widget.signal) return ''
   const def = signals.find((s) => s.name === widget.signal)
-  if (def?.unit) return def.unit
-  return FALLBACK_UNIT_TABLE[widget.signal] ?? ''
+  const stored = def?.unit ?? FALLBACK_UNIT_TABLE[widget.signal] ?? ''
+  return units.unitOf(stored)
 }
 
 const WidgetPreviewImpl = ({

--- a/src/components/live-data/LiveCards.tsx
+++ b/src/components/live-data/LiveCards.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/utils'
 import type { SignalDef } from '@canshift/core'
+import type { DisplayUnits } from '../../hooks/useDisplayUnits'
 
 const PERCENT = 100
 const DECIMALS = 1
@@ -7,6 +8,7 @@ const NO_VALUE = '—'
 
 export interface LiveCardsProps {
   signals: readonly SignalDef[]
+  units: DisplayUnits
   values: Record<string, number>
   selected: readonly string[]
   onToggle: (name: string) => void
@@ -23,7 +25,7 @@ const fractionOf = (signal: SignalDef, value: number | undefined): number => {
   return Math.max(0, Math.min(1, (value - signal.min) / range))
 }
 
-export const LiveCards = ({ signals, values, selected, onToggle }: LiveCardsProps) => (
+export const LiveCards = ({ signals, values, units, selected, onToggle }: LiveCardsProps) => (
   <div className="grid gap-px border border-ui-line bg-ui-line [grid-template-columns:repeat(auto-fill,minmax(228px,1fr))]">
     {signals.map((signal) => {
       const value = values[signal.name]
@@ -50,8 +52,11 @@ export const LiveCards = ({ signals, values, selected, onToggle }: LiveCardsProp
             </span>
           </div>
           <div className="font-mono text-[30px] leading-none tracking-[-0.02em] tabular-nums text-ui-ink">
-            {formatValue(value)}
-            <span className="text-[13px] tracking-normal text-ui-faint"> {signal.unit}</span>
+            {formatValue(value === undefined ? undefined : units.valueOf(value, signal.unit))}
+            <span className="text-[13px] tracking-normal text-ui-faint">
+              {' '}
+              {units.unitOf(signal.unit)}
+            </span>
           </div>
           <div className="mt-3 h-[3px] bg-ui-line">
             <div

--- a/src/components/signals/CanSignalTable.tsx
+++ b/src/components/signals/CanSignalTable.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react'
+import { displayUnit } from '@canshift/core'
 import type { SignalDef } from '@canshift/core'
 import { cn } from '@/lib/utils'
 import { formatByteRange, parseByteRange } from '../../lib/signal-bytes'
+import type { DisplayUnits } from '../../hooks/useDisplayUnits'
+import { UNIT_SYSTEM_OPTIONS } from '../../constants/units'
 import type { SignalUsage } from '../../hooks/useSignalUsage'
 
 const GRID = [
@@ -13,6 +16,7 @@ const DECIMALS = 1
 const NO_VALUE = '—'
 
 export interface CanSignalTableProps {
+  units: DisplayUnits
   signals: readonly SignalDef[]
   values: Record<string, number>
   usage: SignalUsage
@@ -24,7 +28,7 @@ const formatValue = (value: number | undefined): string => {
   return Number.isInteger(value) ? String(value) : value.toFixed(DECIMALS)
 }
 
-export const CanSignalTable = ({ signals, values, usage, onPatch }: CanSignalTableProps) => (
+export const CanSignalTable = ({ signals, values, usage, units, onPatch }: CanSignalTableProps) => (
   <div className="min-h-0 flex-1 overflow-y-auto">
     <div
       className={cn(
@@ -46,6 +50,7 @@ export const CanSignalTable = ({ signals, values, usage, onPatch }: CanSignalTab
         signal={signal}
         value={values[signal.name]}
         pages={usage.get(signal.name) ?? []}
+        units={units}
         onPatch={onPatch}
       />
     ))}
@@ -56,10 +61,11 @@ interface SignalRowProps {
   signal: SignalDef
   value: number | undefined
   pages: number[]
+  units: DisplayUnits
   onPatch: (name: string, patch: Partial<SignalDef>) => void
 }
 
-const SignalRow = ({ signal, value, pages, onPatch }: SignalRowProps) => {
+const SignalRow = ({ signal, value, pages, units, onPatch }: SignalRowProps) => {
   const unused = pages.length === 0
   return (
     <div
@@ -88,8 +94,10 @@ const SignalRow = ({ signal, value, pages, onPatch }: SignalRowProps) => {
           if (range) onPatch(signal.name, range)
         }}
       />
-      <span className="text-right tabular-nums">{formatValue(value)}</span>
-      <span className="text-[13px] text-ui-faint">{signal.unit}</span>
+      <span className="text-right tabular-nums">
+        {formatValue(value === undefined ? undefined : units.valueOf(value, signal.unit))}
+      </span>
+      <UnitCell signal={signal} units={units} />
       <span className="flex flex-wrap gap-1">
         {pages.map((page) => (
           <span key={page} className="border border-ui-line-strong px-[7px] text-[11.5px]">
@@ -99,6 +107,33 @@ const SignalRow = ({ signal, value, pages, onPatch }: SignalRowProps) => {
         {unused && <span className="text-[12px] text-ui-faint">not used</span>}
       </span>
     </div>
+  )
+}
+
+interface UnitCellProps {
+  signal: SignalDef
+  units: DisplayUnits
+}
+
+const UnitCell = ({ signal, units }: UnitCellProps) => {
+  if (!units.hasPair(signal.unit)) {
+    return <span className="text-[13px] text-ui-faint">{signal.unit}</span>
+  }
+  return (
+    <select
+      value={units.system}
+      aria-label={`Unit for ${signal.name}`}
+      onChange={(e) => {
+        units.setSystem(e.target.value as DisplayUnits['system'])
+      }}
+      className="w-full border border-ui-line bg-transparent px-1 py-1 font-mono text-[13px] text-ui-ink hover:border-ui-ink"
+    >
+      {UNIT_SYSTEM_OPTIONS.map((option) => (
+        <option key={option.value} value={option.value}>
+          {displayUnit(signal.unit, option.value)}
+        </option>
+      ))}
+    </select>
   )
 }
 

--- a/src/components/signals/Obd2Table.tsx
+++ b/src/components/signals/Obd2Table.tsx
@@ -1,6 +1,7 @@
 import { OBD2_MODE01_PIDS } from '@canshift/core'
 import type { SignalDef } from '@canshift/core'
 import { cn } from '@/lib/utils'
+import type { DisplayUnits } from '../../hooks/useDisplayUnits'
 import type { SignalUsage } from '../../hooks/useSignalUsage'
 
 const GRID = [
@@ -16,6 +17,7 @@ const CONTEXT =
   'OBD-II is the fallback when the car has no ECU profile: the dash polls standard PIDs instead of listening to raw frames. Slower and fewer signals, but it works on any car built after 2008.'
 
 export interface Obd2TableProps {
+  units: DisplayUnits
   signals: readonly SignalDef[]
   values: Record<string, number>
   usage: SignalUsage
@@ -36,6 +38,7 @@ export const Obd2Table = ({
   signals,
   values,
   usage,
+  units,
   intervalMs,
   intervals,
   onInterval,
@@ -95,8 +98,14 @@ export const Obd2Table = ({
           <span className="truncate font-bold" title={entry.description}>
             {entry.signal}
           </span>
-          <span className="text-right tabular-nums">{formatValue(values[entry.signal])}</span>
-          <span className="text-[13px] text-ui-faint">{entry.unit}</span>
+          <span className="text-right tabular-nums">
+            {formatValue(
+              values[entry.signal] === undefined
+                ? undefined
+                : units.valueOf(values[entry.signal] as number, entry.unit)
+            )}
+          </span>
+          <span className="text-[13px] text-ui-faint">{units.unitOf(entry.unit)}</span>
           <span className="flex items-center gap-3">
             {signal === undefined ? (
               <span className="text-[12px] text-ui-faint">{NOT_IN_PROFILE}</span>

--- a/src/constants/units.ts
+++ b/src/constants/units.ts
@@ -1,0 +1,9 @@
+import { UNIT_SYSTEMS } from '@canshift/core'
+import type { UnitSystem } from '@canshift/core'
+
+const LABELS: Record<UnitSystem, string> = {
+  metric: 'Metric',
+  imperial: 'Imperial',
+}
+
+export const UNIT_SYSTEM_OPTIONS = UNIT_SYSTEMS.map((value) => ({ value, label: LABELS[value] }))

--- a/src/hooks/useDisplayUnits.ts
+++ b/src/hooks/useDisplayUnits.ts
@@ -1,0 +1,39 @@
+import { useCallback, useMemo } from 'react'
+import {
+  DEFAULT_UNIT_SYSTEM,
+  canonicalValue,
+  displayUnit,
+  displayValue,
+  hasUnitPair,
+  type UnitSystem,
+} from '@canshift/core'
+import { useDashboardStore } from '../stores/dashboard.store'
+
+export interface DisplayUnits {
+  system: UnitSystem
+  setSystem: (system: UnitSystem) => void
+  unitOf: (signalUnit: string) => string
+  valueOf: (value: number, signalUnit: string) => number
+  storedValueOf: (shown: number, signalUnit: string) => number
+  hasPair: (signalUnit: string) => boolean
+}
+
+export const useDisplayUnits = (): DisplayUnits => {
+  const system = useDashboardStore((s) => s.config?.units) ?? DEFAULT_UNIT_SYSTEM
+  const setSystem = useDashboardStore((s) => s.setUnits)
+
+  const unitOf = useCallback((signalUnit: string) => displayUnit(signalUnit, system), [system])
+  const valueOf = useCallback(
+    (value: number, signalUnit: string) => displayValue(value, signalUnit, system),
+    [system]
+  )
+  const storedValueOf = useCallback(
+    (shown: number, signalUnit: string) => canonicalValue(shown, signalUnit, system),
+    [system]
+  )
+
+  return useMemo(
+    () => ({ system, setSystem, unitOf, valueOf, storedValueOf, hasPair: hasUnitPair }),
+    [system, setSystem, unitOf, valueOf, storedValueOf]
+  )
+}

--- a/src/lib/live-csv.test.ts
+++ b/src/lib/live-csv.test.ts
@@ -13,27 +13,42 @@ const SAMPLES = [
 
 describe('buildLiveCsv', () => {
   it('heads every column with the signal and its unit', () => {
-    const [head] = buildLiveCsv(SIGNALS, SAMPLES).split('\n')
+    const [head] = buildLiveCsv(SIGNALS, SAMPLES, 'metric').split('\n')
     expect(head).toBe('seconds,rpm (rpm),water (°C),gear')
   })
 
   it('writes one row per sample, in order, with the elapsed second', () => {
-    const rows = buildLiveCsv(SIGNALS, SAMPLES).split('\n')
+    const rows = buildLiveCsv(SIGNALS, SAMPLES, 'metric').split('\n')
     expect(rows).toHaveLength(3)
     expect(rows[1]).toBe('0.0,5200,88,')
     expect(rows[2]).toBe('0.1,5310.5,88,4')
   })
 
   it('leaves a cell empty rather than inventing a value the app never received', () => {
-    expect(buildLiveCsv(SIGNALS, SAMPLES).split('\n')[1]?.endsWith(',')).toBe(true)
+    expect(buildLiveCsv(SIGNALS, SAMPLES, 'metric').split('\n')[1]?.endsWith(',')).toBe(true)
   })
 
   it('quotes a field that would break the format', () => {
-    const csv = buildLiveCsv([signal('oil, hot', 'bar')], [{ t: 0, values: { 'oil, hot': 1 } }])
+    const csv = buildLiveCsv(
+      [signal('oil, hot', 'bar')],
+      [{ t: 0, values: { 'oil, hot': 1 } }],
+      'metric'
+    )
     expect(csv.split('\n')[0]).toBe('seconds,"oil, hot (bar)"')
   })
 
+  it('writes the imperial unit in the header and the converted value in the row', () => {
+    const csv = buildLiveCsv(
+      [signal('coolant', '°C')],
+      [{ t: 0, values: { coolant: 100 } }],
+      'imperial'
+    )
+    const [head, row] = csv.split('\n')
+    expect(head).toBe('seconds,coolant (°F)')
+    expect(row).toBe('0.0,212')
+  })
+
   it('produces a header even with no samples, so an empty recording is still readable', () => {
-    expect(buildLiveCsv(SIGNALS, []).split('\n')).toHaveLength(1)
+    expect(buildLiveCsv(SIGNALS, [], 'metric').split('\n')).toHaveLength(1)
   })
 })

--- a/src/lib/live-csv.ts
+++ b/src/lib/live-csv.ts
@@ -1,3 +1,4 @@
+import { displayUnit, displayValue, type UnitSystem } from '@canshift/core'
 import type { SignalDef } from '@canshift/core'
 import type { LiveSample } from '../hooks/useLiveSampler'
 
@@ -7,24 +8,26 @@ const NEEDS_QUOTES = /[",\n]/
 const escapeCsv = (value: string): string =>
   NEEDS_QUOTES.test(value) ? `"${value.replace(/"/g, '""')}"` : value
 
-const header = (signals: readonly SignalDef[]): string[] => [
+const header = (signals: readonly SignalDef[], system: UnitSystem): string[] => [
   'seconds',
-  ...signals.map((signal) =>
-    signal.unit.length > 0 ? `${signal.name} (${signal.unit})` : signal.name
-  ),
+  ...signals.map((signal) => {
+    const unit = displayUnit(signal.unit, system)
+    return unit.length > 0 ? `${signal.name} (${unit})` : signal.name
+  }),
 ]
 
 export const buildLiveCsv = (
   signals: readonly SignalDef[],
-  samples: readonly LiveSample[]
+  samples: readonly LiveSample[],
+  system: UnitSystem
 ): string => {
   const rows = [
-    header(signals),
+    header(signals, system),
     ...samples.map((sample) => [
       sample.t.toFixed(TIME_DECIMALS),
       ...signals.map((signal) => {
         const value = sample.values[signal.name]
-        return value === undefined ? '' : String(value)
+        return value === undefined ? '' : String(displayValue(value, signal.unit, system))
       }),
     ]),
   ]

--- a/src/routes/DeviceRoute.tsx
+++ b/src/routes/DeviceRoute.tsx
@@ -20,6 +20,9 @@ import { useProjectStore } from '../stores/project/project.store'
 import { useProjectFileActions } from '../hooks/useProjectFileActions'
 import { useCatalogueIndex } from '../hooks/useCatalogueIndex'
 import { ecuLabelForKey } from '../utils/ecu-label'
+import { useDisplayUnits } from '../hooks/useDisplayUnits'
+import { UNIT_SYSTEM_OPTIONS } from '../constants/units'
+import type { UnitSystem } from '@canshift/core'
 import { PROJECT_FILE_ACCEPT } from '../lib/project-file'
 
 const BoardConfigRoute = lazy(() => import('./BoardConfigRoute'))
@@ -48,6 +51,7 @@ const DeviceRoute = () => {
   const updateScreen = useScreenSettingsStore((s) => s.update)
   const activeProjectId = useProjectStore((s) => s.activeProjectId)
   const catalogue = useCatalogueIndex()
+  const units = useDisplayUnits()
   const { fileInputRef, exportProjectFile, openImportPicker, handleImportChange } =
     useProjectFileActions()
   const [advancedOpen, setAdvancedOpen] = useState(false)
@@ -111,6 +115,15 @@ const DeviceRoute = () => {
               }))}
               onChange={(value) => {
                 setTargetProfile(value as ScreenProfileId)
+              }}
+            />
+            <SettingRow
+              label="UNITS"
+              note="Switches every signal that has an imperial equivalent."
+              value={units.system}
+              options={UNIT_SYSTEM_OPTIONS}
+              onChange={(value) => {
+                units.setSystem(value as UnitSystem)
               }}
             />
             <SettingRow

--- a/src/routes/LiveDataRoute.tsx
+++ b/src/routes/LiveDataRoute.tsx
@@ -5,6 +5,7 @@ import { LiveDataEmpty } from '../components/live-data/LiveDataEmpty'
 import { LiveCards } from '../components/live-data/LiveCards'
 import { LivePlot } from '../components/live-data/LivePlot'
 import { BusSilentNotice } from '../components/states/BusSilentNotice'
+import { useDisplayUnits } from '../hooks/useDisplayUnits'
 import { useLiveSignals } from '../hooks/useLiveSignals'
 import { useLiveSampler, WINDOW_MAX_S, WINDOW_MIN_S, WINDOW_STEP_S } from '../hooks/useLiveSampler'
 import { useSignalStore } from '../stores/signal.store'
@@ -36,6 +37,7 @@ const LiveDataRoute = () => {
 
   const values = paused ? frozen : live
   const sampler = useLiveSampler(values, windowSeconds)
+  const units = useDisplayUnits()
 
   const goToSignals = () => {
     void navigate('/signals')
@@ -57,7 +59,7 @@ const LiveDataRoute = () => {
     const samples = sampler.stopRecording()
     if (samples.length === 0) return
     const stamp = new Date().toISOString().replace(/[:.]/g, '-')
-    downloadFile(liveCsvFilename(stamp), CSV_MIME, buildLiveCsv(signals, samples))
+    downloadFile(liveCsvFilename(stamp), CSV_MIME, buildLiveCsv(signals, samples, units.system))
   }
 
   const meta = useMemo(
@@ -111,7 +113,13 @@ const LiveDataRoute = () => {
       <BusSilentNotice />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
-        <LiveCards signals={signals} values={values} selected={selected} onToggle={toggle} />
+        <LiveCards
+          signals={signals}
+          values={values}
+          units={units}
+          selected={selected}
+          onToggle={toggle}
+        />
         <LivePlot
           signals={signals}
           selected={selected}

--- a/src/routes/RightSidebar.tsx
+++ b/src/routes/RightSidebar.tsx
@@ -7,6 +7,7 @@ import { SelectedWidgetEditor } from '../components/editor/SelectedWidgetEditor'
 import { RouteLoading } from '../components/shell/RouteLoading'
 import { useDashboardStore } from '../stores/dashboard.store'
 import { useSignalStore } from '../stores/signal.store'
+import { useDisplayUnits } from '../hooks/useDisplayUnits'
 import { configVerdict } from '../lib/burn-verdict'
 import { displayLabelForSignal } from '../utils/signal-labels'
 import { retypeWidget, type PaletteWidgetType } from '../lib/new-widget'
@@ -20,6 +21,11 @@ const widgetLabel = (widget: Widget): string => {
   if (widget.signal.length > 0) return displayLabelForSignal(widget.signal).toUpperCase()
   return widget.type.toUpperCase()
 }
+
+const ENTRY_DECIMALS = 2
+
+const roundForEntry = (value: number): number =>
+  Math.round(value * 10 ** ENTRY_DECIMALS) / 10 ** ENTRY_DECIMALS
 
 const dangerOf = (widget: Widget): { at: number | null; below: boolean; editable: boolean } => {
   if (widget.config.type !== 'gauge') return { at: null, below: false, editable: false }
@@ -39,6 +45,7 @@ export const RightSidebar = ({ pageId }: RightSidebarProps) => {
   const selectedWidgetId = useDashboardStore((s) => s.selectedWidgetId)
   const clipboardCount = useDashboardStore((s) => s.clipboardWidgets.length)
   const signals = useSignalStore((s) => s.signals)
+  const units = useDisplayUnits()
   const [advancedOpen, setAdvancedOpen] = useState(false)
 
   const { selectWidget, updateWidget, reorderWidget, removeWidget, pasteWidgets } =
@@ -60,6 +67,7 @@ export const RightSidebar = ({ pageId }: RightSidebarProps) => {
   const index = selected === null ? -1 : widgets.indexOf(selected)
   const verdict = configVerdict(config, signals)
   const danger = selected === null ? null : dangerOf(selected)
+  const selectedUnit = signals.find((signal) => signal.name === selected?.signal)?.unit ?? ''
 
   return (
     <aside className={ASIDE}>
@@ -94,13 +102,18 @@ export const RightSidebar = ({ pageId }: RightSidebarProps) => {
           }}
           canMoveUp={index > 0}
           canMoveDown={index >= 0 && index < widgets.length - 1}
-          dangerAt={danger.at}
+          dangerAt={
+            danger.at === null ? null : roundForEntry(units.valueOf(danger.at, selectedUnit))
+          }
           dangerBelow={danger.below}
           dangerEditable={danger.editable}
           onDangerAt={(value) => {
             if (selected.config.type !== 'gauge' || value === null) return
             updateWidget(pageId, selected.id, {
-              config: { ...selected.config, dangerLevel: value },
+              config: {
+                ...selected.config,
+                dangerLevel: units.storedValueOf(value, selectedUnit),
+              },
             })
           }}
           onDangerBelow={(below) => {

--- a/src/routes/SignalsRoute.tsx
+++ b/src/routes/SignalsRoute.tsx
@@ -20,6 +20,7 @@ import { useLiveSignals } from '../hooks/useLiveSignals'
 import { useSignalUsage } from '../hooks/useSignalUsage'
 import { useCatalogueIndex } from '../hooks/useCatalogueIndex'
 import { useProfileChange } from '../hooks/useProfileChange'
+import { useDisplayUnits } from '../hooks/useDisplayUnits'
 import { ecuLabelForKey } from '../utils/ecu-label'
 import { profileGroups } from '../lib/profile-options'
 import { downloadFile } from '../lib/download'
@@ -46,6 +47,7 @@ const SignalsRoute = () => {
   const usage = useSignalUsage()
   const catalogue = useCatalogueIndex()
   const profile = useProfileChange(catalogue)
+  const units = useDisplayUnits()
   const scanner = useCanScanner()
   const connected = useDeviceStore((s) => s.connected)
   const simulationMode = useDeviceStore((s) => s.simulationMode)
@@ -86,13 +88,22 @@ const SignalsRoute = () => {
   }
 
   const panes: Record<Pane, ReactNode> = {
-    can: <CanSignalTable signals={shown} values={values} usage={usage} onPatch={updateSignal} />,
+    can: (
+      <CanSignalTable
+        signals={shown}
+        values={values}
+        usage={usage}
+        units={units}
+        onPatch={updateSignal}
+      />
+    ),
     obd2: (
       <div className="flex min-h-0 flex-1 flex-col">
         <Obd2Table
           signals={signals}
           values={values}
           usage={usage}
+          units={units}
           intervalMs={pollIntervalMs}
           intervals={POLL_INTERVALS}
           onInterval={setPollIntervalMs}


### PR DESCRIPTION
Closes #233. Consumes the conversion table published in `@canshift/core` 8.1.0.

## One switch

`DEVICE → SETTINGS → UNITS`, with the consequence stated beside it: *"Switches every signal that has an imperial equivalent."* It writes `config.units`, so the choice travels with the config — into the `.canshift` export and into what BURN sends — rather than living in this browser.

`useDisplayUnits` is the single reader: `unitOf(signalUnit)`, `valueOf(value, signalUnit)`, `storedValueOf(shown, signalUnit)`, `hasPair(signalUnit)`. Every surface goes through it, and no surface knows a factor.

## Where it shows

- **SIGNALS / CAN** — the `UNIT` cell is a select on rows that have a pair and plain text on rows that do not, and the `VALUE` column converts with it. Picking the other unit on any row is the same act as the global switch, because there is one unit system and not one per row — which is what "changes every displayed value at once, with no per-row action" asks for. The select is there so a row with an alternative *looks* different from one without.
- **SIGNALS / OBD-II** — the same rule on the PID table.
- **LIVE** — the cards convert, and the exported CSV writes the display unit in the header and the converted number in the row.
- **The dash preview** — the unit string beside every value follows, so the canvas keeps showing what the device will show.
- **The widget editor** — `DANGER AT` is entered and read in the current unit.

## Nothing converts at rest

The CAN payload, the decoded value, the `SignalDef` and the stored `dangerLevel` stay in the unit the signal declares. `config.units` records only what to display. #233 is explicit about the reason, and it is the failure this design exists to avoid: converting at rest is how a threshold silently becomes wrong on the next import.

The threshold round trip is the proof: a coolant gauge at `110` in metric reads `230` in imperial, typing `230` stores `110`, and switching back shows `110` — not `110.000001`.

## kPa

#233 lists `bar ↔ psi`. The table core ships also carries `kPa ↔ psi`, because `kPa` is what the MaxxECU profile broadcasts for MAP — without it the one pressure signal most configs have would have stayed metric while the switch claimed to change everything.

## Test plan

- `typecheck` · `lint` · `test` (472) · `build` — green.
- `live-csv.test.ts` gains an imperial case: header `coolant (°F)`, row `0.0,212`.
- Verified in Helium at 1440×900, switching UNITS to imperial:
  - SIGNALS shows `psi` / `°F` / `mph` with converted values, and leaves `rpm`, `%`, `λ` alone;
  - LIVE cards read `24.2 psi`, `-37.3 °F`, `44.2 mph`, `45.5 psi`;
  - the canvas unit strings read `mph`, `°F`, `psi`;
  - the coolant gauge's `DANGER AT` goes `110` → `230`, typing `230` and switching back gives `110`.
- No console errors on any surface.

## Not in this PR

The **device** does not honour `units` yet — CANShift/canshift-firmware#270. Until it does, an imperial config makes the preview disagree with the dash. The field is optional and the firmware ignores keys it does not read, so nothing breaks in the meantime.