### PR TITLE
fix(tuner): a LIVE card calls a signal what every other view calls it

### DIFF
--- a/src/components/live-data/LiveCards.tsx
+++ b/src/components/live-data/LiveCards.tsx
@@ -45,7 +45,7 @@ export const LiveCards = ({ signals, values, units, selected, onToggle }: LiveCa
         >
           <div className="mb-2 flex items-baseline gap-2.5">
             <span className="truncate font-mono text-[10px] tracking-[0.16em] text-ui-muted">
-              {signal.name.replace(/_/g, ' ').toUpperCase()}
+              {signal.name}
             </span>
             <span className="ml-auto shrink-0 font-mono text-[10px] text-ui-accent">
               {signal.canFrameId}


### PR DESCRIPTION
Found by rendering `CANShift Tuner v2.dc.html`'s LIVE view next to the app.

A LIVE card rendered `signal.name.replace(/_/g, ' ').toUpperCase()`, so `throttle_pos` read `THROTTLE POS`. The plot's signal list, two panels to the right on the same screen, listed it as `throttle_pos` — and so does the SIGNALS table, the widget editor's signal field and the exported CSV.

The mockup renders `{{ l.name }}` untouched. The card keeps its styling — mono 10 px at `0.16em`, which is what made uppercasing look plausible — but the label is the signal's actual name, so the same signal reads the same way everywhere it appears.

## Test plan

- `typecheck` · `lint` · `test` (479) · `build` — green.
- Rendered at 1440 × 900: cards read `rpm`, `throttle_pos`, `map_kpa`, matching the plot list beside them.