### PR TITLE
fix(tuner): the dash's not_app_image rejection reads as English, not a slug

### DIFF
--- a/src/lib/firmware/ota-errors.test.ts
+++ b/src/lib/firmware/ota-errors.test.ts
@@ -24,6 +24,7 @@ describe('otaErrorText', () => {
       'empty_chunk',
       'offset_mismatch',
       'overrun',
+      'not_app_image',
       'ota_write_failed',
       'write_failed',
       'incomplete',

--- a/src/lib/firmware/ota-errors.ts
+++ b/src/lib/firmware/ota-errors.ts
@@ -17,6 +17,8 @@ const OTA_ERROR_MESSAGES: Record<string, string> = {
   empty_chunk: 'The dash received an empty chunk — check the cable and try again.',
   offset_mismatch: 'A chunk of the update arrived out of order — check the cable and try again.',
   overrun: 'The tuner sent more data than it declared — reload the tuner and try again.',
+  not_app_image:
+    'The dash refused this file as not an app image — pick the app-only firmware.bin, not a merged or bootloader .bin.',
   ota_write_failed: 'The dash could not write the update to flash — restart it and try again.',
   write_failed: 'The dash could not store a chunk of the update — check the cable and try again.',
   incomplete: 'The update was finished before all of it arrived — start the flash again.',


### PR DESCRIPTION
CANShift/canshift-firmware#282 adds a new OTA wire slug, `not_app_image` — the dash now refuses a non-app image at the first chunk instead of writing the whole thing and failing at commit.

Without a mapping here, `otaErrorText` falls through to `transportErrorText`, which returns the code verbatim — exactly the raw-slug leak #294 closed. This adds the message and the slug to the list `ota-errors.test.ts` iterates, so the suite keeps failing on any future firmware error that arrives unmapped.

## Test plan

- `typecheck`, `lint`, `format:check` clean
- `vitest src/lib/firmware/` — 94 pass, including the no-slug-leaks assertion over the extended list

🤖 Generated with [Claude Code](https://claude.com/claude-code)