### PR TITLE
feat(tuner): every grid path resolves the panel's tier instead of assuming 12 × 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "canshift-tuner",
       "version": "0.1.0",
       "dependencies": {
-        "@canshift/core": "^8.3.0",
+        "@canshift/core": "^8.4.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@canshift/core": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-8.3.0.tgz",
-      "integrity": "sha512-vo94B6lNusJNff5Ottqh07Ku82pqTHBZjP6hascx9SHMOvQLeAFx6zuAQvU76xgugTi1uqsyno+yR9MJGCi4GA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@canshift/core/-/core-8.4.0.tgz",
+      "integrity": "sha512-a2oC6jLSUR4Hn6OrqEsKxBWQ/wDejdTZzaH3sp/6Q83E1qyhAsNt+bNTEqWUdd/ups4b0s89wWSw9VrSq5z1lw==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@canshift/core": "^8.3.0",
+    "@canshift/core": "^8.4.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.23",

--- a/src/components/editor/Canvas.tsx
+++ b/src/components/editor/Canvas.tsx
@@ -27,6 +27,7 @@ import { useCarouselScale } from '../../hooks/useCarouselScale'
 import { useCanvasDialogs } from '../../hooks/useCanvasDialogs'
 import { resolveBgColor, resolvePalette } from '../../hooks/useEffectivePalette'
 import { useActiveDayMode } from '../../hooks/useActiveDayMode'
+import { useDisplayTier } from '../../hooks/useDisplayTier'
 import { PreviewOverlay } from './preview/PreviewOverlay'
 import type { PreviewMode } from './preview/preview-modes'
 
@@ -56,6 +57,7 @@ const Canvas = ({
   const pages = useDashboardStore((s) => s.config?.pages ?? EMPTY_PAGES)
   const theme = useDashboardStore((s) => s.config?.theme)
   const isDayMode = useActiveDayMode()
+  const tier = useDisplayTier()
 
   const selectedWidgetId = useDashboardStore((s) => s.selectedWidgetId)
   const selectedWidgetIds = useDashboardStore((s) => s.selectedWidgetIds)
@@ -104,7 +106,10 @@ const Canvas = ({
   const { revLimiting, flashPhase, startRevLimiter } = useRevLimiterFlash()
 
   const overlappingIds = useMemo(() => overlappingWidgetIds(page.widgets), [page.widgets])
-  const overflowingIds = useMemo(() => overflowingWidgetIds(page.widgets), [page.widgets])
+  const overflowingIds = useMemo(
+    () => overflowingWidgetIds(page.widgets, tier),
+    [page.widgets, tier]
+  )
 
   useCanvasKeyboard({
     selectWidget,
@@ -254,6 +259,7 @@ const Canvas = ({
                   }}
                 >
                   <PageFrame
+                    tracks={tier}
                     page={candidate}
                     topBar={topBar}
                     scale={candidate.id === page.id ? scale : scale * THUMBNAIL_RATIO}

--- a/src/components/editor/canvas/grid-guides.tsx
+++ b/src/components/editor/canvas/grid-guides.tsx
@@ -1,31 +1,38 @@
 import { useMemo } from 'react'
-import { LAYOUT_GRID, resolveGridRect } from '@canshift/core'
+import { BASE_GRID_TRACKS, resolveGridRect } from '@canshift/core'
+import type { GridTracks } from '@canshift/core'
 
 export interface GridGuidesProps {
   areaWidth: number
   areaHeight: number
   effScale: number
+  tracks?: GridTracks
 }
 
 const VERTICAL_GUIDE = 'absolute bottom-0 top-0 w-px bg-[#FFFFFF0A]'
 
 const HORIZONTAL_GUIDE = 'absolute left-0 right-0 h-px bg-[#FFFFFF0A]'
 
-export const GridGuides = ({ areaWidth, areaHeight, effScale }: GridGuidesProps) => {
+export const GridGuides = ({
+  areaWidth,
+  areaHeight,
+  effScale,
+  tracks = BASE_GRID_TRACKS,
+}: GridGuidesProps) => {
   const guides = useMemo(() => {
     const area = { width: areaWidth, height: areaHeight }
     const verticals: number[] = []
-    for (let c = 0; c < LAYOUT_GRID.COLUMNS; c++) {
-      const r = resolveGridRect({ col: c, colSpan: 1, row: 0, rowSpan: 1 }, area)
+    for (let c = 0; c < tracks.columns; c++) {
+      const r = resolveGridRect({ col: c, colSpan: 1, row: 0, rowSpan: 1 }, area, tracks)
       verticals.push(r.x, r.x + r.w)
     }
     const horizontals: number[] = []
-    for (let r = 0; r < LAYOUT_GRID.ROWS; r++) {
-      const rect = resolveGridRect({ col: 0, colSpan: 1, row: r, rowSpan: 1 }, area)
+    for (let r = 0; r < tracks.rows; r++) {
+      const rect = resolveGridRect({ col: 0, colSpan: 1, row: r, rowSpan: 1 }, area, tracks)
       horizontals.push(rect.y, rect.y + rect.h)
     }
     return { verticals, horizontals }
-  }, [areaWidth, areaHeight])
+  }, [areaWidth, areaHeight, tracks])
 
   return (
     <div className="pointer-events-none absolute inset-0">

--- a/src/components/editor/canvas/page-frame.tsx
+++ b/src/components/editor/canvas/page-frame.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes, ReactNode, Ref } from 'react'
-import type { PageConfig, PagePalette, TopBarConfig, Widget } from '@canshift/core'
+import type { GridTracks, PageConfig, PagePalette, TopBarConfig, Widget } from '@canshift/core'
 import { DashTopBar } from '../DashTopBar'
 import { GridGuides } from './grid-guides'
 import { WidgetLayer } from './widget-layer'
@@ -31,6 +31,7 @@ export interface PageFrameProps {
   scale: number
   palette: PagePalette
   bgColor: string
+  tracks: GridTracks
   isDayMode: boolean
   areaWidth: number
   areaHeight: number
@@ -46,6 +47,7 @@ export const PageFrame = ({
   scale,
   palette,
   bgColor,
+  tracks,
   isDayMode,
   areaWidth,
   areaHeight,
@@ -74,7 +76,7 @@ export const PageFrame = ({
       {...(interaction?.surfaceProps ?? {})}
       className="relative flex-1 cursor-default overflow-hidden"
     >
-      <GridGuides areaWidth={areaWidth} areaHeight={areaHeight} effScale={scale} />
+      <GridGuides areaWidth={areaWidth} areaHeight={areaHeight} effScale={scale} tracks={tracks} />
       <WidgetLayer
         groundColor={bgColor}
         page={page}

--- a/src/hooks/useDragState.ts
+++ b/src/hooks/useDragState.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, type MouseEvent as ReactMouseEvent, type RefObject } from 'react'
 import type { Widget } from '@canshift/core'
 import { LAYOUT_GRID, clampGridPlacement } from '@canshift/core'
+import { useDisplayTier } from './useDisplayTier'
 import { useDashboardStore } from '../stores/dashboard.store'
 
 interface DraggingWidget {
@@ -55,6 +56,7 @@ export const useDragState = ({
   zoomRef,
   scale,
 }: UseDragStateOptions): ((e: ReactMouseEvent, widget: Widget) => void) => {
+  const tier = useDisplayTier()
   const moveWidget = useDashboardStore((s) => s.moveWidget)
   const moveWidgets = useDashboardStore((s) => s.moveWidgets)
   const resolveWidgetCollisions = useDashboardStore((s) => s.resolveWidgetCollisions)
@@ -100,8 +102,8 @@ export const useDragState = ({
         began: false,
       }
 
-      const colPitch = trackPitch(canvasW, LAYOUT_GRID.COLUMNS)
-      const rowPitch = trackPitch(widgetAreaH, LAYOUT_GRID.ROWS)
+      const colPitch = trackPitch(canvasW, tier.columns)
+      const rowPitch = trackPitch(widgetAreaH, tier.rows)
 
       const handleMouseMove = (ev: MouseEvent) => {
         const drag = dragRef.current
@@ -119,7 +121,7 @@ export const useDragState = ({
               drag.widgets,
               (w) => w.startCol,
               (w) => w.colSpan,
-              LAYOUT_GRID.COLUMNS
+              tier.columns
             )
           : rawDeltaCols
         const deltaRows = drag.isMulti
@@ -128,17 +130,20 @@ export const useDragState = ({
               drag.widgets,
               (w) => w.startRow,
               (w) => w.rowSpan,
-              LAYOUT_GRID.ROWS
+              tier.rows
             )
           : rawDeltaRows
 
         const place = (dw: DraggingWidget): { id: string; col: number; row: number } => {
-          const clamped = clampGridPlacement({
-            col: dw.startCol + deltaCols,
-            colSpan: dw.colSpan,
-            row: dw.startRow + deltaRows,
-            rowSpan: dw.rowSpan,
-          })
+          const clamped = clampGridPlacement(
+            {
+              col: dw.startCol + deltaCols,
+              colSpan: dw.colSpan,
+              row: dw.startRow + deltaRows,
+              rowSpan: dw.rowSpan,
+            },
+            tier
+          )
           return { id: dw.id, col: clamped.col, row: clamped.row }
         }
 
@@ -178,6 +183,15 @@ export const useDragState = ({
       window.addEventListener('mousemove', handleMouseMove)
       window.addEventListener('mouseup', handleMouseUp)
     },
-    [dragInputsRef, zoomRef, scale, moveWidget, moveWidgets, resolveWidgetCollisions, beginDrag]
+    [
+      dragInputsRef,
+      zoomRef,
+      scale,
+      moveWidget,
+      moveWidgets,
+      resolveWidgetCollisions,
+      beginDrag,
+      tier,
+    ]
   )
 }

--- a/src/hooks/useResizeState.ts
+++ b/src/hooks/useResizeState.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, type PointerEvent as ReactPointerEvent, type RefObject } from 'react'
 import type { Widget } from '@canshift/core'
 import { LAYOUT_GRID } from '@canshift/core'
+import { useDisplayTier } from './useDisplayTier'
 import { useDashboardStore } from '../stores/dashboard.store'
 
 const MIN_SPAN = 1
@@ -31,6 +32,7 @@ export const useResizeState = ({
   inputsRef,
   scaleRef,
 }: UseResizeStateOptions): ((e: ReactPointerEvent, widget: Widget) => void) => {
+  const tier = useDisplayTier()
   const moveWidget = useDashboardStore((s) => s.moveWidget)
   const beginDrag = useDashboardStore((s) => s.beginDrag)
   const stateRef = useRef<ResizeState | null>(null)
@@ -51,7 +53,7 @@ export const useResizeState = ({
         lastSpan: widget.layout.colSpan,
       }
 
-      const pitch = trackPitch(inputs.canvasW, LAYOUT_GRID.COLUMNS)
+      const pitch = trackPitch(inputs.canvasW, tier.columns)
       let began = false
 
       const onMove = (ev: PointerEvent) => {
@@ -59,7 +61,7 @@ export const useResizeState = ({
         if (!state) return
         const scale = scaleRef.current ?? 1
         const deltaCols = Math.round((ev.clientX - state.startX) / (pitch * scale))
-        const maxSpan = LAYOUT_GRID.COLUMNS - state.startCol
+        const maxSpan = tier.columns - state.startCol
         const nextSpan = Math.min(maxSpan, Math.max(MIN_SPAN, state.startSpan + deltaCols))
         if (nextSpan === state.lastSpan) return
         if (!began) {
@@ -79,6 +81,6 @@ export const useResizeState = ({
       window.addEventListener('pointermove', onMove)
       window.addEventListener('pointerup', onUp)
     },
-    [inputsRef, scaleRef, moveWidget, beginDrag]
+    [inputsRef, scaleRef, moveWidget, beginDrag, tier]
   )
 }

--- a/src/lib/grid-tracks.test.ts
+++ b/src/lib/grid-tracks.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import type { DashboardConfig } from '@canshift/core'
+import { DISPLAY_TIERS } from '@canshift/core'
+import { gridTracksForConfig, gridTracksForProfile } from './grid-tracks'
+
+describe('gridTracksForProfile', () => {
+  it('resolves every catalogued panel through the tier rule, not a constant', () => {
+    const tracks = gridTracksForProfile(undefined)
+    expect(tracks.columns).toBe(DISPLAY_TIERS.base.columns)
+    expect(tracks.rows).toBe(DISPLAY_TIERS.base.rows)
+  })
+
+  it('gives a config with no target profile the same grid as the default panel', () => {
+    expect(gridTracksForConfig(null)).toEqual(gridTracksForProfile(undefined))
+    expect(gridTracksForConfig({ pages: [] } as unknown as DashboardConfig)).toEqual(
+      gridTracksForProfile(undefined)
+    )
+  })
+})

--- a/src/lib/grid-tracks.ts
+++ b/src/lib/grid-tracks.ts
@@ -1,0 +1,10 @@
+import { resolveScreenProfile, tierForPanel } from '@canshift/core'
+import type { DashboardConfig, GridTracks, ScreenProfileId } from '@canshift/core'
+
+export const gridTracksForProfile = (targetProfile: ScreenProfileId | undefined): GridTracks => {
+  const screen = resolveScreenProfile(targetProfile)
+  return tierForPanel(screen.width, screen.height)
+}
+
+export const gridTracksForConfig = (config: DashboardConfig | null): GridTracks =>
+  gridTracksForProfile(config?.targetProfile)

--- a/src/stores/dashboard/clipboard.slice.ts
+++ b/src/stores/dashboard/clipboard.slice.ts
@@ -4,6 +4,7 @@ import { clampGridPlacement, placementsOverlap } from '@canshift/core'
 import { autoPlace } from '../../utils/layout'
 import { pushHistory, toPlacement, widgetRef } from './helpers'
 import type { ClipboardSlice, SliceCreator } from './types'
+import { gridTracksForConfig } from '../../lib/grid-tracks'
 
 export const createClipboardSlice: SliceCreator<ClipboardSlice> = (set) => ({
   clipboardWidgets: [],
@@ -40,7 +41,10 @@ export const createClipboardSlice: SliceCreator<ClipboardSlice> = (set) => ({
         ]
         let pos: { col: number; row: number } | null = null
         for (const cand of candidates) {
-          const placement = clampGridPlacement({ col: cand.col, colSpan, row: cand.row, rowSpan })
+          const placement = clampGridPlacement(
+            { col: cand.col, colSpan, row: cand.row, rowSpan },
+            gridTracksForConfig(s.config)
+          )
           if (!others.some((o) => placementsOverlap(placement, o))) {
             pos = { col: placement.col, row: placement.row }
             break
@@ -106,11 +110,10 @@ export const createClipboardSlice: SliceCreator<ClipboardSlice> = (set) => ({
           : `Nudged ${String(targets.length)} widgets`
       )
       for (const w of targets) {
-        const clamped = clampGridPlacement({
-          ...w.layout,
-          col: w.layout.col + dCol,
-          row: w.layout.row + dRow,
-        })
+        const clamped = clampGridPlacement(
+          { ...w.layout, col: w.layout.col + dCol, row: w.layout.row + dRow },
+          gridTracksForConfig(s.config)
+        )
         w.layout.col = clamped.col
         w.layout.row = clamped.row
       }

--- a/src/stores/dashboard/layout-ops.slice.ts
+++ b/src/stores/dashboard/layout-ops.slice.ts
@@ -1,6 +1,7 @@
 import { clampGridPlacement } from '@canshift/core'
 import { pushHistory } from './helpers'
 import type { LayoutOpsSlice, SliceCreator } from './types'
+import { gridTracksForConfig } from '../../lib/grid-tracks'
 
 export const createLayoutOpsSlice: SliceCreator<LayoutOpsSlice> = (set) => ({
   alignWidgets: (pageId, widgetIds, direction) => {
@@ -40,7 +41,7 @@ export const createLayoutOpsSlice: SliceCreator<LayoutOpsSlice> = (set) => ({
             placement.row = Math.round((minRow + maxRow) / 2 - w.layout.rowSpan / 2)
             break
         }
-        const clamped = clampGridPlacement(placement)
+        const clamped = clampGridPlacement(placement, gridTracksForConfig(s.config))
         w.layout.col = clamped.col
         w.layout.row = clamped.row
       }
@@ -68,7 +69,10 @@ export const createLayoutOpsSlice: SliceCreator<LayoutOpsSlice> = (set) => ({
         const gap = (totalSpan - totalWidgetCols) / (sorted.length - 1)
         let curCol = first.layout.col
         for (const w of sorted) {
-          w.layout.col = clampGridPlacement({ ...w.layout, col: Math.round(curCol) }).col
+          w.layout.col = clampGridPlacement(
+            { ...w.layout, col: Math.round(curCol) },
+            gridTracksForConfig(s.config)
+          ).col
           curCol += w.layout.colSpan + gap
         }
       } else {
@@ -81,7 +85,10 @@ export const createLayoutOpsSlice: SliceCreator<LayoutOpsSlice> = (set) => ({
         const gap = (totalSpan - totalWidgetRows) / (sorted.length - 1)
         let curRow = first.layout.row
         for (const w of sorted) {
-          w.layout.row = clampGridPlacement({ ...w.layout, row: Math.round(curRow) }).row
+          w.layout.row = clampGridPlacement(
+            { ...w.layout, row: Math.round(curRow) },
+            gridTracksForConfig(s.config)
+          ).row
           curRow += w.layout.rowSpan + gap
         }
       }

--- a/src/stores/dashboard/widgets.slice.ts
+++ b/src/stores/dashboard/widgets.slice.ts
@@ -3,6 +3,7 @@ import { clampGridPlacement, isSpanOverflowing, placementsOverlap } from '@cansh
 import { autoPlace, resolveCollisions } from '../../utils/layout'
 import { pushHistory, toPlacement, widgetRef } from './helpers'
 import type { SliceCreator, WidgetsSlice } from './types'
+import { gridTracksForConfig } from '../../lib/grid-tracks'
 
 export const createWidgetsSlice: SliceCreator<WidgetsSlice> = (set) => ({
   addWidget: (pageId, widget) => {
@@ -32,7 +33,7 @@ export const createWidgetsSlice: SliceCreator<WidgetsSlice> = (set) => ({
         ]
         for (const cand of adjacent) {
           const placement = { col: cand.col, colSpan, row: cand.row, rowSpan }
-          if (isSpanOverflowing(placement)) continue
+          if (isSpanOverflowing(placement, gridTracksForConfig(s.config))) continue
           if (!others.some((o) => placementsOverlap(placement, o))) {
             pos = { col: cand.col, row: cand.row }
             break
@@ -86,7 +87,7 @@ export const createWidgetsSlice: SliceCreator<WidgetsSlice> = (set) => ({
         let pos: { col: number; row: number } | null = null
         for (const cand of candidates) {
           const placement = { col: cand.col, colSpan, row: cand.row, rowSpan }
-          if (isSpanOverflowing(placement)) continue
+          if (isSpanOverflowing(placement, gridTracksForConfig(s.config))) continue
           if (!others.some((o) => placementsOverlap(placement, o))) {
             pos = { col: cand.col, row: cand.row }
             break
@@ -165,7 +166,10 @@ export const createWidgetsSlice: SliceCreator<WidgetsSlice> = (set) => ({
             : `Edited ${widgetRef(existing)}`
       pushHistory(s, label)
       const merged = { ...existing, ...patch }
-      merged.layout = { ...clampGridPlacement(merged.layout), zOrder: merged.layout.zOrder }
+      merged.layout = {
+        ...clampGridPlacement(merged.layout, gridTracksForConfig(s.config)),
+        zOrder: merged.layout.zOrder,
+      }
       page.widgets[widgetIdx] = merged
       s.isDirty = true
     })

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,5 +1,6 @@
 import type { GridPlacement } from '@canshift/core'
-import { LAYOUT_GRID, clampGridPlacement, placementsOverlap } from '@canshift/core'
+import { BASE_GRID_TRACKS, clampGridPlacement, placementsOverlap } from '@canshift/core'
+import type { GridTracks } from '@canshift/core'
 
 export interface IdentifiedPlacement extends GridPlacement {
   id: string
@@ -17,12 +18,13 @@ export interface TrackPosition {
 
 export const autoPlace = (
   size: SpanSize,
-  others: readonly GridPlacement[]
+  others: readonly GridPlacement[],
+  tracks: GridTracks = BASE_GRID_TRACKS
 ): TrackPosition | null => {
-  const colSpan = Math.min(size.colSpan, LAYOUT_GRID.COLUMNS)
-  const rowSpan = Math.min(size.rowSpan, LAYOUT_GRID.ROWS)
-  for (let row = 0; row + rowSpan <= LAYOUT_GRID.ROWS; row++) {
-    for (let col = 0; col + colSpan <= LAYOUT_GRID.COLUMNS; col++) {
+  const colSpan = Math.min(size.colSpan, tracks.columns)
+  const rowSpan = Math.min(size.rowSpan, tracks.rows)
+  for (let row = 0; row + rowSpan <= tracks.rows; row++) {
+    for (let col = 0; col + colSpan <= tracks.columns; col++) {
       const candidate: GridPlacement = { col, colSpan, row, rowSpan }
       if (!others.some((o) => placementsOverlap(candidate, o))) return { col, row }
     }

--- a/src/utils/widget-diagnostics.ts
+++ b/src/utils/widget-diagnostics.ts
@@ -1,4 +1,5 @@
-import type { Widget } from '@canshift/core'
+import type { GridTracks, Widget } from '@canshift/core'
+import { BASE_GRID_TRACKS } from '@canshift/core'
 import { isSpanOverflowing, placementsOverlap } from '@canshift/core'
 
 export const overlappingWidgetIds = (widgets: readonly Widget[]): Set<string> => {
@@ -18,10 +19,13 @@ export const overlappingWidgetIds = (widgets: readonly Widget[]): Set<string> =>
   return ids
 }
 
-export const overflowingWidgetIds = (widgets: readonly Widget[]): Set<string> => {
+export const overflowingWidgetIds = (
+  widgets: readonly Widget[],
+  tracks: GridTracks = BASE_GRID_TRACKS
+): Set<string> => {
   const ids = new Set<string>()
   for (const w of widgets) {
-    if (isSpanOverflowing(w.layout)) ids.add(w.id)
+    if (isSpanOverflowing(w.layout, tracks)) ids.add(w.id)
   }
   return ids
 }


### PR DESCRIPTION
Closes #252. Consumes `@canshift/core` **8.4.0**, where the grid helpers gained a tier parameter (canshift-core#131).

#276 resolved the tier for the widget cap and stopped there, because `clampGridPlacement`, `resolveGridRect` and `isSpanOverflowing` took no tier — a `medium` panel would have resolved correctly and then been placed on the base grid anyway. Core fixed that, so the rest can follow.

## Every path that touches the grid

`gridTracksForConfig(config)` resolves the tier from the config's target profile, outside React, so the store slices can use it too:

- **placement** — `widgets.slice` (auto-place and merge), `layout-ops.slice` (align, distribute), `clipboard.slice` (paste, nudge)
- **rendering** — `grid-guides` draws the tier's tracks, `page-frame` passes it down, `Canvas` resolves it once
- **gestures** — `useDragState` (pitch, group delta clamp, drop clamp) and `useResizeState` (pitch, max span)
- **diagnostics** — `overflowingWidgetIds` takes the tier, so the overflow badge answers to the panel

`autoPlace` and `overflowingWidgetIds` default to `BASE_GRID_TRACKS`, so their tests and any other caller are unchanged.

## Nothing changes today, which is the point

Every board in the catalogue is 320 × 240 and resolves to `base`, so this PR is behaviour-preserving by construction — verified by re-rendering the six pages, which are identical to before. The value is that the tuner and the device now compute placement from the same rule, before there is hardware to disagree about it.

## Still open on canshift-core#131

The font ladder and the gutter/frame padding stay tier-independent. Both are design decisions rather than refactors — `BIG_TO_DEVICE_FONT` maps `big: 80 → 40 px` and `40` is not in `base.valueFaces`, so "snap into the tier's faces" would silently move every 80-token widget. Argued on the core issue.

## Test plan

- `typecheck` · `lint` · `test` (505) · `build` — green.
- `grid-tracks.test.ts`: the default panel resolves to the base tier's columns and rows, and a config with no target profile gets the same grid as no config at all.
- Six pages re-rendered at 1440 × 900: identical to before, no UNBOUND band, no console errors.