### PR TITLE
feat(tuner): a board resolves its build through its chip family

### DIFF
--- a/src/lib/firmware/board-resolution.ts
+++ b/src/lib/firmware/board-resolution.ts
@@ -1,3 +1,4 @@
+import { normalizeChip } from './manifest'
 import type { BoardManifest, BoardManifestEntry } from './manifest'
 
 export type BoardSource = 'detected' | 'default' | 'none'
@@ -19,8 +20,6 @@ export const resolveBoardSelection = (
   if (detected) return { boards, selectedId: detected.id, source: 'detected' }
   return { boards, selectedId: boards[0]?.id ?? null, source: 'default' }
 }
-
-const normalizeChip = (chip: string): string => chip.toLowerCase().replace(/[^a-z0-9]/g, '')
 
 export const chipFamiliesMatch = (expected: string, detected: string): boolean =>
   normalizeChip(expected) === normalizeChip(detected)

--- a/src/lib/firmware/flash.test.ts
+++ b/src/lib/firmware/flash.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   assertChipMatchesBoard,
+  chipIsSupported,
   flashFileArray,
   FlashError,
   handshakeFailureMessage,
@@ -45,6 +46,18 @@ describe('assertChipMatchesBoard', () => {
 
   it('passes when no board chip is known (old release / no manifest)', () => {
     expect(() => assertChipMatchesBoard(undefined, 'ESP32-S3')).not.toThrow()
+  })
+})
+
+describe('chipIsSupported', () => {
+  it('accepts both families CANShift publishes firmware for', () => {
+    expect(chipIsSupported('ESP32')).toBe(true)
+    expect(chipIsSupported('ESP32-S3')).toBe(true)
+  })
+
+  it('rejects a family that has no published firmware', () => {
+    expect(chipIsSupported('ESP32-C3')).toBe(false)
+    expect(chipIsSupported('ESP8266')).toBe(false)
   })
 })
 

--- a/src/lib/firmware/flash.ts
+++ b/src/lib/firmware/flash.ts
@@ -7,7 +7,7 @@ const PRE_RESET_BAUD = 115_200
 const MERGED_FLASH_OFFSET = 0x0
 const NVS_FLASH_OFFSET = 0x9000
 
-const SUPPORTED_CHIPS: readonly string[] = ['ESP32']
+const SUPPORTED_CHIPS: readonly string[] = ['esp32', 'esp32s3']
 
 const PRE_RESET_HOLD_MS = 250
 const PRE_RESET_SETTLE_MS = 600
@@ -68,12 +68,15 @@ export class UnsupportedChipError extends Error {
   readonly detectedChip: string
   constructor(detectedChip: string) {
     super(
-      `Refusing to flash — detected ${detectedChip}, CANShift firmware is built only for classic ESP32. Writing it onto a different family will brick the device.`
+      `Refusing to flash — detected ${detectedChip}, CANShift publishes firmware for ESP32 and ESP32-S3 only. Writing it onto a different family will brick the device.`
     )
     this.name = 'UnsupportedChipError'
     this.detectedChip = detectedChip
   }
 }
+
+export const chipIsSupported = (detectedChip: string): boolean =>
+  SUPPORTED_CHIPS.some((chip) => chipFamiliesMatch(chip, detectedChip))
 
 export const assertChipMatchesBoard = (
   expectedChip: string | undefined,
@@ -185,7 +188,7 @@ const handshake = async (
   const detectedChip = loader.chip.CHIP_NAME
   onLog(`Detected chip: ${detectedChip}`)
   assertChipMatchesBoard(expectedChip, detectedChip)
-  if (!SUPPORTED_CHIPS.includes(detectedChip)) throw new UnsupportedChipError(detectedChip)
+  if (!chipIsSupported(detectedChip)) throw new UnsupportedChipError(detectedChip)
 }
 
 const writeImages = async (

--- a/src/lib/firmware/manifest.test.ts
+++ b/src/lib/firmware/manifest.test.ts
@@ -52,6 +52,30 @@ const MANIFEST = JSON.stringify({
   ],
 })
 
+const SCHEMA_3_MANIFEST = JSON.stringify({
+  schema: 3,
+  version: '3.0.0',
+  tag: 'v3.0.0',
+  firmwares: {
+    esp32: {
+      merged: { file: 'canshift-esp32-v3.0.0-merged.bin', sha256: SHA },
+      firmware: { file: 'canshift-esp32-v3.0.0-firmware.bin', sha256: SHA },
+      spiffs: { file: 'canshift-esp32-v3.0.0-spiffs.bin', sha256: SHA },
+    },
+    esp32s3: {
+      merged: { file: 'canshift-esp32s3-v3.0.0-merged.bin', sha256: SHA },
+      firmware: { file: 'canshift-esp32s3-v3.0.0-firmware.bin', sha256: SHA },
+      spiffs: { file: 'canshift-esp32s3-v3.0.0-spiffs.bin', sha256: SHA },
+    },
+  },
+  boards: [
+    { id: 'crowpanel_28', chip: 'esp32', display: 'ILI9341 320x240', touch: 'XPT2046' },
+    { id: 'generic_ili9341_gt911', chip: 'esp32', display: 'ILI9341 320x240', touch: 'GT911' },
+    { id: 'waveshare_s3_28', chip: 'esp32s3', display: 'ST7789 240x320', touch: 'CST3530' },
+    { id: 'orphan_c3', chip: 'esp32c3', display: 'ST7789 240x320', touch: 'CST816S' },
+  ],
+})
+
 describe('parseManifest', () => {
   it('parses a well-formed manifest and its boards', () => {
     const manifest = parseManifest(MANIFEST)
@@ -73,6 +97,39 @@ describe('parseManifest', () => {
       sha256: SHA,
     })
     expect(findBoard(manifest, 'crowpanel_28')?.artifacts.spiffs.sha256).toBe(SHA)
+  })
+
+  it('resolves every board of a schema-3 manifest to its chip-family firmware', () => {
+    const manifest = parseManifest(SCHEMA_3_MANIFEST)
+    expect(manifest).not.toBeNull()
+    if (!manifest) return
+    expect(findBoard(manifest, 'crowpanel_28')?.artifacts.merged).toEqual({
+      file: 'canshift-esp32-v3.0.0-merged.bin',
+      sha256: SHA,
+    })
+    expect(findBoard(manifest, 'generic_ili9341_gt911')?.artifacts.firmware.file).toBe(
+      'canshift-esp32-v3.0.0-firmware.bin'
+    )
+    expect(findBoard(manifest, 'waveshare_s3_28')?.artifacts.spiffs.file).toBe(
+      'canshift-esp32s3-v3.0.0-spiffs.bin'
+    )
+  })
+
+  it('drops a board whose chip family ships no firmware', () => {
+    const manifest = parseManifest(SCHEMA_3_MANIFEST)
+    expect(manifest?.boards.map((board) => board.id)).not.toContain('orphan_c3')
+    expect(manifest?.boards).toHaveLength(3)
+  })
+
+  it('matches the firmware key to the board chip whatever their punctuation', () => {
+    const raw = JSON.stringify({
+      schema: 3,
+      version: '3.0.0',
+      tag: 'v3.0.0',
+      firmwares: { 'ESP32-S3': { merged: 'm.bin', firmware: 'f.bin', spiffs: 's.bin' } },
+      boards: [{ id: 'b', chip: 'esp32s3', display: 'd', touch: 't' }],
+    })
+    expect(findBoard(parseManifest(raw)!, 'b')?.artifacts.merged.file).toBe('m.bin')
   })
 
   it('uppercases are normalised and a malformed checksum degrades to null', () => {

--- a/src/lib/firmware/manifest.ts
+++ b/src/lib/firmware/manifest.ts
@@ -47,7 +47,9 @@ const toArtifacts = (value: unknown): BoardArtifacts | null => {
   return { merged, firmware, spiffs }
 }
 
-const toEntry = (value: unknown): BoardManifestEntry | null => {
+type BoardIdentity = Omit<BoardManifestEntry, 'artifacts'>
+
+const toIdentity = (value: unknown): BoardIdentity | null => {
   if (typeof value !== 'object' || value === null) return null
   const e = value as Record<string, unknown>
   if (
@@ -58,10 +60,35 @@ const toEntry = (value: unknown): BoardManifestEntry | null => {
   ) {
     return null
   }
-  const artifacts = toArtifacts(e.artifacts)
-  if (!artifacts) return null
-  return { id: e.id, chip: e.chip, display: e.display, touch: e.touch, artifacts }
+  return { id: e.id, chip: e.chip, display: e.display, touch: e.touch }
 }
+
+export const normalizeChip = (chip: string): string => chip.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+const toChipFirmwares = (value: unknown): Map<string, BoardArtifacts> => {
+  if (typeof value !== 'object' || value === null) return new Map()
+  const entries = Object.entries(value as Record<string, unknown>).flatMap(([chip, raw]) => {
+    const artifacts = toArtifacts(raw)
+    return artifacts === null ? [] : [[normalizeChip(chip), artifacts] as const]
+  })
+  return new Map(entries)
+}
+
+const perBoardEntry = (value: unknown): BoardManifestEntry | null => {
+  const identity = toIdentity(value)
+  if (!identity) return null
+  const artifacts = toArtifacts((value as Record<string, unknown>).artifacts)
+  return artifacts === null ? null : { ...identity, artifacts }
+}
+
+const perChipEntry =
+  (firmwares: Map<string, BoardArtifacts>) =>
+  (value: unknown): BoardManifestEntry | null => {
+    const identity = toIdentity(value)
+    if (!identity) return null
+    const artifacts = firmwares.get(normalizeChip(identity.chip))
+    return artifacts === undefined ? null : { ...identity, artifacts }
+  }
 
 export const parseManifest = (raw: string): BoardManifest | null => {
   let parsed: unknown
@@ -75,6 +102,8 @@ export const parseManifest = (raw: string): BoardManifest | null => {
   if (typeof manifest.schema !== 'number') return null
   if (typeof manifest.version !== 'string' || typeof manifest.tag !== 'string') return null
   if (!Array.isArray(manifest.boards)) return null
+  const firmwares = toChipFirmwares(manifest.firmwares)
+  const toEntry = firmwares.size > 0 ? perChipEntry(firmwares) : perBoardEntry
   const boards = manifest.boards.map(toEntry).filter((b): b is BoardManifestEntry => b !== null)
   if (boards.length === 0) return null
   return { schema: manifest.schema, version: manifest.version, tag: manifest.tag, boards }


### PR DESCRIPTION
Closes the tuner half of CANShift/canshift-firmware#88, the last open slice of the runtime-board-configuration umbrella (CANShift/canshift-firmware#68).

## Why

The firmware is now one universal binary per chip family — every driver compiled in, the board picked at boot from the profile blob the tuner already writes to NVS. Releases are about to stop publishing one artifact set per board id and start publishing one per chip family. The flasher has to read that manifest before the firmware starts emitting it, or the next release leaves the Firmware view with nothing to flash.

## What

**Manifest schema 3.** The wire form moves the artifacts off each board and onto a `firmwares` map keyed by chip family, with `boards` becoming the catalog the picker offers:

```jsonc
{ "schema": 3, "version": "...", "tag": "...",
  "firmwares": { "esp32": { "merged": {…}, "firmware": {…}, "spiffs": {…} }, "esp32s3": { … } },
  "boards": [ { "id": "crowpanel_28", "chip": "esp32", "display": "…", "touch": "…" } ] }
```

`parseManifest` resolves each board to its chip's artifacts at the wire boundary, so `BoardManifestEntry` keeps the shape the rest of the app already consumes — `useFlashTarget`, `board-resolution` and the picker are untouched. The per-board mapper stays for schema 1 and 2, so every published release still flashes. A board whose chip family ships no firmware is dropped, exactly like a malformed entry.

**The flasher accepts an ESP32-S3.** `SUPPORTED_CHIPS` refused everything but classic ESP32, so the Waveshare S3 board could never be flashed end to end whatever the manifest said. It now matches on the normalised family, which is the same comparison `assertChipMatchesBoard` uses — the board-vs-chip mismatch guard is unchanged and still refuses to write an esp32 image onto an S3.

`normalizeChip` moves to `manifest.ts` and `board-resolution.ts` imports it rather than keeping its own copy.

## Test plan

- `manifest.test.ts` — schema-3 resolution across two chip families, a board dropped when its family ships nothing, punctuation-insensitive key matching (`ESP32-S3` ↔ `esp32s3`), plus the existing schema-1/2 cases unchanged.
- `flash.test.ts` — `chipIsSupported` accepts ESP32 and ESP32-S3, rejects C3 and ESP8266.
- `lint`, `typecheck`, `test` (510), `format:check` green locally.

Ships before the firmware release-workflow PR so no release can land on a flasher that cannot read it.