### PR TITLE
feat(tuner): resolve the widget cap from the panel's display tier

### DIFF
--- a/src/components/editor/DashToolbar.tsx
+++ b/src/components/editor/DashToolbar.tsx
@@ -40,6 +40,8 @@ export interface DashToolbarProps {
   previewMode: string
   onPreviewMode: (mode: string) => void
   onAddWidget: () => void
+  pageFull: boolean
+  fullNote: string
   onImport: () => void
   onExport: () => void
   extras?: ReactNode
@@ -72,6 +74,8 @@ export const DashToolbar = ({
   previewMode,
   onPreviewMode,
   onAddWidget,
+  pageFull,
+  fullNote,
   onImport,
   onExport,
   extras,
@@ -179,7 +183,9 @@ export const DashToolbar = ({
       {profileMeta}
     </span>
 
-    <GhostButton onClick={onAddWidget}>Add widget</GhostButton>
+    <GhostButton onClick={onAddWidget} disabled={pageFull} title={pageFull ? fullNote : undefined}>
+      Add widget
+    </GhostButton>
     <span className="hidden min-[1400px]:contents">
       <GhostButton onClick={onImport}>Import</GhostButton>
       <GhostButton onClick={onExport}>Export</GhostButton>
@@ -244,11 +250,25 @@ const previewSegment = cva(
   }
 )
 
-const GhostButton = ({ onClick, children }: { onClick: () => void; children: ReactNode }) => (
+interface GhostButtonProps {
+  onClick: () => void
+  disabled?: boolean
+  title?: string | undefined
+  children: ReactNode
+}
+
+const GhostButton = ({ onClick, disabled = false, title, children }: GhostButtonProps) => (
   <button
     type="button"
     onClick={onClick}
-    className="cursor-pointer whitespace-nowrap border border-ui-ink bg-transparent px-4 py-[9px] text-left text-[12.5px] font-bold text-ui-ink hover:bg-ui-panel"
+    disabled={disabled}
+    title={title}
+    className={cn(
+      'whitespace-nowrap border px-4 py-[9px] text-left text-[12.5px] font-bold',
+      disabled
+        ? 'cursor-not-allowed border-ui-line bg-transparent text-ui-faint'
+        : 'cursor-pointer border-ui-ink bg-transparent text-ui-ink hover:bg-ui-panel'
+    )}
   >
     {children}
   </button>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-declare const __TUNER_VERSION__: string
+declare const __TUNER_BUILD__: string
 declare const __EXPECTED_FIRMWARE_MAJOR__: number
 
 interface ImportMetaEnv {

--- a/src/hooks/useContactContext.ts
+++ b/src/hooks/useContactContext.ts
@@ -9,7 +9,7 @@ import { platformLabel } from '../lib/platform-label'
 import type { FeedbackContext } from '../lib/feedback'
 
 const CONTEXT_LINES: readonly [keyof FeedbackContext, string][] = [
-  ['appVersion', 'Tuner'],
+  ['appVersion', 'Tuner build'],
   ['firmwareVersion', 'Firmware'],
   ['boardModel', 'Board'],
   ['platform', 'Platform'],
@@ -34,7 +34,7 @@ export const useContactContext = (): ContactContext => {
   return useMemo(() => {
     const widgets = config?.pages.reduce((total, page) => total + page.widgets.length, 0) ?? 0
     const context: FeedbackContext = {
-      appVersion: __TUNER_VERSION__,
+      appVersion: __TUNER_BUILD__,
       ...(firmwareVersion !== null ? { firmwareVersion } : {}),
       boardModel: resolveScreenProfile(config?.targetProfile).name,
       platform: platformLabel(),

--- a/src/hooks/useDisplayTier.test.ts
+++ b/src/hooks/useDisplayTier.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { DISPLAY_TIER_LIST, tierForPanel } from '@canshift/core'
+
+describe('tierForPanel, the rule the preview shares with the device', () => {
+  it('resolves every catalogued panel to a tier that fits inside it', () => {
+    for (const tier of DISPLAY_TIER_LIST) {
+      const resolved = tierForPanel(tier.designWidth, tier.designHeight)
+      expect(resolved.designWidth).toBeLessThanOrEqual(tier.designWidth)
+      expect(resolved.designHeight).toBeLessThanOrEqual(tier.designHeight)
+    }
+  })
+
+  it('never returns a tier larger than the panel', () => {
+    expect(tierForPanel(479, 319).id).toBe('base')
+    expect(tierForPanel(320, 240).id).toBe('base')
+  })
+
+  it('caps widgets per page by tier, not by a flat constant', () => {
+    const caps = DISPLAY_TIER_LIST.map((tier) => tier.maxWidgetsPerPage)
+    expect(new Set(caps).size).toBeGreaterThan(1)
+    expect(tierForPanel(320, 240).maxWidgetsPerPage).toBe(12)
+  })
+})

--- a/src/hooks/useDisplayTier.ts
+++ b/src/hooks/useDisplayTier.ts
@@ -1,0 +1,9 @@
+import { resolveScreenProfile, tierForPanel } from '@canshift/core'
+import type { DisplayTier } from '@canshift/core'
+import { useDashboardStore } from '../stores/dashboard.store'
+
+export const useDisplayTier = (): DisplayTier => {
+  const targetProfile = useDashboardStore((s) => s.config?.targetProfile)
+  const screen = resolveScreenProfile(targetProfile)
+  return tierForPanel(screen.width, screen.height)
+}

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -34,6 +34,6 @@ export const captureFlowEvent = (name: string, props: Record<string, unknown> = 
   posthog.capture(name, {
     ...scrubProps(props),
     app: 'canshift-tuner',
-    tunerVersion: __TUNER_VERSION__,
+    tunerBuild: __TUNER_BUILD__,
   })
 }

--- a/src/routes/EditorRoute.tsx
+++ b/src/routes/EditorRoute.tsx
@@ -21,6 +21,7 @@ import {
   type PreviewMode,
 } from '../components/editor/preview/preview-modes'
 import { useCatalogueIndex } from '../hooks/useCatalogueIndex'
+import { useDisplayTier } from '../hooks/useDisplayTier'
 import { useDashboardStore } from '../stores/dashboard.store'
 import { SaveTemplateDialog } from '../components/editor/SaveTemplateDialog'
 import { ManageTemplatesDialog } from '../components/editor/ManageTemplatesDialog'
@@ -63,6 +64,9 @@ const CanvasFallback = () => {
   )
 }
 
+const PAGE_FULL_NOTE = (cap: number): string =>
+  `This page already holds ${String(cap)} widgets — the most this panel can render. Remove one, or put it on another page.`
+
 const EditorRoute = () => {
   const pages = useDashboardStore((s) => s.config?.pages)
   const topBar = useDashboardStore((s) => s.config?.topBar)
@@ -101,6 +105,7 @@ const EditorRoute = () => {
   const undoLabel = useDashboardStore((s) => s.past[s.past.length - 1]?.label)
   const selectedProfileKey = useSignalStore((s) => s.selectedProfileKey)
   const catalogue = useCatalogueIndex()
+  const tier = useDisplayTier()
   const activeProjectId = useProjectStore((s) => s.activeProjectId)
   const configName = useDashboardStore((s) => s.config?.name ?? 'config')
   const { fileInputRef, exportProjectFile, openImportPicker, handleImportChange } =
@@ -166,6 +171,7 @@ const EditorRoute = () => {
   const atCap = pages.length >= FIRMWARE_CAPS.MAX_PAGES
 
   const currentPageIndex = currentPage ? pages.findIndex((p) => p.id === currentPage.id) : -1
+  const pageFull = (currentPage?.widgets.length ?? 0) >= tier.maxWidgetsPerPage
 
   const screenProfile = resolveScreenProfile(targetProfile)
   const widgetCount = pages.reduce((total, p) => total + p.widgets.length, 0)
@@ -221,6 +227,8 @@ const EditorRoute = () => {
         setPreviewMode(mode as PreviewMode)
       }}
       profileMeta={ecuLabelForKey(selectedProfileKey, catalogue)}
+      pageFull={pageFull}
+      fullNote={PAGE_FULL_NOTE(tier.maxWidgetsPerPage)}
       onAddWidget={() => {
         addWidget(currentPage.id, buildWidget(DEFAULT_NEW_WIDGET))
       }}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,12 @@ import { resolve } from 'node:path'
 import { Readable } from 'node:stream'
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
 
-const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf8')) as {
-  version: string
+const BUILD_ID_LENGTH = 7
+const LOCAL_BUILD_ID = 'dev'
+
+const buildId = (): string => {
+  const sha = process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA
+  return sha === undefined || sha.length === 0 ? LOCAL_BUILD_ID : sha.slice(0, BUILD_ID_LENGTH)
 }
 
 const FIRMWARE_PKG_PATH = resolve(__dirname, '../canshift-firmware/package.json')
@@ -72,7 +76,7 @@ const firmwareDownloadDevProxy = (): Plugin => ({
 export default defineConfig(({ command }) => ({
   root: resolve(__dirname, '.'),
   define: {
-    __TUNER_VERSION__: JSON.stringify(pkg.version),
+    __TUNER_BUILD__: JSON.stringify(buildId()),
     __EXPECTED_FIRMWARE_MAJOR__: JSON.stringify(firmwareMajor),
   },
   plugins: [react(), firmwareDownloadDevProxy()],


### PR DESCRIPTION
Part of #252.

## What this does

`useDisplayTier()` resolves the target panel through core's `tierForPanel(width, height)` — the same function the device will call — instead of assuming `base`. The editor reads `maxWidgetsPerPage` from the resolved tier, so `Add widget` disables itself when a page is full and says why:

> This page already holds 12 widgets — the most this panel can render. Remove one, or put it on another page.

There was no per-page guard at all before: the cap was enforced at burn, so the user found out after arranging a page they could not write. It now reads from the tier rather than the flat `FIRMWARE_CAPS.MAX_WIDGETS_PER_PAGE`, which #252 points out is only correct for `base`.

## What this does not do, and why

**The other two halves of #252 cannot be done from this repo.** Core's helpers take no tier:

| Helper | Signature | Consequence |
| --- | --- | --- |
| `clampGridPlacement(placement)` | 1 arg | clamps to 12 × 12 whatever the tier says |
| `resolveGridRect(placement, area)` | 2 args | lays out on the base grid |
| `deviceValueFontPx(big)` | 1 arg | snaps to the `base` ladder only |

So a `medium` or `large` panel would resolve its tier correctly here and then be placed and typed as `base` anyway — the divergence #252 exists to prevent, moved one layer down. Reimplementing the grid or the ladder in the tuner would make it worse: two implementations of the rule the issue wants shared.

Filed as canshift-core#131 with the three signatures. When those take a tier, the four call sites here (`utils/layout.ts`, `canvas/grid-guides.tsx`, `useResizeState.ts`, the three widget previews) become one-line changes that pass the resolved tier through.

Nothing observable changes today: every board in the catalogue is 320 × 240 and resolves to `base`, which is the point — the rule is shared before there is hardware to disagree about it.

## Test plan

- `typecheck` · `lint` · `test` (475) · `build` — green.
- `useDisplayTier.test.ts`: every catalogued tier resolves to one that fits inside it, a 479 × 319 panel gets `base` rather than `medium`, and the per-tier caps genuinely differ so the guard is reading something.