### PR TITLE
feat(tuner): a control button renders all four states, from the vocabulary the dash uses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^8.1.0",
+        "@canshift/core": "^8.3.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-8.1.0.tgz",
-      "integrity": "sha512-QW3l3IfCEEKwpKlaGxxvc1XH3ZS564K2VcRQ3DlOYU1Dja340sDWIoI4N+cOW2F1LFdv67UqyPqPW2KDsCpK3Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-8.3.0.tgz",
+      "integrity": "sha512-vo94B6lNusJNff5Ottqh07Ku82pqTHBZjP6hascx9SHMOvQLeAFx6zuAQvU76xgugTi1uqsyno+yR9MJGCi4GA==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^8.1.0",
+    "@canshift/core": "^8.3.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/components/editor/WidgetPreview.tsx
+++ b/src/components/editor/WidgetPreview.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { memo } from 'react'
 import type { ComponentType } from 'react'
-import type { Widget, WidgetConfig, PagePalette } from '@canshift/core'
+import type { ControlState, Widget, WidgetConfig, PagePalette } from '@canshift/core'
 import { MAXXECU_SIGNAL_UNITS } from '@canshift/core'
 import { useSignalStore } from '../../stores/signal.store'
 import { ButtonPreview } from './widget-previews/Button'
@@ -32,7 +32,7 @@ interface RenderContext {
   w: number
   h: number
   revLimiting: boolean
-  buttonActive: boolean
+  buttonState: ControlState
   cycleStateIndex: number | undefined
   noAnimate: boolean
   testValue: number | null
@@ -83,7 +83,7 @@ const RENDERERS: RendererDispatch = {
       widget={widget}
       w={ctx.w}
       h={ctx.h}
-      active={ctx.buttonActive}
+      state={ctx.buttonState}
       cycleStateIndex={ctx.cycleStateIndex}
     />
   ),
@@ -98,7 +98,7 @@ interface WidgetPreviewProps {
   displayH: number
   palette?: PagePalette
   revLimiting?: boolean
-  buttonActive?: boolean
+  buttonState?: ControlState
   cycleStateIndex?: number | undefined
   noAnimate?: boolean
   testValue?: number | null
@@ -123,7 +123,7 @@ const WidgetPreviewImpl = ({
   displayH: rawH,
   palette,
   revLimiting = false,
-  buttonActive = false,
+  buttonState = 'off',
   cycleStateIndex,
   noAnimate = false,
   testValue = null,
@@ -140,7 +140,7 @@ const WidgetPreviewImpl = ({
     w,
     h,
     revLimiting: noAnimate ? false : revLimiting,
-    buttonActive,
+    buttonState,
     cycleStateIndex,
     noAnimate,
     testValue,

--- a/src/components/editor/property-panel/button-fields.tsx
+++ b/src/components/editor/property-panel/button-fields.tsx
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 import { useState } from 'react'
-import type { ButtonWidgetConfig } from '@canshift/core'
+import type { ButtonWidgetConfig, ControlState } from '@canshift/core'
 import { resolveGridRect, resolveScreenProfile } from '@canshift/core'
 
 import { Checkbox } from '@/components/ui/checkbox'
@@ -13,6 +13,7 @@ import { convertCycleToSingle, convertSingleToCycle, EMPTY_PAGES } from './butto
 import { SingleModeBody } from './button/single-mode-body'
 import { type ConfigFieldsProps } from './shared'
 import { PanelField, PanelInput } from '@/components/ui/form-field'
+import { controlFor, statesFor } from '../../../lib/control-paint'
 
 const previewToggle = cva('shrink-0 cursor-pointer border border-solid px-2 py-[3px] text-[10px]', {
   variants: {
@@ -24,12 +25,22 @@ const previewToggle = cva('shrink-0 cursor-pointer border border-solid px-2 py-[
   defaultVariants: { active: false },
 })
 
+const STATE_LABELS: Record<ControlState, string> = {
+  off: 'Off',
+  armed: 'Armed',
+  active: 'Active',
+  unavailable: 'Unavailable',
+}
+
+const kickerOf = (cfg: ButtonWidgetConfig, signal: string): string =>
+  cfg.kicker !== undefined && cfg.kicker !== '' ? cfg.kicker : signal
+
 export const ButtonFields = ({ widget, onChange }: ConfigFieldsProps) => {
   const pages = useDashboardStore((s) => s.config?.pages ?? EMPTY_PAGES)
   const targetProfile = useDashboardStore((s) => s.config?.targetProfile)
   const topBarHeight = useDashboardStore((s) => s.config?.topBar.height ?? 0)
   const pageIds = pages.map((p) => p.id)
-  const [previewActive, setPreviewActive] = useState(false)
+  const [previewStateIndex, setPreviewStateIndex] = useState(0)
   const [previewStateIdx, setPreviewStateIdx] = useState(0)
 
   if (widget.config.type !== 'button') return null
@@ -46,6 +57,9 @@ export const ButtonFields = ({ widget, onChange }: ConfigFieldsProps) => {
   const previewScale = Math.min(PREVIEW_MAX_SCALE, PREVIEW_BUDGET_W / w, PREVIEW_BUDGET_H / h)
   const previewW = Math.round(w * previewScale)
   const previewH = Math.round(h * previewScale)
+
+  const previewStates = statesFor(controlFor(kickerOf(cfg, widget.signal)))
+  const previewState = previewStates[previewStateIndex % previewStates.length] ?? 'off'
 
   const cycleStateCount = cfg.mode === 'cycle' ? cfg.states.length : 0
   const clampedPreviewIdx = cycleStateCount > 0 ? previewStateIdx % cycleStateCount : 0
@@ -68,27 +82,29 @@ export const ButtonFields = ({ widget, onChange }: ConfigFieldsProps) => {
             className="inline-block shrink-0 overflow-hidden border border-solid"
             // eslint-disable-next-line no-inline-style/no-inline-style
             style={{
-              borderColor: previewActive
-                ? widget.style.primaryColor
-                : 'hsl(var(--brand-neutral-300))',
+              borderColor:
+                previewState === 'off'
+                  ? 'hsl(var(--brand-neutral-300))'
+                  : widget.style.primaryColor,
             }}
           >
             <WidgetPreview
               widget={widget}
               displayW={previewW}
               displayH={previewH}
-              buttonActive={previewActive}
+              buttonState={previewState}
               cycleStateIndex={cfg.mode === 'cycle' ? clampedPreviewIdx : undefined}
             />
           </div>
           {cfg.mode === 'single' ? (
             <button
+              title="Step through the states the dash will render"
               onClick={() => {
-                setPreviewActive((v) => !v)
+                setPreviewStateIndex((i) => i + 1)
               }}
-              className={cn(previewToggle({ active: previewActive }))}
+              className={cn(previewToggle({ active: previewState !== 'off' }))}
             >
-              {previewActive ? 'Active' : 'Idle'}
+              {STATE_LABELS[previewState]}
             </button>
           ) : (
             <button

--- a/src/components/editor/widget-previews/Button.tsx
+++ b/src/components/editor/widget-previews/Button.tsx
@@ -1,5 +1,13 @@
 import { memo } from 'react'
-import { WIDGET_ACCENT_COLOR, WIDGET_DIM_COLORS } from '@canshift/core'
+import { CONTROL_STEP_MAX, GAUGE_TRACK_COLORS, type ControlState } from '@canshift/core'
+import { cn } from '@/lib/utils'
+import {
+  controlFor,
+  controlSurface,
+  controlText,
+  defaultControlColors,
+} from '../../../lib/control-paint'
+import { BLINK } from '../widget-preview.styles'
 import { type BaseRendererProps, formatSignalLabel } from './shared'
 
 const FRAME = [
@@ -16,7 +24,7 @@ const LABEL = [
 ].join(' ')
 
 export interface ButtonRendererProps extends BaseRendererProps {
-  active: boolean
+  state: ControlState
   cycleStateIndex?: number | undefined
 }
 
@@ -67,13 +75,24 @@ const kickerFromConfig = (cfg: { mode: string }, signal: string): string => {
   return actionType !== undefined ? (KICKER_BY_ACTION_TYPE[actionType] ?? '') : ''
 }
 
-const KICKER_ENGAGED_COLOR = 'rgba(255,255,255,0.75)'
+const SEGMENT_ROW = 'mt-0.5 flex w-full gap-[2px]'
+const SEGMENT = 'h-[2px] flex-1'
+const DEMO_LEVEL = 3
+
+const SegmentRow = ({ level, lit, unlit }: { level: number; lit: string; unlit: string }) => (
+  <span className={SEGMENT_ROW}>
+    {Array.from({ length: CONTROL_STEP_MAX }, (_, i) => (
+      // eslint-disable-next-line no-inline-style/no-inline-style
+      <span key={i} className={SEGMENT} style={{ background: i < level ? lit : unlit }} />
+    ))}
+  </span>
+)
 
 export const ButtonPreview = memo(function ButtonPreview({
   widget,
   w,
   h,
-  active,
+  state,
   cycleStateIndex,
 }: ButtonRendererProps) {
   if (widget.config.type !== 'button') return null
@@ -92,37 +111,55 @@ export const ButtonPreview = memo(function ButtonPreview({
   const showLabel = cfg.showLabel !== false
   const { fontSize } = computeButtonPreviewMetrics(w, h, kicker !== '', displayText.length)
 
-  const engagedColor = displayColors?.active ?? WIDGET_ACCENT_COLOR
-  const idleBorder = displayColors?.normal ?? st.textColor
-
-  const bgColor = active ? engagedColor : 'transparent'
-  const borderColor = active ? engagedColor : idleBorder
-  const textColor = active ? '#FFFFFF' : st.textColor
-  const kickerColor = active ? KICKER_ENGAGED_COLOR : WIDGET_DIM_COLORS.night
+  const control = controlFor(kicker)
+  const colors = defaultControlColors(displayColors?.normal ?? st.textColor, displayColors?.active)
+  const surface = controlSurface(state, colors)
+  const text = control === null ? null : controlText(control, state, displayText)
+  const word = text?.word ?? displayText
+  const qualifier = text?.qualifier ?? ''
+  const stepper = control?.kind === 'stepper'
 
   return (
     <div
-      className={FRAME}
+      className={cn(FRAME, surface.pulses && BLINK)}
       // eslint-disable-next-line no-inline-style/no-inline-style
-      style={{ width: w, height: h, background: bgColor, borderColor }}
+      style={{
+        width: w,
+        height: h,
+        background: surface.background,
+        borderColor: surface.borderColor,
+      }}
     >
       {showLabel && kicker !== '' && (
         <span
           className={KICKER}
           // eslint-disable-next-line no-inline-style/no-inline-style
-          style={{ color: kickerColor }}
+          style={{ color: surface.kickerColor, opacity: surface.kickerOpacity }}
         >
           {kicker}
+          {qualifier !== '' && (
+            <>
+              <br />
+              {qualifier}
+            </>
+          )}
         </span>
       )}
       {showLabel && (
         <span
           className={LABEL}
           // eslint-disable-next-line no-inline-style/no-inline-style
-          style={{ color: textColor, fontSize }}
+          style={{ color: surface.wordColor, fontSize }}
         >
-          {displayText}
+          {word}
         </span>
+      )}
+      {stepper && state !== 'unavailable' && (
+        <SegmentRow
+          level={state === 'off' ? 0 : DEMO_LEVEL}
+          lit={surface.wordColor}
+          unlit={GAUGE_TRACK_COLORS.plain}
+        />
       )}
     </div>
   )

--- a/src/lib/control-paint.test.ts
+++ b/src/lib/control-paint.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { CONTROL_STATES } from '@canshift/core'
+import {
+  controlFor,
+  controlSurface,
+  controlText,
+  defaultControlColors,
+  statesFor,
+} from './control-paint'
+
+const COLORS = defaultControlColors('#FFFFFF', '#FF4747')
+
+describe('controlSurface', () => {
+  it('pulses on armed and on nothing else', () => {
+    const pulsing = CONTROL_STATES.filter((state) => controlSurface(state, COLORS).pulses)
+    expect(pulsing).toEqual(['armed'])
+  })
+
+  it('fills the ground only when the control is engaged', () => {
+    expect(controlSurface('off', COLORS).background).toBe('transparent')
+    expect(controlSurface('armed', COLORS).background).toBe('transparent')
+    expect(controlSurface('active', COLORS).background).toBe('#FF4747')
+    expect(controlSurface('unavailable', COLORS).background).toBe('transparent')
+  })
+
+  it('gives an unavailable control the lock pair, not a grey-out of the ink', () => {
+    const locked = controlSurface('unavailable', COLORS)
+    expect(locked.borderColor).toBe('#333333')
+    expect(locked.wordColor).toBe('#6B6B6B')
+    expect(locked.kickerColor).toBe('#6B6B6B')
+  })
+
+  it('drops the engaged kicker to 75 % rather than tinting it', () => {
+    expect(controlSurface('active', COLORS).kickerColor).toBe('#FFFFFF')
+    expect(controlSurface('active', COLORS).kickerOpacity).toBe(0.75)
+    expect(controlSurface('off', COLORS).kickerOpacity).toBe(1)
+  })
+})
+
+describe('statesFor', () => {
+  it('offers armed only on the controls that declare it', () => {
+    expect(statesFor(controlFor('LAUNCH'))).toContain('armed')
+    expect(statesFor(controlFor('CRUISE'))).toContain('armed')
+    expect(statesFor(controlFor('TRACTION'))).toContain('armed')
+    expect(statesFor(controlFor('ANTI-LAG'))).not.toContain('armed')
+    expect(statesFor(controlFor('PIT LIMIT'))).not.toContain('armed')
+    expect(statesFor(controlFor('ECU MAP'))).not.toContain('armed')
+  })
+
+  it('leaves a button that is not one of the six with two states', () => {
+    expect(statesFor(controlFor('BOOST'))).toEqual(['off', 'active'])
+  })
+})
+
+describe('controlText', () => {
+  it('stacks the reason as a qualifier instead of joining it to the name', () => {
+    const locked = controlText(controlFor('ANTI-LAG')!, 'unavailable', 'ANTI-LAG')
+    expect(locked.kicker).toBe('ANTI-LAG')
+    expect(locked.qualifier).toBe('EGT HIGH')
+    expect(locked.word).toBe('LOCKED')
+  })
+
+  it('fills the parameter a phrase asks for', () => {
+    expect(controlText(controlFor('LAUNCH')!, 'armed', 'LAUNCH').qualifier).toBe('4200 rpm')
+    expect(controlText(controlFor('TRACTION')!, 'active', 'TRACTION').word).toBe('LEVEL 3')
+    expect(controlText(controlFor('PIT LIMIT')!, 'unavailable', 'PIT').qualifier).toBe('GEAR 4')
+  })
+
+  it('falls back to the widget label when the state has no word of its own', () => {
+    expect(controlText(controlFor('ANTI-LAG')!, 'armed', 'ANTI-LAG').word).toBe('ANTI-LAG')
+  })
+})

--- a/src/lib/control-paint.ts
+++ b/src/lib/control-paint.ts
@@ -1,0 +1,92 @@
+import {
+  CONTROL_KICKER_ENGAGED_OPACITY,
+  CONTROL_PAINT,
+  CONTROL_STATES,
+  WIDGET_ACCENT_COLOR,
+  WIDGET_DIM_COLORS,
+  WIDGET_LOCK_INK_COLORS,
+  WIDGET_LOCK_LINE_COLORS,
+  controlByKicker,
+  fillParam,
+  supportsArmed,
+  type ControlDefinition,
+  type ControlState,
+  type ControlTone,
+} from '@canshift/core'
+
+export interface ControlColors {
+  ink: string
+  engaged: string
+}
+
+const WHITE = '#FFFFFF'
+
+const TONES: Record<ControlTone, (colors: ControlColors) => string> = {
+  ink: (c) => c.ink,
+  dim: () => WIDGET_DIM_COLORS.night,
+  white: () => WHITE,
+  engaged: (c) => c.engaged,
+  lockLine: () => WIDGET_LOCK_LINE_COLORS.night,
+  lockInk: () => WIDGET_LOCK_INK_COLORS.night,
+}
+
+export interface ControlSurface {
+  borderColor: string
+  background: string
+  kickerColor: string
+  kickerOpacity: number
+  wordColor: string
+  pulses: boolean
+}
+
+export const controlSurface = (state: ControlState, colors: ControlColors): ControlSurface => {
+  const paint = CONTROL_PAINT[state]
+  return {
+    borderColor: TONES[paint.border](colors),
+    background: paint.ground === null ? 'transparent' : TONES[paint.ground](colors),
+    kickerColor: TONES[paint.kicker](colors),
+    kickerOpacity: paint.kicker === 'white' ? CONTROL_KICKER_ENGAGED_OPACITY : 1,
+    wordColor: TONES[paint.word](colors),
+    pulses: paint.pulses,
+  }
+}
+
+export const defaultControlColors = (ink: string, engaged: string | undefined): ControlColors => ({
+  ink,
+  engaged: engaged ?? WIDGET_ACCENT_COLOR,
+})
+
+export const statesFor = (control: ControlDefinition | null): readonly ControlState[] => {
+  if (!control) return ['off', 'active']
+  return CONTROL_STATES.filter((state) => state !== 'armed' || supportsArmed(control))
+}
+
+export interface ControlText {
+  kicker: string
+  qualifier: string
+  word: string
+}
+
+const DEMO_PARAM: Record<string, number> = {
+  level: 3,
+  rpm: 4200,
+  speedKph: 110,
+  gear: 4,
+}
+
+export const controlText = (
+  control: ControlDefinition,
+  state: ControlState,
+  fallbackWord: string
+): ControlText => {
+  const phrase = control.phrases[state]
+  const param = DEMO_PARAM[phrase.param] ?? null
+  const word = fillParam(phrase.stateWord, param)
+  return {
+    kicker: control.kicker,
+    qualifier: fillParam(phrase.kickerSuffix, param),
+    word: word.length > 0 ? word : fallbackWord,
+  }
+}
+
+export const controlFor = (kicker: string): ControlDefinition | null => controlByKicker(kicker)


### PR DESCRIPTION
Closes #269. Consumes `@canshift/core` **8.3.0**, whose `CONTROLS` table is parity-tested against `canshift-firmware/src/ui/control_vocabulary.cpp`, and the lock colour pair from 8.2.0.

## What the preview showed before

Two states, from a boolean: idle and active, with the widget's own label as the state word. `DASH_DESIGN_SYSTEM.md` §6 specifies four, and the firmware renders four.

## What it shows now

The preview resolves the control from the button's kicker. For one of the six — `ANTI-LAG`, `TRACTION`, `LAUNCH`, `PIT LIMIT`, `CRUISE`, `ECU MAP` — it renders what the dash will render, taken from the shared table rather than from the label the user typed:

| State | LAUNCH renders |
| --- | --- |
| off | `LAUNCH` · `OFF` |
| armed | `LAUNCH` / `4200 rpm` · `ARMED`, **pulsing** |
| active | `LAUNCH` / `HOLDING` · `4200` |
| unavailable | `LAUNCH` / `MOVING` · `LOCKED`, in the lock pair |

**The kicker stacks.** The reason owns its own line — `LAUNCH` then `MOVING`, never `LAUNCH · MOVING` — because a 4-column button has 9 characters of kicker budget and `PIT LIMIT` alone spends it. That is the doc's measurement, and the preview now shows the wrap the device would have to do.

**Armed is per control.** Launch, cruise and traction offer it; anti-lag, pit limit and the ECU map step straight from off to active, because there is no physical in-between for them. `statesFor` reads `supportsArmed` rather than assuming four everywhere.

**Only armed pulses.** Active is steady — a control that is intervening says so in its kicker (`TRACTION` / `CUTTING`), it does not move.

**Steppers show their segment row.** Traction and the ECU map draw six cells under the state word, lit in the word's own colour and unlit in `CS_TRACK`.

A button whose kicker is not one of the six keeps two states and its own label: the four states are a property of *controls*, and those six are the controls.

## Where the state comes from

The canvas renders `off` — a control's live state is the car's, and there is no car in the editor. The four states are explored in the widget's own panel, where the `Off / Armed / Active / Unavailable` control steps through the ones that control supports. That is the surface where you are deciding what the button will look like.

## Test plan

- `typecheck` · `lint` · `test` (488) · `build` — green.
- `control-paint.test.ts`: exactly one state pulses; the ground fills only when engaged; unavailable takes `#333333` / `#6B6B6B` rather than a dimmed ink; the engaged kicker is white at 75 % rather than tinted; armed is offered only to launch, cruise and traction; an unrecognised kicker gets two states; the qualifier is stacked, not joined; `%d` is filled per phrase.
- Driven in Helium at 1440 × 900: with the kicker set to `LAUNCH` the control cycles `Off → Armed → Active → Unavailable`, and the preview reads `LAUNCH / 4200 rpm / ARMED`, then `LAUNCH / HOLDING / 4200` on an engaged ground, then `LAUNCH / MOVING / LOCKED` in the lock pair. With the kicker left at `TRACK` it cycles `Off → Active` only. No console errors.