### PR TITLE
chore(tuner): report the deploy identifier instead of a version nobody bumps

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-declare const __TUNER_VERSION__: string
+declare const __TUNER_BUILD__: string
 declare const __EXPECTED_FIRMWARE_MAJOR__: number
 
 interface ImportMetaEnv {

--- a/src/hooks/useContactContext.ts
+++ b/src/hooks/useContactContext.ts
@@ -9,7 +9,7 @@ import { platformLabel } from '../lib/platform-label'
 import type { FeedbackContext } from '../lib/feedback'
 
 const CONTEXT_LINES: readonly [keyof FeedbackContext, string][] = [
-  ['appVersion', 'Tuner'],
+  ['appVersion', 'Tuner build'],
   ['firmwareVersion', 'Firmware'],
   ['boardModel', 'Board'],
   ['platform', 'Platform'],
@@ -34,7 +34,7 @@ export const useContactContext = (): ContactContext => {
   return useMemo(() => {
     const widgets = config?.pages.reduce((total, page) => total + page.widgets.length, 0) ?? 0
     const context: FeedbackContext = {
-      appVersion: __TUNER_VERSION__,
+      appVersion: __TUNER_BUILD__,
       ...(firmwareVersion !== null ? { firmwareVersion } : {}),
       boardModel: resolveScreenProfile(config?.targetProfile).name,
       platform: platformLabel(),

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -34,6 +34,6 @@ export const captureFlowEvent = (name: string, props: Record<string, unknown> = 
   posthog.capture(name, {
     ...scrubProps(props),
     app: 'canshift-tuner',
-    tunerVersion: __TUNER_VERSION__,
+    tunerBuild: __TUNER_BUILD__,
   })
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,12 @@ import { resolve } from 'node:path'
 import { Readable } from 'node:stream'
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
 
-const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf8')) as {
-  version: string
+const BUILD_ID_LENGTH = 7
+const LOCAL_BUILD_ID = 'dev'
+
+const buildId = (): string => {
+  const sha = process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA
+  return sha === undefined || sha.length === 0 ? LOCAL_BUILD_ID : sha.slice(0, BUILD_ID_LENGTH)
 }
 
 const FIRMWARE_PKG_PATH = resolve(__dirname, '../canshift-firmware/package.json')
@@ -72,7 +76,7 @@ const firmwareDownloadDevProxy = (): Plugin => ({
 export default defineConfig(({ command }) => ({
   root: resolve(__dirname, '.'),
   define: {
-    __TUNER_VERSION__: JSON.stringify(pkg.version),
+    __TUNER_BUILD__: JSON.stringify(buildId()),
     __EXPECTED_FIRMWARE_MAJOR__: JSON.stringify(firmwareMajor),
   },
   plugins: [react(), firmwareDownloadDevProxy()],


### PR DESCRIPTION
Closes #178.

## The three questions, answered together

#178 asks whether the tuner follows the firmware's version, core's, or its own line; whether it is bumped per change or derived; and whether the header should show a version at all. One answer covers all three: **the tuner has no versions to have a policy about.**

It is deployed continuously from `main`, has no tags, no releases, and is not consumed as a package — `private: true`, nothing installs it. A semver number on a continuously deployed app is a number someone has to remember to bump, and the moment they forget it is worse than nothing: it points a bug report at the wrong build.

What actually helps is the **deploy identifier**. `__TUNER_BUILD__` is now the short commit SHA, from `VERCEL_GIT_COMMIT_SHA` (or `GITHUB_SHA`), falling back to `dev` for a local build. Nobody bumps it, it is never stale, and it names exactly the build the user was running.

## The premise moved

#178 says "it shows in the header, so users read it". Since the restyle it does not — the header has no version slot. The value travels in two places that matter more:

- the **contact report**, where a bug report now reads `Tuner build: a1b2c3d` instead of `Tuner: 0.1.0`;
- **PostHog**, where the property is `tunerBuild` rather than `tunerVersion`, because it no longer is one.

`appVersion` stays the wire field name in the feedback body — the backend contract is unchanged, only the value it carries is now useful.

## `package.json`

Still `0.1.0`, now genuinely package metadata: nothing in the app reads it, and `vite.config.ts` no longer imports it.

## Test plan

- `typecheck` · `lint` · `test` (472) · `build` — green.
- Built twice: with `VERCEL_GIT_COMMIT_SHA=abcdef1234567890` the bundle carries `abcdef1`; without it, `appVersion:"dev"`.