### PR TITLE
fix(tuner): a widget box takes the page ground, so day mode is not black boxes on white

### DIFF
--- a/src/components/editor/WidgetBox.tsx
+++ b/src/components/editor/WidgetBox.tsx
@@ -23,6 +23,7 @@ export interface WidgetBoxProps {
   onDragStart: (e: MouseEvent, widget: Widget) => void
   onResizeStart?: ((e: PointerEvent, widget: Widget) => void) | undefined
   onSignalDrop: (widget: Widget, signalName: string) => void
+  groundColor: string
 }
 
 const GRIP_WIDTH_PX = 12
@@ -38,7 +39,7 @@ const box = cva('absolute box-border cursor-move select-none overflow-hidden', {
       overflowing: 'bg-[#2A1A00]',
       selected: 'bg-selection-bg',
       multi: 'bg-[#0A0A1E]',
-      plain: 'bg-black',
+      plain: 'bg-transparent',
     },
     glow: {
       overlapping: 'shadow-[0_0_0_1px_#FF222244,0_0_8px_#FF222288]',
@@ -102,8 +103,11 @@ export const WidgetBox = memo(function WidgetBox({
   onDragStart,
   onResizeStart,
   onSignalDrop,
+  groundColor,
 }: WidgetBoxProps) {
   const acceptsSignal = SIGNAL_CONSUMING_TYPES.has(widget.type)
+  const fill = fillOf(isOverlapping, isOverflowing, isSelected, isInMultiSelection)
+  const isPlain = fill === 'plain'
   const { layout } = widget
   const rect = resolveGridRect(layout, { width: areaWidth, height: areaHeight })
   const displayW = rect.w * scale
@@ -144,7 +148,7 @@ export const WidgetBox = memo(function WidgetBox({
       }}
       className={cn(
         box({
-          fill: fillOf(isOverlapping, isOverflowing, isSelected, isInMultiSelection),
+          fill,
           glow: glowOf(isOverlapping, isOverflowing, isInMultiSelection),
           ring: ringOf(isFlashing, isSelected),
         }),
@@ -156,6 +160,7 @@ export const WidgetBox = memo(function WidgetBox({
         top: rect.y * scale,
         width: displayW,
         height: displayH,
+        ...(isPlain ? { background: groundColor } : {}),
       }}
     >
       {onResizeStart && (

--- a/src/components/editor/WidgetPreview.tsx
+++ b/src/components/editor/WidgetPreview.tsx
@@ -19,6 +19,7 @@ import { useDisplayUnits } from '../../hooks/useDisplayUnits'
 const FALLBACK_UNIT_TABLE: Readonly<Record<string, string>> = MAXXECU_SIGNAL_UNITS
 
 const applyPalette = (widget: Widget, palette: PagePalette): Widget => {
+  if (widget.style.respectDayMode === false) return widget
   return {
     ...widget,
     style: {

--- a/src/components/editor/canvas/page-frame.tsx
+++ b/src/components/editor/canvas/page-frame.tsx
@@ -75,6 +75,7 @@ export const PageFrame = ({
     >
       <GridGuides areaWidth={areaWidth} areaHeight={areaHeight} effScale={scale} />
       <WidgetLayer
+        groundColor={bgColor}
         page={page}
         palette={palette}
         effScale={scale}

--- a/src/components/editor/canvas/widget-layer.tsx
+++ b/src/components/editor/canvas/widget-layer.tsx
@@ -3,6 +3,7 @@ import { CruiseControlPreview } from '../CruiseControlPreview'
 import { WidgetBox } from '../WidgetBox'
 
 export interface WidgetLayerProps {
+  groundColor: string
   page: PageConfig
   palette: PagePalette
   effScale: number
@@ -34,6 +35,7 @@ const CustomBody = (props: WidgetLayerProps) => (
         key={widget.id}
         widget={widget}
         palette={props.palette}
+        groundColor={props.groundColor}
         scale={props.effScale}
         areaWidth={props.areaWidth}
         areaHeight={props.areaHeight}


### PR DESCRIPTION
Closes #272.

## The black boxes

Every widget box painted `bg-black`, a literal, whatever the theme. In night mode `#000000` sits close enough to the `#121212` ground to pass unnoticed. Switch the canvas to day and the page ground goes light while forty widgets stay solid black — unreadable, and nothing like what the device would show.

A widget has **no fill of its own**: `WidgetStyle` has no background field, and the firmware's `getEffectiveBgColor` returns the active theme face's ground. So the box now paints the resolved page ground, which is visually identical to no fill and keeps masking the editor's grid guides exactly as the black did.

## `respectDayMode` was ignored

`applyPalette` overwrote `widget.style.textColor` with the active palette's text unconditionally. The firmware does not:

```cpp
uint32_t ThemeManager::getEffectiveTextColor(uint32_t styleTextColor, bool respectDayMode) {
    if (!respectDayMode) return styleTextColor;
    return getEffectiveTextColor();
}
```

A widget that opts out keeps its own colour on the glass and had it overridden in the preview. It now opts out in both.

## What #272 asked to decide

Between resolving colours from the active face at render time, and storing a day colour beside every night colour. The firmware had already decided: it resolves at render time and treats the stored colour as an override gated on `respectDayMode`. The tuner now does the same, so switching day/night still writes nothing to the config.

## Test plan

- `typecheck` · `lint` · `test` (488) · `build` — green.
- Verified in Helium at 1440 × 900, in simulation, through the dash's own Screen Settings: night renders `#121212` ground with light values, day renders `#E8E8E8` ground with dark values, and no widget is a black rectangle in either. The stored config is byte-identical across the switch.