### PR TITLE
feat(tuner): the board profile can be written from DEVICE, without a flash

### DIFF
--- a/src/components/device/BoardProfileRow.tsx
+++ b/src/components/device/BoardProfileRow.tsx
@@ -1,0 +1,49 @@
+import { cn } from '@/lib/utils'
+
+export interface BoardProfileRowProps {
+  boardName: string | null
+  canProvision: boolean
+  busy: boolean
+  blockedNote: string
+  note: string | null
+  onProvision: () => void
+}
+
+const NO_BOARD = 'Pick a board in the board definition below before writing a profile to the dash.'
+
+export const BoardProfileRow = ({
+  boardName,
+  canProvision,
+  busy,
+  blockedNote,
+  note,
+  onProvision,
+}: BoardProfileRowProps) => (
+  <div className="mt-4 border-t border-ui-line pt-4">
+    <div className="flex flex-wrap items-center gap-4">
+      <div className="min-w-0">
+        <div className="mb-[3px] font-mono text-[10.5px] tracking-[0.16em] text-ui-muted">
+          BOARD PROFILE
+        </div>
+        <div className="text-[13px] text-ui-faint">
+          {boardName === null ? NO_BOARD : `Writes ${boardName} to the dash, which then reboots.`}
+        </div>
+      </div>
+      <button
+        type="button"
+        disabled={!canProvision}
+        title={canProvision ? undefined : blockedNote}
+        onClick={onProvision}
+        className={cn(
+          'ml-auto shrink-0 whitespace-nowrap border px-4 py-2 text-[12.5px] font-bold',
+          canProvision
+            ? 'cursor-pointer border-ui-ink bg-transparent text-ui-ink hover:bg-ui-panel'
+            : 'cursor-not-allowed border-ui-line bg-transparent text-ui-faint'
+        )}
+      >
+        {busy ? 'WRITING…' : 'WRITE PROFILE'}
+      </button>
+    </div>
+    {note !== null && <p className="mt-3 text-[13px] leading-[1.5] text-ui-muted">{note}</p>}
+  </div>
+)

--- a/src/routes/DeviceRoute.tsx
+++ b/src/routes/DeviceRoute.tsx
@@ -21,6 +21,8 @@ import { useProjectFileActions } from '../hooks/useProjectFileActions'
 import { useCatalogueIndex } from '../hooks/useCatalogueIndex'
 import { ecuLabelForKey } from '../utils/ecu-label'
 import { useDisplayUnits } from '../hooks/useDisplayUnits'
+import { provisionMessage, useProvisionBoardProfile } from '../hooks/useProvisionBoardProfile'
+import { BoardProfileRow } from '../components/device/BoardProfileRow'
 import { useResolvedBoardProfile } from '../hooks/useResolvedBoardProfile'
 import { UNIT_SYSTEM_OPTIONS } from '../constants/units'
 import type { UnitSystem } from '@canshift/core'
@@ -32,6 +34,12 @@ const BRIGHTNESS_STEPS = [20, 40, 60, 80, 100]
 const displayFact = (screen: { width: number; height: number }, driver: string | null): string => {
   const size = `${String(screen.width)} × ${String(screen.height)}`
   return driver === null ? size : `${driver.toUpperCase()} · ${size}`
+}
+
+const provisionBlockedNote = (hasBoard: boolean, linked: boolean): string => {
+  if (!hasBoard) return 'No board picked — choose one in the board definition below.'
+  if (!linked) return 'Connect the dash over USB to write its board profile.'
+  return ''
 }
 
 const TRANSPORT = 'USB CDC'
@@ -59,6 +67,7 @@ const DeviceRoute = () => {
   const catalogue = useCatalogueIndex()
   const units = useDisplayUnits()
   const panelDriver = useResolvedBoardProfile()?.profile.lcd.driver ?? null
+  const provision = useProvisionBoardProfile()
   const { fileInputRef, exportProjectFile, openImportPicker, handleImportChange } =
     useProjectFileActions()
   const [advancedOpen, setAdvancedOpen] = useState(false)
@@ -146,6 +155,15 @@ const DeviceRoute = () => {
               }}
             />
           </div>
+          <BoardProfileRow
+            boardName={provision.resolved?.profile.boardName ?? null}
+            canProvision={provision.canProvision}
+            busy={provision.state.kind === 'writing'}
+            blockedNote={provisionBlockedNote(provision.resolved !== null, provision.linked)}
+            note={provisionMessage(provision.state)}
+            onProvision={provision.provision}
+          />
+
           <button
             type="button"
             onClick={() => {


### PR DESCRIPTION
Closes #266.

`BoardProfileProvision` was removed with the old Firmware route in #265. Half of it survived as an action on the Flash pane's DONE block — the case that matters after a full flash, which wipes NVS. The other half had no home: **writing a profile to an already-running dash**, which is what you do after picking a different board, or after the firmware rejected the one it had.

DEVICE now carries it, under SETTINGS beside the board definition it describes:

> **BOARD PROFILE** · Writes Elecrow CrowPanel 2.8″ ESP32 to the dash, which then reboots. · `WRITE PROFILE`

The button is disabled until there is something to write and somewhere to write it, and says which is missing rather than greying out silently — *"No board picked — choose one in the board definition below"* or *"Connect the dash over USB to write its board profile"*. The outcome prints under the row through `provisionMessage`, so all five states of the write say something, including `unknown_board_id` from #277.

No new transport work: `useProvisionBoardProfile` already picks the id form for a catalogue board and the blob for a custom one.

## Test plan

- `typecheck` · `lint` · `test` (488) · `build` — green.
- Rendered at 1440 × 900: with no board picked the row reads *"Pick a board in the board definition below before writing a profile to the dash."* and `WRITE PROFILE` is disabled, which is the state a fresh profile is in.
- **Not verified on hardware** — the write itself needs a board.