### PR TITLE
fix(tuner): byte ranges read start:end, as the mockup writes them

### DIFF
--- a/src/lib/signal-bytes.test.ts
+++ b/src/lib/signal-bytes.test.ts
@@ -7,19 +7,20 @@ describe('formatByteRange', () => {
   })
 
   it('shows a multi-byte signal as an inclusive range', () => {
-    expect(formatByteRange(0, 2)).toBe('0–1')
-    expect(formatByteRange(4, 4)).toBe('4–7')
+    expect(formatByteRange(0, 2)).toBe('0:1')
+    expect(formatByteRange(4, 4)).toBe('4:7')
   })
 })
 
 describe('parseByteRange', () => {
   it('reads back what it wrote', () => {
-    expect(parseByteRange('0–1')).toEqual({ startByte: 0, byteLength: 2 })
+    expect(parseByteRange('0:1')).toEqual({ startByte: 0, byteLength: 2 })
     expect(parseByteRange('3')).toEqual({ startByte: 3, byteLength: 1 })
   })
 
-  it('accepts a plain hyphen, which is what a keyboard types', () => {
+  it('accepts the separators a keyboard and the old format produce', () => {
     expect(parseByteRange('4-7')).toEqual({ startByte: 4, byteLength: 4 })
+    expect(parseByteRange('4–7')).toEqual({ startByte: 4, byteLength: 4 })
   })
 
   it('tolerates surrounding whitespace', () => {

--- a/src/lib/signal-bytes.ts
+++ b/src/lib/signal-bytes.ts
@@ -2,7 +2,7 @@ import { SIGNAL_BYTE_LENGTHS } from '@canshift/core'
 import type { SignalByteLength } from '@canshift/core'
 
 const MAX_START_BYTE = 7
-const RANGE = /^\s*(\d+)\s*(?:[-–]\s*(\d+)\s*)?$/
+const RANGE = /^\s*(\d+)\s*(?:[:\-–]\s*(\d+)\s*)?$/
 
 export interface ByteRange {
   startByte: number
@@ -10,7 +10,7 @@ export interface ByteRange {
 }
 
 export const formatByteRange = (startByte: number, byteLength: number): string =>
-  byteLength <= 1 ? String(startByte) : `${String(startByte)}–${String(startByte + byteLength - 1)}`
+  byteLength <= 1 ? String(startByte) : `${String(startByte)}:${String(startByte + byteLength - 1)}`
 
 export const parseByteRange = (raw: string): ByteRange | null => {
   const match = RANGE.exec(raw)

--- a/src/routes/SignalsRoute.tsx
+++ b/src/routes/SignalsRoute.tsx
@@ -152,7 +152,7 @@ const SignalsRoute = () => {
                 void scanner.start()
               }}
             >
-              {scanning ? 'Stop scan' : 'Scan bus'}
+              {scanning ? 'STOP SCAN' : 'SCAN BUS'}
             </SignalsAction>
             <SignalsAction
               onClick={() => {


### PR DESCRIPTION
Found by rendering `CANShift Tuner v2.dc.html`'s SIGNALS view next to the app.

## The separator

The mockup's BYTES column reads `0:1`, `2:3`, `4:5`, `6:7`. The app wrote `0–1` with an en dash — a character nobody can type, in a column that is a free-text input. `start:end` is also the conventional CAN byte-range notation, so this was a deviation in both directions at once.

`formatByteRange` now writes `:`. `parseByteRange` accepts `:`, `-` and `–`, so a value typed either way still parses and every profile XML written before this keeps importing — the round-trip test covers exactly that, since `profile-xml.ts` uses the same formatter for its `bytes` attribute.

## `SCAN BUS`

The mockup labels it `SCAN BUS` / `SCANNING…`, uppercase, against `Import XML` and `Download XML` in title case. The app said `Scan bus` / `Stop scan`. Now `SCAN BUS` / `STOP SCAN` — keeping the stop, which the mockup has no equivalent for and which a scan that cannot be interrupted needs.

## Test plan

- `typecheck` · `lint` · `test` (479) · `build` — green.
- `signal-bytes.test.ts`: the formatter writes `0:1` and `4:7`; the parser reads back `0:1`, and still accepts `4-7` and `4–7`.
- Rendered at 1440 × 900 in light theme against the mockup: the BYTES column reads `0:1`, `2`, `3:4`, `5`, `6:7`. Every other column already lined up.