### PR TITLE
fix(tuner): the DEVICE band names the panel driver when a board is resolved

### DIFF
--- a/src/routes/DeviceRoute.tsx
+++ b/src/routes/DeviceRoute.tsx
@@ -21,6 +21,7 @@ import { useProjectFileActions } from '../hooks/useProjectFileActions'
 import { useCatalogueIndex } from '../hooks/useCatalogueIndex'
 import { ecuLabelForKey } from '../utils/ecu-label'
 import { useDisplayUnits } from '../hooks/useDisplayUnits'
+import { useResolvedBoardProfile } from '../hooks/useResolvedBoardProfile'
 import { UNIT_SYSTEM_OPTIONS } from '../constants/units'
 import type { UnitSystem } from '@canshift/core'
 import { PROJECT_FILE_ACCEPT } from '../lib/project-file'
@@ -28,6 +29,11 @@ import { PROJECT_FILE_ACCEPT } from '../lib/project-file'
 const BoardConfigRoute = lazy(() => import('./BoardConfigRoute'))
 
 const BRIGHTNESS_STEPS = [20, 40, 60, 80, 100]
+const displayFact = (screen: { width: number; height: number }, driver: string | null): string => {
+  const size = `${String(screen.width)} × ${String(screen.height)}`
+  return driver === null ? size : `${driver.toUpperCase()} · ${size}`
+}
+
 const TRANSPORT = 'USB CDC'
 const UNSET = '—'
 
@@ -52,6 +58,7 @@ const DeviceRoute = () => {
   const activeProjectId = useProjectStore((s) => s.activeProjectId)
   const catalogue = useCatalogueIndex()
   const units = useDisplayUnits()
+  const panelDriver = useResolvedBoardProfile()?.profile.lcd.driver ?? null
   const { fileInputRef, exportProjectFile, openImportPicker, handleImportChange } =
     useProjectFileActions()
   const [advancedOpen, setAdvancedOpen] = useState(false)
@@ -94,7 +101,7 @@ const DeviceRoute = () => {
         <BoardBand
           facts={[
             { label: 'MODEL', value: screen.name },
-            { label: 'DISPLAY', value: `${String(screen.width)} × ${String(screen.height)}` },
+            { label: 'DISPLAY', value: displayFact(screen, panelDriver) },
             { label: 'FIRMWARE', value: firmwareVersion ?? UNSET },
             { label: 'TRANSPORT', value: TRANSPORT },
             { label: 'ECU PROFILE', value: ecuLabelForKey(selectedProfileKey, catalogue) },


### PR DESCRIPTION
Found by rendering `CANShift Tuner v2.dc.html`'s DEVICE view next to the app.

The mockup's `DISPLAY` cell reads `ILI9341 · 320 × 240`. The app showed `320 × 240` — the driver, which is the fact that decides whether an image will even boot on the panel, was missing.

It now reads the driver from the **resolved board profile** and prefixes it. With no board selected or detected the cell keeps showing the size alone: the screen profile knows the panel's dimensions, not its controller, and several catalogue boards share 240 × 320, so inferring a driver from the size would be a guess printed as a fact.

## Also seen, filed not fixed

The mockup's SETTINGS has a fourth row the app does not: **BUS RATE**, `500 kbit`, *"must match the car, or nothing decodes"*. The value exists on the board profile as `can.defaultSpeedKbps`, but there is nowhere to override it — `DashboardConfig` has no bitrate field, so a car on a 250 kbit bus cannot be configured. The mockup shows a `BUS RATE` row the app does not have; it is fixture text rather than a specified control, so nothing follows from it.

## Test plan

- `typecheck` · `lint` · `test` (479) · `build` — green.
- Rendered at 1440 × 900 in light theme: with no board resolved the cell reads `320 × 240` as before, which is the state a fresh profile is in.

