### PR TITLE
fix(tuner): the canvas sizes values the way the device does, and scales them

### DIFF
--- a/src/components/editor/WidgetBox.tsx
+++ b/src/components/editor/WidgetBox.tsx
@@ -184,6 +184,7 @@ export const WidgetBox = memo(function WidgetBox({
         palette={palette}
         displayW={displayW}
         displayH={displayH}
+        scale={scale}
         revLimiting={revLimiting}
       />
     </div>

--- a/src/components/editor/WidgetPreview.tsx
+++ b/src/components/editor/WidgetPreview.tsx
@@ -40,6 +40,7 @@ interface RenderContext {
   danger: boolean
   signalUnit: string
   unbound: boolean
+  scale: number
 }
 
 type WidgetTypeKey = WidgetConfig['type']
@@ -73,6 +74,7 @@ const RENDERERS: RendererDispatch = {
         testValue={ctx.testValue}
         signalUnit={ctx.signalUnit}
         unbound={ctx.unbound}
+        scale={ctx.scale}
       />
     )
   },
@@ -88,7 +90,9 @@ const RENDERERS: RendererDispatch = {
       cycleStateIndex={ctx.cycleStateIndex}
     />
   ),
-  gear: (widget, ctx) => <GearPreview widget={widget} w={ctx.w} h={ctx.h} unbound={ctx.unbound} />,
+  gear: (widget, ctx) => (
+    <GearPreview widget={widget} w={ctx.w} h={ctx.h} unbound={ctx.unbound} scale={ctx.scale} />
+  ),
   timer: (widget, ctx) => <TimerPreview widget={widget} w={ctx.w} h={ctx.h} />,
   image: (widget, ctx) => <ImagePreview widget={widget} w={ctx.w} h={ctx.h} />,
 }
@@ -97,6 +101,7 @@ interface WidgetPreviewProps {
   widget: Widget
   displayW: number
   displayH: number
+  scale?: number
   palette?: PagePalette
   revLimiting?: boolean
   buttonState?: ControlState
@@ -122,6 +127,7 @@ const WidgetPreviewImpl = ({
   widget,
   displayW: rawW,
   displayH: rawH,
+  scale = 1,
   palette,
   revLimiting = false,
   buttonState = 'off',
@@ -148,6 +154,7 @@ const WidgetPreviewImpl = ({
     danger,
     signalUnit,
     unbound,
+    scale,
   }
 
   const render = RENDERERS[resolved.config.type]

--- a/src/components/editor/property-panel/button-fields.tsx
+++ b/src/components/editor/property-panel/button-fields.tsx
@@ -92,6 +92,7 @@ export const ButtonFields = ({ widget, onChange }: ConfigFieldsProps) => {
               widget={widget}
               displayW={previewW}
               displayH={previewH}
+              scale={previewScale}
               buttonState={previewState}
               cycleStateIndex={cfg.mode === 'cycle' ? clampedPreviewIdx : undefined}
             />

--- a/src/components/editor/widget-previews/GaugeArc.tsx
+++ b/src/components/editor/widget-previews/GaugeArc.tsx
@@ -1,5 +1,10 @@
 import { memo } from 'react'
-import { GAUGE_ARC, GAUGE_TRACK_COLORS, STALE_PLACEHOLDER, deviceValueFontPx } from '@canshift/core'
+import {
+  GAUGE_ARC,
+  GAUGE_TRACK_COLORS,
+  STALE_PLACEHOLDER,
+  gaugeValueFontSize,
+} from '@canshift/core'
 import { cn } from '@/lib/utils'
 import { WIDGET_DIM_COLOR, thresholdPct } from '../widget-preview.styles'
 import { effectiveValue, gaugeArcD } from './gauge-math'
@@ -7,6 +12,7 @@ import { type BaseRendererProps, formatSignalLabel } from './shared'
 import { MONO_FONT, UI_FONT, UI_LABEL_TRACKING, UI_LABEL_WEIGHT } from '../../../lib/typography'
 
 export interface GaugeArcRendererProps extends BaseRendererProps {
+  scale: number
   revLimiting: boolean
   danger: boolean
   testValue?: number | null
@@ -25,6 +31,7 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
   danger,
   testValue,
   unbound = false,
+  scale,
 }: GaugeArcRendererProps) {
   if (widget.config.type !== 'gauge') return null
   const cfg = widget.config
@@ -50,8 +57,7 @@ export const GaugeArcPreview = memo(function GaugeArcPreview({
   const revFlash = cfg.revFlash === true
   const showRevFlash = revFlash && revLimiting
 
-  const autoValueSize = Math.max(11, Math.min(r * 0.55, h * 0.3, 42))
-  const valueFontSize = cfg.big !== undefined ? deviceValueFontPx(cfg.big) : autoValueSize
+  const valueFontSize = gaugeValueFontSize(h / scale, cfg.big) * scale
 
   return (
     <svg width={w} height={h} className="block overflow-hidden" aria-hidden="true">

--- a/src/components/editor/widget-previews/GaugeNumeric.tsx
+++ b/src/components/editor/widget-previews/GaugeNumeric.tsx
@@ -3,7 +3,7 @@ import {
   SECONDARY_BAR,
   STALE_PLACEHOLDER,
   WIDGET_TOP_RULE,
-  deviceValueFontPx,
+  gaugeValueFontSize,
   valueUnitFontSize,
   widgetTopRulePx,
 } from '@canshift/core'
@@ -38,6 +38,7 @@ export interface GaugeNumericRendererProps extends BaseRendererProps {
   testValue?: number | null
   signalUnit: string
   unbound?: boolean
+  scale: number
 }
 
 export const GaugeNumericPreview = memo(function GaugeNumericPreview({
@@ -48,6 +49,7 @@ export const GaugeNumericPreview = memo(function GaugeNumericPreview({
   testValue,
   signalUnit,
   unbound = false,
+  scale,
 }: GaugeNumericRendererProps) {
   if (widget.config.type !== 'gauge') return null
   const cfg = widget.config
@@ -63,12 +65,9 @@ export const GaugeNumericPreview = memo(function GaugeNumericPreview({
 
   const signalLabel = formatSignalLabel(widget.signal)
   const sigHeaderH = 14
-  const availH = h - sigHeaderH
 
   const valueStr = String(valueOnly)
-  const charBudget = valueStr.length + prefix.length + signalUnit.length * 0.45
-  const autoSize = Math.max(10, Math.min(availH * 0.85, (w - 16) / (charBudget * 0.68)))
-  const fontSize = cfg.big !== undefined ? deviceValueFontPx(cfg.big) : autoSize
+  const fontSize = gaugeValueFontSize(h / scale, cfg.big) * scale
   const rulePx = widgetTopRulePx(Math.round(fontSize))
   const ruleColor = danger
     ? WIDGET_TOP_RULE.dangerColor

--- a/src/components/editor/widget-previews/Gear.tsx
+++ b/src/components/editor/widget-previews/Gear.tsx
@@ -3,6 +3,7 @@ import {
   STALE_PLACEHOLDER,
   WIDGET_TOP_RULE,
   deviceValueFontPx,
+  gearFontSize,
   widgetTopRulePx,
 } from '@canshift/core'
 import { cn } from '@/lib/utils'
@@ -16,30 +17,21 @@ const VALUE_ROW = 'flex w-full shrink-0 items-center justify-center'
 const VALUE = 'inline-block w-full text-center font-mono font-extrabold leading-none'
 
 interface GearRendererProps extends BaseRendererProps {
+  scale: number
   unbound?: boolean
 }
-
-const AUTO_FONT_MIN_PX = 10
-const AUTO_FONT_MAX_PX = 48
-const AUTO_FONT_WIDTH_RATIO = 0.72
-const AUTO_FONT_HEIGHT_RATIO = 0.85
-
-const autoFontPx = (w: number, h: number): number =>
-  Math.max(
-    AUTO_FONT_MIN_PX,
-    Math.min(AUTO_FONT_MAX_PX, w * AUTO_FONT_WIDTH_RATIO, h * AUTO_FONT_HEIGHT_RATIO)
-  )
 
 export const GearPreview = memo(function GearPreview({
   widget,
   w,
   h,
   unbound = false,
+  scale,
 }: GearRendererProps) {
   if (widget.config.type !== 'gear') return null
   const cfg = widget.config
   const st = widget.style
-  const fontSize = cfg.big !== undefined ? deviceValueFontPx(cfg.big) : autoFontPx(w, h)
+  const fontSize = cfg.big !== undefined ? deviceValueFontPx(cfg.big) * scale : gearFontSize(w, h)
   const rulePx = widgetTopRulePx(Math.round(fontSize))
   const ruleColor = rulePx === WIDGET_TOP_RULE.primaryPx ? st.textColor : WIDGET_TOP_RULE.trackColor
 

--- a/src/components/editor/widget-previews/value-font.test.ts
+++ b/src/components/editor/widget-previews/value-font.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { gaugeValueFontSize, gearFontSize } from '@canshift/core'
+
+const GAUGE_CPP = resolve(
+  import.meta.dirname,
+  '../../../../../canshift-firmware/src/ui/widgets/gauge_widget.cpp'
+)
+
+const constant = (source: string, name: string): number | null => {
+  const match = new RegExp(`constexpr\\s+\\w+\\s+${name}\\s*=\\s*(\\d+)`).exec(source)
+  return match ? Number(match[1]) : null
+}
+
+describe('the value font follows the device, not the box', () => {
+  it('steps rather than scaling continuously', () => {
+    expect(gaugeValueFontSize(120, undefined)).toBe(48)
+    expect(gaugeValueFontSize(90, undefined)).toBe(48)
+    expect(gaugeValueFontSize(89, undefined)).toBe(17)
+    expect(gaugeValueFontSize(40, undefined)).toBe(17)
+    expect(gaugeValueFontSize(39, undefined)).toBe(10)
+  })
+
+  it('lets a declared class win over the box, in both directions', () => {
+    expect(gaugeValueFontSize(500, 64)).toBe(32)
+    expect(gaugeValueFontSize(20, 96)).toBe(48)
+  })
+
+  it('keeps a widget that declares a class larger than a short one that does not', () => {
+    const declared = gaugeValueFontSize(120, 64)
+    const shortBox = gaugeValueFontSize(50, undefined)
+    expect(declared).toBeGreaterThan(shortBox)
+  })
+
+  it('sizes a gear from both edges of its box', () => {
+    expect(gearFontSize(100, 100)).toBe(gearFontSize(100, 100))
+    expect(gearFontSize(20, 100)).toBeLessThan(gearFontSize(100, 100))
+  })
+})
+
+const describeIfFirmware = existsSync(GAUGE_CPP) ? describe : describe.skip
+
+describeIfFirmware('gauge value font firmware parity', () => {
+  const source = existsSync(GAUGE_CPP) ? readFileSync(GAUGE_CPP, 'utf8') : ''
+
+  it('uses the same breakpoints the firmware compiles in', () => {
+    expect(constant(source, 'kValueFontHeightPrimary')).toBe(90)
+    expect(constant(source, 'kValueFontSizePrimary')).toBe(48)
+    expect(constant(source, 'kValueFontHeightSecondary')).toBe(40)
+    expect(constant(source, 'kValueFontSizeSecondary')).toBe(17)
+    expect(constant(source, 'kValueFontSizeUnits')).toBe(10)
+  })
+})


### PR DESCRIPTION
Continues #153. Two faults, one visible symptom: the value hierarchy on the canvas was inverted against the design comp.

## The device steps, the canvas fitted

`gauge_widget.cpp` sizes a value in three steps from the box height — `≥ 90 px → 48`, `≥ 40 px → 17`, else `10` — unless the widget declares a class, in which case `big` wins outright. The tuner fitted the value continuously to the box instead.

The result on Engine: WATER, OIL T, OIL PRESS and FUEL PRESS all declare `big: 64` and rendered **small**, while GEARBOX, DIFF and BATT declare nothing and rendered **huge** by filling their boxes. The comp says the opposite, and so does the glass.

**Core already had the rule.** `gaugeValueFontSize(height, big)` implements those exact breakpoints, and `gearFontSize` the gear's 0.72/0.85 ratios. The previews rolled their own instead — `Math.min(availH * 0.85, (w - 16) / (charBudget * 0.68))` for the numeric gauge, `Math.min(r * 0.55, h * 0.3, 42)` for the arc, and a hand-copy of the gear ratios. All three now call core.

## The canvas scale was missing

The second fault, and the one that made every declared class look wrong: `deviceValueFontPx(big)` returns **device** pixels, and the preview applied it as CSS pixels inside a box already multiplied by the canvas scale. At the default zoom that is ~2.5×, so a widget asking for a 32 px device face rendered at 32 CSS px in a box drawn 2.5× too large.

`WidgetPreview` now carries the canvas `scale`, converts the box back to device space before asking core, and multiplies the answer. The gear's ratio path was accidentally correct — ratios of an already-scaled box — and stays as it is.

## Result

Street reads SPEED and GEAR as heroes, RPM at mid, WATER and FUEL smaller, BATT and ODO small. Engine reads its four primaries large over three small ones. Both match the comp.

## Test plan

- `typecheck` · `lint` · `test` (503) · `build` — green.
- `value-font.test.ts`: the size steps rather than scaling (90 → 48, 89 → 17, 40 → 17, 39 → 10); a declared class beats the box in both directions; a widget that declares a class stays larger than a short one that does not; and a parity block asserting the five breakpoint constants against `gauge_widget.cpp`.
- Six pages rendered at 1440 × 900 and compared to `CANShift Dash Pages.dc.html`.