### PR TITLE
feat(tuner): provision a catalogue board by id instead of a 1.5 KB blob

### DIFF
--- a/src/components/firmware/FlashDonePanel.tsx
+++ b/src/components/firmware/FlashDonePanel.tsx
@@ -2,6 +2,7 @@ const DONE_BORDER = 'border-t-[3px] border-t-[#00cc2a]'
 
 export interface FlashDonePanelProps {
   outcome: string
+  provisionNote: string | null
   provisionLabel: string | null
   onOpenDash: () => void
   onFlashAnother: () => void
@@ -10,6 +11,7 @@ export interface FlashDonePanelProps {
 
 export const FlashDonePanel = ({
   outcome,
+  provisionNote,
   provisionLabel,
   onOpenDash,
   onFlashAnother,
@@ -43,5 +45,8 @@ export const FlashDonePanel = ({
         </button>
       )}
     </div>
+    {provisionNote !== null && (
+      <p className="mt-5 text-[13px] leading-[1.5] text-ui-muted">{provisionNote}</p>
+    )}
   </div>
 )

--- a/src/hooks/useProvisionBoardProfile.ts
+++ b/src/hooks/useProvisionBoardProfile.ts
@@ -2,7 +2,11 @@ import { useState } from 'react'
 import { usbService } from '../transport'
 import { useDeviceStore } from '../stores/device.store'
 import { useLogStore } from '../stores/log.store'
-import { boardProfileBlob, type BoardProfileWriteResult } from '../lib/firmware/board-provision'
+import {
+  boardProfileBlob,
+  type BoardProfileWriteResult,
+  type BoardProvision,
+} from '../lib/firmware/board-provision'
 import { useResolvedBoardProfile, type ResolvedBoardProfile } from './useResolvedBoardProfile'
 import { errorMessage } from '../lib/error-message'
 import { transportErrorText } from '../transport/humanize-transport-error'
@@ -12,7 +16,25 @@ export type ProvisionState =
   | { kind: 'writing' }
   | { kind: 'ok'; restart: boolean }
   | { kind: 'invalid' }
+  | { kind: 'unknown-board' }
   | { kind: 'error'; message: string }
+
+const STATE_MESSAGES: Record<ProvisionState['kind'], (state: ProvisionState) => string | null> = {
+  idle: () => null,
+  writing: () => 'Writing the board profile…',
+  ok: (state) =>
+    state.kind === 'ok' && state.restart
+      ? 'Board profile saved — the dash is rebooting to apply it.'
+      : 'Board profile saved.',
+  invalid: () => 'The firmware rejected this profile. Re-check the board definition on DEVICE.',
+  'unknown-board': () =>
+    'This firmware build has no driver for that board. Flash a build that lists it, or describe the board by hand on DEVICE.',
+  error: (state) =>
+    state.kind === 'error' ? `Board profile write failed — ${state.message}.` : null,
+}
+
+export const provisionMessage = (state: ProvisionState): string | null =>
+  STATE_MESSAGES[state.kind](state)
 
 export interface UseProvisionBoardProfile {
   resolved: ResolvedBoardProfile | null
@@ -22,6 +44,11 @@ export interface UseProvisionBoardProfile {
   provision: () => void
   reset: () => void
 }
+
+const provisionFor = (resolved: ResolvedBoardProfile): BoardProvision =>
+  resolved.source === 'catalog'
+    ? { kind: 'catalog', boardId: resolved.profile.boardId }
+    : { kind: 'custom', blob: boardProfileBlob(resolved.profile) }
 
 export const useProvisionBoardProfile = (): UseProvisionBoardProfile => {
   const resolved = useResolvedBoardProfile()
@@ -38,7 +65,7 @@ export const useProvisionBoardProfile = (): UseProvisionBoardProfile => {
     setState({ kind: 'writing' })
     log('info', `Provisioning board profile “${resolved.profile.boardName}” over USB`)
     void usbService
-      .setBoardProfile(boardProfileBlob(resolved.profile))
+      .setBoardProfile(provisionFor(resolved))
       .then((result: BoardProfileWriteResult) => {
         if (result.kind === 'ok') {
           setState({ kind: 'ok', restart: result.restart })
@@ -53,6 +80,11 @@ export const useProvisionBoardProfile = (): UseProvisionBoardProfile => {
         if (result.kind === 'invalid') {
           setState({ kind: 'invalid' })
           log('error', 'Firmware rejected the board profile (invalid_board_profile)')
+          return
+        }
+        if (result.kind === 'unknown-board') {
+          setState({ kind: 'unknown-board' })
+          log('error', `This build has no board called “${resolved.profile.boardId}”`)
           return
         }
         setState({ kind: 'error', message: transportErrorText(result.error) })

--- a/src/lib/firmware/board-provision.test.ts
+++ b/src/lib/firmware/board-provision.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { BOARD_PROFILES, parseBoardProfile } from '@canshift/core'
-import { boardProfileBlob, interpretBoardProfileAck } from './board-provision'
+import {
+  boardProfileBlob,
+  boardProvisionPayload,
+  interpretBoardProfileAck,
+} from './board-provision'
 
 const sampleProfile = () => {
   const profile = BOARD_PROFILES[0]
@@ -53,6 +57,36 @@ describe('interpretBoardProfileAck', () => {
     expect(interpretBoardProfileAck({ ok: false, error: 'timeout' })).toEqual({
       kind: 'error',
       error: 'timeout',
+    })
+  })
+})
+
+describe('boardProvisionPayload', () => {
+  it('sends a catalogue board by id, in the wire format', () => {
+    expect(boardProvisionPayload({ kind: 'catalog', boardId: 'waveshare_s3_28' })).toEqual({
+      board_id: 'waveshare_s3_28',
+    })
+  })
+
+  it('sends a custom board as the blob it has always sent', () => {
+    const blob = boardProfileBlob(sampleProfile())
+    expect(boardProvisionPayload({ kind: 'custom', blob })).toBe(blob)
+  })
+})
+
+describe('interpretBoardProfileAck, unknown board', () => {
+  it('tells an unknown id apart from an invalid profile', () => {
+    expect(interpretBoardProfileAck({ ok: false, error: 'unknown_board_id' })).toEqual({
+      kind: 'unknown-board',
+    })
+    expect(interpretBoardProfileAck({ ok: false, error: 'invalid_board_profile' })).toEqual({
+      kind: 'invalid',
+    })
+  })
+
+  it('reads the code out of the ack payload as well as the envelope', () => {
+    expect(interpretBoardProfileAck({ ok: true, data: { error: 'unknown_board_id' } })).toEqual({
+      kind: 'unknown-board',
     })
   })
 })

--- a/src/lib/firmware/board-provision.ts
+++ b/src/lib/firmware/board-provision.ts
@@ -7,9 +7,25 @@ const NVS_KEY = 'profile'
 const NVS_PARTITION_SIZE = 0x5000
 
 export const INVALID_BOARD_PROFILE = 'invalid_board_profile'
+export const UNKNOWN_BOARD_ID = 'unknown_board_id'
 
 export type BoardProfileWriteResult =
-  { kind: 'ok'; restart: boolean } | { kind: 'invalid' } | { kind: 'error'; error: string }
+  | { kind: 'ok'; restart: boolean }
+  | { kind: 'invalid' }
+  | { kind: 'unknown-board' }
+  | { kind: 'error'; error: string }
+
+export type BoardProvision =
+  { kind: 'catalog'; boardId: string } | { kind: 'custom'; blob: BoardProfileBlob }
+
+export interface BoardProvisionWire {
+  board_id?: string
+}
+
+export const boardProvisionPayload = (
+  provision: BoardProvision
+): BoardProvisionWire | BoardProfileBlob =>
+  provision.kind === 'catalog' ? { board_id: provision.boardId } : provision.blob
 
 export const boardProfileBlob = (profile: BoardProfile): BoardProfileBlob =>
   JSON.parse(serializeBoardProfile(profile)) as BoardProfileBlob
@@ -23,17 +39,16 @@ interface BoardProfileAck {
   data?: Record<string, unknown>
 }
 
+const failureFor = (error: string): BoardProfileWriteResult => {
+  if (error.includes(UNKNOWN_BOARD_ID)) return { kind: 'unknown-board' }
+  if (error.includes(INVALID_BOARD_PROFILE)) return { kind: 'invalid' }
+  return { kind: 'error', error }
+}
+
 export const interpretBoardProfileAck = (result: BoardProfileAck): BoardProfileWriteResult => {
-  if (!result.ok) {
-    const error = result.error ?? 'unknown_error'
-    return error.includes(INVALID_BOARD_PROFILE) ? { kind: 'invalid' } : { kind: 'error', error }
-  }
+  if (!result.ok) return failureFor(result.error ?? 'unknown_error')
   const data = result.data ?? {}
-  if (typeof data.error === 'string') {
-    return data.error.includes(INVALID_BOARD_PROFILE)
-      ? { kind: 'invalid' }
-      : { kind: 'error', error: data.error }
-  }
+  if (typeof data.error === 'string') return failureFor(data.error)
   if (data.status !== undefined && data.status !== 'ok') {
     return { kind: 'error', error: `unexpected status: ${String(data.status)}` }
   }

--- a/src/routes/FirmwareRoute.tsx
+++ b/src/routes/FirmwareRoute.tsx
@@ -11,7 +11,7 @@ import { useFlashTarget } from '../hooks/useFlashTarget'
 import { useFlashRun } from '../hooks/useFlashRun'
 import { useFlashProgress } from '../hooks/useFlashProgress'
 import { useFlasherStore } from '../stores/flasher.store'
-import { useProvisionBoardProfile } from '../hooks/useProvisionBoardProfile'
+import { provisionMessage, useProvisionBoardProfile } from '../hooks/useProvisionBoardProfile'
 import { useProjectFileActions } from '../hooks/useProjectFileActions'
 import { useProjectStore } from '../stores/project/project.store'
 import { useConnectionStore } from '../stores/connection.store'
@@ -123,6 +123,7 @@ const FirmwareRoute = () => {
       <FlashDonePanel
         outcome={`${target.release?.version ?? 'Firmware'} is on the board.`}
         provisionLabel={provision.canProvision ? 'Provision the board profile' : null}
+        provisionNote={provisionMessage(provision.state)}
         onOpenDash={() => {
           void navigate('/dash')
         }}

--- a/src/transport/usb-service.ts
+++ b/src/transport/usb-service.ts
@@ -1,4 +1,4 @@
-import type { BoardProfileBlob, DashboardConfig, ScreenSettings } from '@canshift/core'
+import type { DashboardConfig, ScreenSettings } from '@canshift/core'
 import { validateDashboard } from '@canshift/core'
 
 import {
@@ -15,8 +15,10 @@ import {
 import type { BurnPushResult, FirmwareIdentityResult, PingResult, RawAck, UsbResult } from './types'
 import { toUsbResult } from './types'
 import {
+  boardProvisionPayload,
   interpretBoardProfileAck,
   type BoardProfileWriteResult,
+  type BoardProvision,
 } from '../lib/firmware/board-provision'
 import { getSerialClient } from './webserial-client'
 import { burnConfigChunked } from './chunked-config'
@@ -55,10 +57,10 @@ export const usbService = {
     return toUsbResult(result)
   },
 
-  setBoardProfile: async (blob: BoardProfileBlob): Promise<BoardProfileWriteResult> => {
+  setBoardProfile: async (provision: BoardProvision): Promise<BoardProfileWriteResult> => {
     const result = await getSerialClient().send(
       CMD_SET_BOARD_PROFILE,
-      { payload: blob },
+      { payload: boardProvisionPayload(provision) },
       { scaleWithPayload: true, timeoutMs: 5_000 }
     )
     return interpretBoardProfileAck(result)


### PR DESCRIPTION
Closes #242. Firmware side is CANShift/canshift-firmware#256.

## Which shape gets sent

`CMD_SET_BOARD_PROFILE` takes two payloads, told apart by whether `magic` is present. The tuner now picks by where the board came from:

- **`{ board_id }`** when the board is one core's `BOARD_PROFILES` lists — a few dozen bytes over serial instead of ~1.5 KB, validated against the firmware's catalogue *before* anything reaches NVS.
- **the blob** when the user described a board the firmware has no driver for. That path is unchanged; it is the only one that can describe unknown hardware, and it still fails later at display init rather than at the ack.

`useResolvedBoardProfile` already knows which it is — `source: 'catalog' | 'custom'` — so the choice is that field and not a heuristic. `board_id` is snake_case at the wire boundary and nowhere else, per the repo rule.

## `unknown_board_id`

The new error code gets its own state rather than being folded into `invalid_board_profile`, because they mean opposite things: one says *this build has no driver for that board*, the other says *this profile is malformed*. The user reads:

> This firmware build has no driver for that board. Flash a build that lists it, or describe the board by hand on DEVICE.

## The outcome was invisible

Worth flagging: since the restyle, `useProvisionBoardProfile`'s state was rendered nowhere. Provisioning from the Flash pane's DONE block succeeded or failed in the log only. `provisionMessage(state)` is a lookup over the five states and the DONE block prints it, so all four non-idle outcomes now say something.

## The `GET_STATUS` bug

#242 notes the device used to report the compile-time board id rather than the provisioned one, and asks whether the tuner worked around it. It did not — `useVersionHandshake` stores `identity.boardId` as given, and `useFlashTarget` uses it only to preselect the model. Nothing to unwind.

## Test plan

- `typecheck` · `lint` · `test` (479) · `build` — green.
- `board-provision.test.ts` gains: a catalogue board serialises to `{ board_id }`, a custom board passes its blob through untouched, `unknown_board_id` and `invalid_board_profile` resolve to different states, and the code is read out of the ack payload as well as the envelope.
- **Not verified on hardware** — the id form needs a board running a build that carries the catalogue.