### PR TITLE
fix(tuner): a merged image is refused before OTA writes it, and a failure says what to actually do

### DIFF
--- a/src/hooks/useFlasher.ts
+++ b/src/hooks/useFlasher.ts
@@ -2,7 +2,7 @@ import { flashFirmware } from '../lib/firmware/flash'
 import { boardProfileNvsImage } from '../lib/firmware/board-provision'
 import { useResolvedBoardProfile } from './useResolvedBoardProfile'
 import { downloadFirmwareAsset } from '../lib/firmware/download'
-import { flashFirmwareOta } from '../lib/firmware/ota'
+import { flashFirmwareOta, OtaError } from '../lib/firmware/ota'
 import { errorMessage } from '../lib/error-message'
 import { isWebSerialAvailable } from '../lib/web-serial'
 import { findFirmwareAsset } from '../lib/firmware/releases'
@@ -13,7 +13,7 @@ import {
 } from '../stores/firmware-selection.store'
 import { useLogStore } from '../stores/log.store'
 import { useFlasherStore } from '../stores/flasher.store'
-import type { FlasherState } from '../stores/flasher.store'
+import type { FlasherState, FlashTransport } from '../stores/flasher.store'
 
 export type { FlasherState }
 
@@ -61,16 +61,21 @@ export const useFlasher = (): UseFlasher => {
   const flash = (expectedChip?: string) => {
     if (selection.kind === 'none') return
     if (!isWebSerialAvailable()) {
-      setState({ kind: 'error', message: 'WebSerial unavailable in this browser.' })
+      setState({
+        kind: 'error',
+        message: 'WebSerial unavailable in this browser.',
+        transport: 'unknown',
+      })
       return
     }
     const name = selection.kind === 'release' ? selection.release.tag : selection.firmware.name
     log('info', `Flash requested — ${name}`)
 
-    void runFlash(selection, log, setState, expectedChip, resolvedBoard?.blob).catch(
+    const transport = pickTransport()
+    void runFlash(transport, selection, log, setState, expectedChip, resolvedBoard?.blob).catch(
       (err: unknown) => {
         const message = errorMessage(err)
-        setState({ kind: 'error', message })
+        setState({ kind: 'error', message, transport })
         log('error', `Flash failed: ${message}`)
       }
     )
@@ -91,11 +96,9 @@ const resolveOtaBytes = async (
 
   const asset = findFirmwareAsset(selection.release)
   if (!asset) {
-    log(
-      'warn',
-      'No app-only firmware.bin asset on this release — falling back to merged bytes (may not boot via OTA)'
+    throw new OtaError(
+      `${selection.release.tag} ships no app-only firmware.bin, so it cannot be written over OTA — disconnect the tuner and flash its merged image with the BOOT-button flasher instead.`
     )
-    return selection.firmware.bytes
   }
   log('info', `Fetching ${asset.name} for OTA (app partition only)`)
   const firmware = await downloadFirmwareAsset(asset, () => undefined)
@@ -158,14 +161,18 @@ const runEsptoolFlash = async (
   )
 }
 
+const pickTransport = (): FlashTransport =>
+  useConnectionStore.getState().status === 'connected' ? 'ota' : 'esptool'
+
 const runFlash = async (
+  transport: FlashTransport,
   selection: Exclude<FirmwareSelection, { kind: 'none' }>,
   log: ReturnType<typeof useLogStore.getState>['push'],
   setState: (next: FlasherState) => void,
   expectedChip?: string,
   boardProfileBlob?: string
 ): Promise<void> => {
-  if (useConnectionStore.getState().status === 'connected') {
+  if (transport === 'ota') {
     await runOtaFlash(selection, log, setState)
     return
   }

--- a/src/lib/firmware/image.test.ts
+++ b/src/lib/firmware/image.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+
+import { InvalidFirmwareImageError, NotAnAppImageError, verifyAppImage } from './image'
+
+const ESP_IMAGE_MAGIC = 0xe9
+const APP_DESC_MAGIC = 0xabcd5432
+const APP_DESC_OFFSET = 0x20
+
+const appImage = (size = 512): Uint8Array => {
+  const bytes = new Uint8Array(size)
+  bytes[0] = ESP_IMAGE_MAGIC
+  new DataView(bytes.buffer).setUint32(APP_DESC_OFFSET, APP_DESC_MAGIC, true)
+  return bytes
+}
+
+const bootloaderImage = (size = 512): Uint8Array => {
+  const bytes = new Uint8Array(size)
+  bytes[0] = ESP_IMAGE_MAGIC
+  return bytes
+}
+
+const rejectionOf = (bytes: Uint8Array): string => {
+  try {
+    verifyAppImage(bytes)
+  } catch (err: unknown) {
+    if (err instanceof NotAnAppImageError) return err.rejection
+    return `unexpected: ${String(err)}`
+  }
+  return 'accepted'
+}
+
+describe('verifyAppImage', () => {
+  it('accepts an app-only image', () => {
+    expect(rejectionOf(appImage())).toBe('accepted')
+  })
+
+  it('rejects a bootloader or merged image that has the ESP magic but no app descriptor', () => {
+    expect(rejectionOf(bootloaderImage())).toBe('not-app-only')
+  })
+
+  it('rejects a merged image whose padding precedes the bootloader', () => {
+    const merged = new Uint8Array(4096).fill(0xff)
+    expect(rejectionOf(merged)).toBe('not-an-esp-image')
+  })
+
+  it('rejects a file that is not an ESP32 image at all', () => {
+    expect(rejectionOf(new Uint8Array(512))).toBe('not-an-esp-image')
+  })
+
+  it('rejects a file too short to hold an app descriptor', () => {
+    expect(rejectionOf(appImage().subarray(0, 64))).toBe('too-small')
+  })
+
+  it('reads the descriptor relative to a view offset, not the backing buffer', () => {
+    const padded = new Uint8Array(1024)
+    padded.set(appImage(), 512)
+    expect(rejectionOf(padded.subarray(512))).toBe('accepted')
+  })
+
+  it('does not collide with InvalidFirmwareImageError', () => {
+    let caught: unknown = null
+    try {
+      verifyAppImage(bootloaderImage())
+    } catch (err: unknown) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(NotAnAppImageError)
+    expect(caught).not.toBeInstanceOf(InvalidFirmwareImageError)
+  })
+})

--- a/src/lib/firmware/image.ts
+++ b/src/lib/firmware/image.ts
@@ -1,5 +1,9 @@
 const ESP_IMAGE_MAGIC = 0xe9
 const BOOTLOADER_FLASH_OFFSET = 0x1000
+const APP_DESC_MAGIC = 0xabcd5432
+const APP_DESC_OFFSET = 0x20
+const APP_DESC_BYTES = 256
+const MIN_APP_IMAGE_BYTES = APP_DESC_OFFSET + APP_DESC_BYTES
 
 export class InvalidFirmwareImageError extends Error {
   readonly firstByte: number
@@ -27,4 +31,37 @@ export const verifyImageMagic = (bytes: Uint8Array): void => {
     return
   }
   throw new InvalidFirmwareImageError(bytes[0] ?? 0)
+}
+
+export type AppImageRejection = 'too-small' | 'not-an-esp-image' | 'not-app-only'
+
+const APP_IMAGE_MESSAGE: Record<AppImageRejection, string> = {
+  'too-small': 'OTA needs the app-only firmware.bin — this file is too small to be one.',
+  'not-an-esp-image': 'OTA needs the app-only firmware.bin — this file is not an ESP32 image.',
+  'not-app-only':
+    'OTA needs the app-only firmware.bin — this file carries no app descriptor, so it is a merged or bootloader image. Pick the firmware.bin build, or disconnect the tuner to write merged bytes with the BOOT-button flasher.',
+}
+
+export class NotAnAppImageError extends Error {
+  readonly rejection: AppImageRejection
+  constructor(rejection: AppImageRejection) {
+    super(APP_IMAGE_MESSAGE[rejection])
+    this.name = 'NotAnAppImageError'
+    this.rejection = rejection
+  }
+}
+
+const readUint32LE = (bytes: Uint8Array, offset: number): number =>
+  new DataView(bytes.buffer, bytes.byteOffset + offset, 4).getUint32(0, true)
+
+export const verifyAppImage = (bytes: Uint8Array): void => {
+  if (bytes.byteLength < MIN_APP_IMAGE_BYTES) {
+    throw new NotAnAppImageError('too-small')
+  }
+  if (bytes[0] !== ESP_IMAGE_MAGIC) {
+    throw new NotAnAppImageError('not-an-esp-image')
+  }
+  if (readUint32LE(bytes, APP_DESC_OFFSET) !== APP_DESC_MAGIC) {
+    throw new NotAnAppImageError('not-app-only')
+  }
 }

--- a/src/lib/firmware/ota-errors.test.ts
+++ b/src/lib/firmware/ota-errors.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+
+import { otaErrorText } from './ota-errors'
+
+describe('otaErrorText', () => {
+  it('explains the commit rejection that means a merged image was sent', () => {
+    const text = otaErrorText('ota_end_failed', '0x1503')
+
+    expect(text).toMatch(/refused it/)
+    expect(text).toMatch(/not a valid ESP32 app/)
+    expect(text).toMatch(/firmware\.bin/)
+  })
+
+  it('never leaks the raw slug for any code the firmware can send', () => {
+    const slugs = [
+      'bad_args',
+      'no_ota_partition',
+      'size_out_of_range',
+      'ota_begin_failed',
+      'begin_failed',
+      'sha_engine_failed',
+      'b64_decode',
+      'not_receiving',
+      'empty_chunk',
+      'offset_mismatch',
+      'overrun',
+      'ota_write_failed',
+      'write_failed',
+      'incomplete',
+      'sha256_mismatch',
+      'ota_end_failed',
+      'set_boot_failed',
+      'commit_failed',
+    ]
+
+    for (const slug of slugs) {
+      expect(otaErrorText(slug)).not.toContain(slug)
+    }
+  })
+
+  it('humanises transport codes through the shared transport map', () => {
+    expect(otaErrorText('ack_timeout')).not.toContain('ack_timeout')
+    expect(otaErrorText('not_connected')).not.toContain('not_connected')
+  })
+
+  it('keeps an unrecognised esp_err visible for a bug report', () => {
+    expect(otaErrorText('ota_end_failed', '0x9999')).toContain('0x9999')
+  })
+
+  it('joins reason to base without doubling the full stop', () => {
+    expect(otaErrorText('set_boot_failed', '0x1502')).not.toMatch(/\.\s*—/)
+    expect(otaErrorText('set_boot_failed', '0x1502')).toMatch(/\.$/)
+  })
+
+  it('falls back to a generic message when the dash sends no code', () => {
+    expect(otaErrorText(undefined)).toMatch(/went wrong/)
+  })
+})

--- a/src/lib/firmware/ota-errors.ts
+++ b/src/lib/firmware/ota-errors.ts
@@ -1,0 +1,50 @@
+import { transportErrorText } from '../../transport/humanize-transport-error'
+
+const OTA_ERROR_MESSAGES: Record<string, string> = {
+  bad_args: 'The dash rejected the update request as malformed — reload the tuner and try again.',
+  no_ota_partition:
+    'This board has no spare update partition, so it cannot update itself over USB — flash it with the BOOT-button flasher instead.',
+  size_out_of_range:
+    'The image does not fit this board’s update partition — check you picked the build for this model.',
+  ota_begin_failed:
+    'The dash could not open its update partition — restart the dash and try again.',
+  begin_failed: 'The dash refused to start the update — restart it and try again.',
+  sha_engine_failed:
+    'The dash’s checksum engine failed part-way through — restart the dash and try again.',
+  b64_decode: 'A chunk of the update arrived corrupted — check the cable and try again.',
+  not_receiving:
+    'The dash is not expecting update data — restart the dash and start the flash again.',
+  empty_chunk: 'The dash received an empty chunk — check the cable and try again.',
+  offset_mismatch: 'A chunk of the update arrived out of order — check the cable and try again.',
+  overrun: 'The tuner sent more data than it declared — reload the tuner and try again.',
+  ota_write_failed: 'The dash could not write the update to flash — restart it and try again.',
+  write_failed: 'The dash could not store a chunk of the update — check the cable and try again.',
+  incomplete: 'The update was finished before all of it arrived — start the flash again.',
+  sha256_mismatch:
+    'The image arrived corrupted — its checksum does not match what the tuner sent. Check the cable and flash again.',
+  ota_end_failed: 'The dash checked the finished image and refused it.',
+  set_boot_failed: 'The dash could not switch its boot slot to the new firmware.',
+  commit_failed: 'The dash could not finish the update.',
+}
+
+const ESP_OTA_DETAIL: Record<string, string> = {
+  '0x1501': 'its partition table has conflicting update slots',
+  '0x1502': 'its stored update-slot data is corrupt',
+  '0x1503':
+    'the image is not a valid ESP32 app, which usually means a merged or bootloader .bin was sent instead of the app-only firmware.bin',
+  '0x1504': 'the image has a lower security version than the board accepts',
+  '0x1505': 'a previous rollback did not complete',
+  '0x1506': 'the board is not in a state that allows this',
+}
+
+const withReason = (base: string, reason: string): string =>
+  `${base.replace(/\.$/, '')} — ${reason}.`
+
+const detailReason = (detail: string): string =>
+  ESP_OTA_DETAIL[detail.toLowerCase()] ?? `the board reported esp_err ${detail}`
+
+export const otaErrorText = (code: string | undefined, detail?: string): string => {
+  const base = OTA_ERROR_MESSAGES[code ?? ''] ?? transportErrorText(code)
+  if (detail === undefined || detail.length === 0) return base
+  return withReason(base, detailReason(detail))
+}

--- a/src/lib/firmware/ota.test.ts
+++ b/src/lib/firmware/ota.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+import { flashFirmwareOta, OtaError } from './ota'
+import { NotAnAppImageError } from './image'
+import { getSerialClient } from '../../transport/webserial-client'
+import { CMD_OTA_END } from '../../transport/opcodes'
+
+vi.mock('../../transport/webserial-client', () => ({
+  getSerialClient: vi.fn(),
+}))
+
+const sendMock = vi.fn()
+
+const APP_DESC_MAGIC = 0xabcd5432
+const APP_DESC_OFFSET = 0x20
+
+const appImage = (): Uint8Array => {
+  const bytes = new Uint8Array(512)
+  bytes[0] = 0xe9
+  new DataView(bytes.buffer).setUint32(APP_DESC_OFFSET, APP_DESC_MAGIC, true)
+  return bytes
+}
+
+const flash = (bytes: Uint8Array, onLog: (line: string) => void = () => undefined): Promise<void> =>
+  flashFirmwareOta({ bytes, onProgress: () => undefined, onLog })
+
+beforeEach(() => {
+  sendMock.mockReset()
+  sendMock.mockResolvedValue({ ok: true })
+  vi.mocked(getSerialClient).mockReturnValue({ send: sendMock } as unknown as ReturnType<
+    typeof getSerialClient
+  >)
+})
+
+describe('flashFirmwareOta image gate', () => {
+  it('refuses a merged image without sending a single byte to the board', async () => {
+    const merged = new Uint8Array(4096).fill(0xff)
+
+    await expect(flash(merged)).rejects.toBeInstanceOf(NotAnAppImageError)
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses a bootloader image before OTA_BEGIN', async () => {
+    const bootloader = new Uint8Array(512)
+    bootloader[0] = 0xe9
+
+    await expect(flash(bootloader)).rejects.toThrow(/app descriptor/)
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('transfers an app-only image', async () => {
+    await flash(appImage())
+
+    expect(sendMock).toHaveBeenCalled()
+  })
+})
+
+describe('flashFirmwareOta rejections', () => {
+  it('throws a humanised commit failure and logs the raw slug for diagnosis', async () => {
+    const lines: string[] = []
+    sendMock.mockImplementation((cmd: number) =>
+      cmd === CMD_OTA_END
+        ? Promise.resolve({ ok: false, error: 'ota_end_failed', data: { detail: '0x1503' } })
+        : Promise.resolve({ ok: true })
+    )
+
+    const caught = await flash(appImage(), (line) => lines.push(line)).catch((err: unknown) => err)
+
+    expect(caught).toBeInstanceOf(OtaError)
+    expect((caught as OtaError).message).toMatch(/not a valid ESP32 app/)
+    expect((caught as OtaError).message).not.toMatch(/ota_end_failed/)
+    expect(lines.some((line) => line.includes('ota_end_failed') && line.includes('0x1503'))).toBe(
+      true
+    )
+  })
+
+  it('humanises a begin rejection', async () => {
+    sendMock.mockResolvedValue({ ok: false, error: 'no_ota_partition' })
+
+    await expect(flash(appImage())).rejects.toThrow(/BOOT-button flasher/)
+  })
+})

--- a/src/lib/firmware/ota.ts
+++ b/src/lib/firmware/ota.ts
@@ -1,5 +1,8 @@
 import { getSerialClient } from '../../transport/webserial-client'
+import type { AckResult } from '../../transport/ack-queue'
 import { CMD_OTA_BEGIN, CMD_OTA_END, CMD_OTA_WRITE } from '../../transport/opcodes'
+import { verifyAppImage } from './image'
+import { otaErrorText } from './ota-errors'
 
 const CHUNK_SIZE = 512
 const ACK_TIMEOUT_MS = 8_000
@@ -37,7 +40,23 @@ const toBase64 = (chunk: Uint8Array): string => {
   return btoa(binary)
 }
 
+const ackField = (ack: AckResult, key: string): string | undefined => {
+  const value = ack.data?.[key]
+  return value === undefined ? undefined : String(value)
+}
+
+const rejection = (stage: string, ack: AckResult, onLog: OtaLog): OtaError => {
+  const detail = ackField(ack, 'detail')
+  const written = ackField(ack, 'written')
+  const suffix = written === undefined ? '' : ` written=${written}`
+  onLog(
+    `${stage} rejected: ${ack.error ?? 'unknown'}${detail === undefined ? '' : ` ${detail}`}${suffix}`
+  )
+  return new OtaError(otaErrorText(ack.error, detail), ack)
+}
+
 export const flashFirmwareOta = async ({ bytes, onProgress, onLog }: OtaOptions): Promise<void> => {
+  verifyAppImage(bytes)
   const client = getSerialClient()
 
   const sha = await sha256Hex(bytes)
@@ -48,7 +67,7 @@ export const flashFirmwareOta = async ({ bytes, onProgress, onLog }: OtaOptions)
     { timeoutMs: ACK_TIMEOUT_MS }
   )
   if (!beginAck.ok) {
-    throw new OtaError(`OTA_BEGIN rejected: ${beginAck.error ?? 'unknown'}`, beginAck)
+    throw rejection('OTA_BEGIN', beginAck, onLog)
   }
 
   let offset = 0
@@ -62,16 +81,7 @@ export const flashFirmwareOta = async ({ bytes, onProgress, onLog }: OtaOptions)
       { timeoutMs: ACK_TIMEOUT_MS, scaleWithPayload: true }
     )
     if (!ack.ok) {
-      const written =
-        ack.data && typeof ack.data === 'object' && 'written' in ack.data
-          ? (ack.data as { written?: unknown }).written
-          : undefined
-      const writtenSuffix =
-        written !== undefined ? ` (firmware reports written=${String(written)})` : ''
-      throw new OtaError(
-        `OTA_WRITE rejected at offset ${String(offset)}: ${ack.error ?? 'unknown'}${writtenSuffix}`,
-        ack
-      )
+      throw rejection(`OTA_WRITE at offset ${String(offset)}`, ack, onLog)
     }
     offset = end
     onProgress(offset, bytes.byteLength)
@@ -84,13 +94,6 @@ export const flashFirmwareOta = async ({ bytes, onProgress, onLog }: OtaOptions)
     { timeoutMs: COMMIT_TIMEOUT_MS }
   )
   if (!commitAck.ok) {
-    const detail =
-      commitAck.data && typeof commitAck.data === 'object' && 'detail' in commitAck.data
-        ? ` (esp_err=${String((commitAck.data as { detail?: unknown }).detail)})`
-        : ''
-    throw new OtaError(
-      `OTA_END commit rejected: ${commitAck.error ?? 'unknown'}${detail}`,
-      commitAck
-    )
+    throw rejection('OTA_END commit', commitAck, onLog)
   }
 }

--- a/src/routes/FirmwareRoute.tsx
+++ b/src/routes/FirmwareRoute.tsx
@@ -16,6 +16,7 @@ import { useProjectFileActions } from '../hooks/useProjectFileActions'
 import { useProjectStore } from '../stores/project/project.store'
 import { useConnectionStore } from '../stores/connection.store'
 import { parseChangelog } from '../lib/firmware/changelog'
+import type { ErrorTransport } from '../stores/flasher.store'
 
 type PaneState = FlashMode | 'running' | 'done'
 
@@ -32,8 +33,12 @@ const KEEPS_CONFIG = 'Keeps the config already on the board.'
 const ERASE_UNAVAILABLE =
   'The erase itself is not wired up yet — it writes to the board in a way that has to be verified on real hardware before it ships.'
 
-const FLASH_FAILED_TAIL =
-  'The board keeps whatever it had before the write started; hold BOOT and try again.'
+const RECOVERY_BY_TRANSPORT: Record<ErrorTransport, string> = {
+  ota: 'The board is still running the firmware it had — an OTA write only takes effect once the whole image checks out, and no BOOT button is involved. Try again.',
+  esptool:
+    'A write that stops partway can leave the board half-flashed — hold BOOT, tap RESET, and flash again to recover it.',
+  unknown: 'The board keeps whatever it had before the write started.',
+}
 
 const NOTICE = 'mb-8 border-l-[3px] border-l-ui-danger py-1 pl-3.5 text-[13px] text-ui-ink'
 
@@ -72,7 +77,8 @@ const FirmwareRoute = () => {
   const notice = (): string | null => {
     if (run.downloadError !== null) return `Could not fetch the build — ${run.downloadError}.`
     if (flasherState.kind !== 'error') return null
-    return `The flash stopped — ${flasherState.message}. ${FLASH_FAILED_TAIL}`
+    const detail = flasherState.message.replace(/\.$/, '')
+    return `The flash stopped — ${detail}. ${RECOVERY_BY_TRANSPORT[flasherState.transport]}`
   }
 
   const activeProject = projects.find((project) => project.id === activeProjectId) ?? null

--- a/src/stores/flasher.store.ts
+++ b/src/stores/flasher.store.ts
@@ -1,10 +1,13 @@
 import { create } from 'zustand'
 
+export type FlashTransport = 'ota' | 'esptool'
+export type ErrorTransport = FlashTransport | 'unknown'
+
 export type FlasherState =
   | { kind: 'idle' }
   | { kind: 'flashing'; written: number; total: number }
   | { kind: 'success' }
-  | { kind: 'error'; message: string }
+  | { kind: 'error'; message: string; transport: ErrorTransport }
 
 interface FlasherStoreState {
   state: FlasherState


### PR DESCRIPTION
Closes #293.

An OTA flash failed at commit with `ota_end_failed (esp_err=0x1503)` — `ESP_ERR_OTA_VALIDATE_FAILED`, i.e. `esp_ota_end()` verified the written image and refused it. The transfer was fine (the firmware's SHA-256 over every received byte matched before `esp_ota_end` was reached), so the file was wrong, not the link. Three defects made that both reachable and unreadable.

## A non-app image is refused before the transfer

`verifyAppImage` joins the existing `verifyImageMagic` in `lib/firmware/image.ts` and reuses its magic constant. It checks enough bytes, `0xE9` at offset 0, and the `esp_app_desc_t` magic `0xABCD5432` at offset `0x20`. That last check is the discriminating one — a bootloader and a merged image both open with `0xE9`, but only an app image carries the descriptor.

The gate sits at the top of `flashFirmwareOta`, so it covers the release path and the previously unvalidated local-file path in one place. Separately, a release with no `firmware.bin` asset now throws instead of falling back to merged bytes; that fallback could only ever end in `0x1503` after a full transfer.

## Recovery advice follows the transport that failed

The error variant of `FlasherState` now carries the transport. `useFlasher.flash()` picks it once via `pickTransport()` and hands it to both `runFlash` and the catch, so the failure and the run cannot disagree. `FirmwareRoute` swapped its single hardcoded tail for a `Record<ErrorTransport, string>`:

- **ota** — the board is still running its old firmware, and no BOOT button is involved
- **esptool** — keeps hold-BOOT/tap-RESET, minus the false promise that the board is untouched
- **unknown** — the pre-transport WebSerial-unavailable case

The old tail told every OTA user to hold BOOT, which puts the chip in ROM download mode where the firmware cannot answer `OTA_BEGIN` at all.

## Firmware error slugs are humanised at the boundary

New `lib/firmware/ota-errors.ts` maps every slug the firmware can emit on an OTA command — read off `ota_receiver.cpp` and `usb_dispatch_ota.cpp` rather than guessed, so it includes the dispatch-layer additions (`bad_args`, `b64_decode`) and the null-guard fallbacks (`begin_failed`, `write_failed`, `commit_failed`). Unknown codes delegate to the existing `transportErrorText`, so `ack_timeout` and friends reuse the messages already written rather than a second copy.

The `esp_err` detail arrives as a hex string, so the `0x150x` range is decoded into a reason clause joined onto the base sentence. An unrecognised value still shows its hex — that is a numeric code, not a slug, and it keeps bug reports actionable.

The three throw sites in `ota.ts` collapsed into one `rejection()` helper that logs the raw slug, detail and byte count via `onLog` and throws the humanised text. The `written=` count moved from the user-facing string to the log, where it belongs.

The reported failure now reads:

> The flash stopped — The dash checked the finished image and refused it — the image is not a valid ESP32 app, which usually means a merged or bootloader .bin was sent instead of the app-only firmware.bin. The board is still running the firmware it had…

## Test plan

- `image.test.ts` — accepts an app image; rejects bootloader, merged, `0xFF`-padded and truncated files; guards the `DataView` against a non-zero `byteOffset`
- `ota-errors.test.ts` — iterates the full slug list asserting none leaks into its own humanised output, so adding a firmware error without a mapping fails the suite; covers transport delegation and the unknown-`esp_err` passthrough
- `ota.test.ts` — nothing reaches the wire when the image is rejected; a commit rejection throws humanised text while the raw slug lands in the log
- `lint`, `typecheck`, `test` (528 passed, 80 files), `build` and `format:check` all green locally

Not covered: no hardware run — the `0x1503` path is reproduced from the firmware sources and the reported failure, not from a board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)