### PR TITLE
feat(tuner): a page can override the top bar's centre and right slot

### DIFF
--- a/src/components/editor/DashTopBar.tsx
+++ b/src/components/editor/DashTopBar.tsx
@@ -1,8 +1,9 @@
 import { useRef, type PointerEvent } from 'react'
-import type { TopBarConfig, TopBarItem } from '@canshift/core'
+import type { TopBarConfig, TopBarItem, PageStatusRow } from '@canshift/core'
 import { DEFAULT_TOP_BAR_LAYOUT, TopBarMetrics } from '@canshift/core'
 import { cva } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
+import { mergePageStatusRow } from '../../lib/top-bar-layout'
 
 const SWIPE_DOWN_THRESHOLD = 18
 
@@ -73,6 +74,7 @@ const formatPreviewSignal = (signal: string, format?: string): string => {
 
 export interface DashTopBarProps {
   topBar: TopBarConfig
+  statusRow?: PageStatusRow | undefined
   scale: number
   settingsOpen: boolean
   isDayMode: boolean
@@ -81,6 +83,7 @@ export interface DashTopBarProps {
 
 export const DashTopBar = ({
   topBar,
+  statusRow,
   scale,
   settingsOpen,
   isDayMode,
@@ -112,7 +115,7 @@ export const DashTopBar = ({
   const dropStaleSeparators = (items: readonly TopBarItem[]): readonly TopBarItem[] =>
     items.filter((it, i) => it.type !== 'separator' || items[i - 1]?.type === 'modeFlag')
 
-  const layout: readonly TopBarItem[] = topBar.layout ?? DEFAULT_TOP_BAR_LAYOUT
+  const layout = mergePageStatusRow(topBar.layout ?? DEFAULT_TOP_BAR_LAYOUT, statusRow)
   const leftItems = dropStaleSeparators(layout.filter((it) => it.position === 'left'))
   const centerItems = dropStaleSeparators(layout.filter((it) => it.position === 'center'))
   const rightItems = dropStaleSeparators(layout.filter((it) => it.position === 'right'))

--- a/src/components/editor/canvas/page-frame.tsx
+++ b/src/components/editor/canvas/page-frame.tsx
@@ -62,6 +62,7 @@ export const PageFrame = ({
     {page.showTopBar !== false && (
       <DashTopBar
         topBar={topBar}
+        statusRow={page.statusRow}
         scale={scale}
         settingsOpen={interaction?.settingsOpen ?? false}
         isDayMode={isDayMode}

--- a/src/lib/top-bar-layout.test.ts
+++ b/src/lib/top-bar-layout.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import type { PageStatusRow, TopBarItem } from '@canshift/core'
+import { mergePageStatusRow } from './top-bar-layout'
+
+const item = (position: TopBarItem['position'], text: string): TopBarItem =>
+  ({ type: 'label', text, position }) as TopBarItem
+
+const LAYOUT: TopBarItem[] = [item('left', 'CAN'), item('center', 'MAP'), item('right', 'LAP')]
+
+describe('mergePageStatusRow', () => {
+  it('leaves the layout alone when the page declares nothing', () => {
+    expect(mergePageStatusRow(LAYOUT, undefined)).toBe(LAYOUT)
+    expect(mergePageStatusRow(LAYOUT, {} as PageStatusRow)).toBe(LAYOUT)
+  })
+
+  it('replaces every base item at the position the page overrides', () => {
+    const merged = mergePageStatusRow(LAYOUT, { right: item('right', 'MAX OIL') } as PageStatusRow)
+    expect(merged.map((i) => (i as { text: string }).text)).toEqual(['CAN', 'MAP', 'MAX OIL'])
+  })
+
+  it('overrides both slots independently', () => {
+    const merged = mergePageStatusRow(LAYOUT, {
+      center: item('center', 'ALS ON'),
+      right: item('right', 'ARMED'),
+    } as PageStatusRow)
+    expect(merged.map((i) => (i as { text: string }).text)).toEqual(['CAN', 'ALS ON', 'ARMED'])
+  })
+
+  it('never touches the left slot, which no page can override', () => {
+    const merged = mergePageStatusRow([...LAYOUT, item('left', 'RATE')], {
+      right: item('right', 'PEAK'),
+    } as PageStatusRow)
+    expect(merged.filter((i) => i.position === 'left')).toHaveLength(2)
+  })
+
+  it('drops several base items at an overridden position, not just the first', () => {
+    const crowded = [item('right', 'A'), item('right', 'B'), item('left', 'CAN')]
+    const merged = mergePageStatusRow(crowded, { right: item('right', 'ONE') } as PageStatusRow)
+    expect(merged.map((i) => (i as { text: string }).text)).toEqual(['CAN', 'ONE'])
+  })
+})

--- a/src/lib/top-bar-layout.ts
+++ b/src/lib/top-bar-layout.ts
@@ -1,0 +1,19 @@
+import type { PageStatusRow, TopBarItem } from '@canshift/core'
+
+type OverridablePosition = 'center' | 'right'
+
+const OVERRIDABLE: readonly OverridablePosition[] = ['center', 'right']
+
+export const mergePageStatusRow = (
+  layout: readonly TopBarItem[],
+  statusRow: PageStatusRow | undefined
+): readonly TopBarItem[] => {
+  if (!statusRow) return layout
+  const overrides = OVERRIDABLE.map((position) => statusRow[position]).filter(
+    (item): item is TopBarItem => item !== undefined
+  )
+  if (overrides.length === 0) return layout
+  const taken = new Set(OVERRIDABLE.filter((position) => statusRow[position] !== undefined))
+  const kept = layout.filter((item) => !taken.has(item.position as OverridablePosition))
+  return [...kept, ...overrides]
+}


### PR DESCRIPTION
The last item of #153.

The comp gives every page its own right slot — `TRIP 128 km` on Street, `LAP 4 — 1:38.42` on Track, `MAX OIL 128` on Engine, `PEAK 1.61` on Tuning, `BEST 1:36.08` on Timing, `ARMED` on Controls. The tuner rendered one top bar for all six.

**It was not a schema gap.** `PageConfig.statusRow` — `{ center?, right? }` — has been in core all along, the firmware's config declares it, and `TopBar::applyPage` merges it. Only the tuner ignored it.

`mergePageStatusRow` mirrors `top_bar_build.cpp` exactly: a page that declares a slot **drops every base item at that position** and appends its own; a page that declares nothing gets the layout untouched. Left is never overridable, on either side.

## What this exposes

The firmware's own config only declares `statusRow` on Engine and Tuning. Street, Track, Timing and Controls fall back to the global right slot, so three of the comp's six per-page slots are missing from the shipped config. That is a firmware-config gap, not a rendering one — the tuner now renders whatever the config declares, and will show the other three the moment they are declared. Not touching the firmware for it.

## Test plan

- `typecheck` · `lint` · `test` (498) · `build` — green.
- `top-bar-layout.test.ts`: no override leaves the array identical; one override replaces every base item at that position; both slots override independently; the left slot is never touched; several base items at an overridden position are all dropped, not just the first.
- Rendered the six pages at 1440 × 900: Engine reads `MAX OIL 95`, Tuning reads `PEAK --` (no maximum seen yet in simulation), the other four keep `LAP 4 1:38.42`. No console errors.