### PR TITLE
fix(tuner): RECENT CONFIGS survives an empty bench, and the theme toggle names the theme

### DIFF
--- a/src/components/shell/ThemeToggleButton.tsx
+++ b/src/components/shell/ThemeToggleButton.tsx
@@ -10,8 +10,8 @@ export const ThemeToggleButton = ({ theme, onToggle }: ThemeToggleButtonProps) =
     type="button"
     onClick={onToggle}
     className="cursor-pointer whitespace-nowrap border-0 border-l border-solid border-ui-header-line bg-transparent px-3 font-mono text-[11px] tracking-[0.14em] text-ui-header-dim hover:text-ui-header-ink"
-    title={theme === 'dark' ? 'Switch to the light theme' : 'Switch to the dark theme'}
+    title="Switch the Tuner theme"
   >
-    {theme === 'dark' ? 'DAY' : 'NIGHT'}
+    {theme === 'dark' ? 'LIGHT' : 'DARK'}
   </button>
 )

--- a/src/components/welcome/WelcomePane.tsx
+++ b/src/components/welcome/WelcomePane.tsx
@@ -87,24 +87,38 @@ export const WelcomePane = ({
           <FirstRunChoice onStartFromDefaults={onStartFromDefaults} onStartBlank={onStartBlank} />
         )}
 
-        {entries.length > 0 && (
-          <>
-            <p className={`${KICKER} border-b border-ui-line pb-2.5`}>RECENT CONFIGS</p>
-            {entries.map((entry) => (
-              <RecentConfigRow
-                key={entry.id}
-                entry={entry}
-                onOpen={onOpen}
-                onExport={onExport}
-                onDelete={onDelete}
-                deletable={entries.length > 1}
-              />
-            ))}
-          </>
+        <p className={`${KICKER} border-b border-ui-line pb-2.5`}>RECENT CONFIGS</p>
+        {entries.length === 0 ? (
+          <EmptyBenchRow />
+        ) : (
+          entries.map((entry) => (
+            <RecentConfigRow
+              key={entry.id}
+              entry={entry}
+              onOpen={onOpen}
+              onExport={onExport}
+              onDelete={onDelete}
+              deletable={entries.length > 1}
+            />
+          ))
         )}
       </div>
     </div>
     {updateBand}
+  </div>
+)
+
+const EMPTY_BENCH_NAME = 'Nothing saved yet'
+const EMPTY_BENCH_META = 'press SAVE and it appears here'
+
+const EmptyBenchRow = () => (
+  <div className="flex max-w-[440px] items-baseline gap-[18px] border-b border-ui-line py-[15px] pl-0 pr-3">
+    <span className="min-w-0 flex-1 truncate text-[15px] font-bold text-ui-muted">
+      {EMPTY_BENCH_NAME}
+    </span>
+    <span className="min-w-0 truncate font-mono text-[11.5px] text-ui-faint">
+      {EMPTY_BENCH_META}
+    </span>
   </div>
 )
 


### PR DESCRIPTION
Two deviations found by rendering `canshift-brand/design/CANShift Tuner v2.dc.html` side by side with the app on a cleared browser, at 1440 × 900, light theme.

## `RECENT CONFIGS` disappeared on first run

The app hid the whole section while the bench was empty. The mockup keeps it and falls back to one placeholder row — its own source is explicit:

```js
recent: (st.recents && st.recents.length) ? st.recents
      : [{ name: 'Nothing saved yet', meta: 'press SAVE and it appears here' }]
```

Which is the better behaviour anyway: the heading is where a first-time user learns that saving is a thing and where saved configs will appear. Hiding it means the first save moves the page under them with no warning.

The row is a plain non-interactive line — no `OPEN`, no `export`, no `delete`, since there is nothing to act on.

## The theme toggle said DAY / NIGHT

The mockup: `uiLabel: st.ui === 'light' ? 'DARK' : 'LIGHT'`, titled *"Switch the Tuner theme"*.

DAY / NIGHT is the **dash's** vocabulary — the device theme, switched on DEVICE and on the canvas Screen Settings, which is a different setting on a different thing. Using the same two words in the header for the Tuner's own chrome made two unrelated switches look like one. The header now says `LIGHT` / `DARK` and the dash keeps DAY / NIGHT.

## Test plan

- `typecheck` · `lint` · `test` (479) · `build` — green.
- Mockup and app rendered at 1440 × 900 in light theme with `localStorage` cleared: header, sidebar, kicker, title, paragraph, both button pairs, the FIRST RUN band and the RECENT CONFIGS block now line up. The remaining differences are state, not layout — the mockup shows a firmware-update band and a `SAVED` button because its fixture says so.